### PR TITLE
v11: Trust-layer truth + foundation hardening (release v1.1.0)

### DIFF
--- a/.add/tooling/add.py
+++ b/.add/tooling/add.py
@@ -162,7 +162,14 @@ def _require_root() -> Path:
 
 
 def load_state(root: Path) -> dict:
-    return json.loads((root / STATE_FILE).read_text(encoding="utf-8"))
+    """Load + parse state.json, failing CLOSED. A corrupt or unreadable state file
+    dies with a clean 'state_invalid' message (never a raw traceback), so every
+    command that loads state degrades gracefully (design-for-failure)."""
+    try:
+        return json.loads((root / STATE_FILE).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        _die(f"state_invalid: {root / STATE_FILE} is corrupt or unreadable "
+             f"({e.__class__.__name__}) — restore it from git or a backup")
 
 
 def _load_state_for_json() -> tuple[Path, dict]:
@@ -531,8 +538,8 @@ def cmd_status(args: argparse.Namespace) -> None:
     state = load_state(root)
     active = state.get("active_task")
     tasks = state.get("tasks", {})
-    print(f"project : {state['project']}")
-    print(f"stage   : {state['stage']}")
+    print(f"project : {state.get('project', '(unknown)')}")
+    print(f"stage   : {state.get('stage', '(unknown)')}")
     # foundation pointer — read the cross-milestone context first (anti-rot)
     if (root / "PROJECT.md").exists():
         print("context : .add/PROJECT.md  (foundation: domain · spec · UI/UX — read first)")
@@ -580,7 +587,7 @@ def cmd_status(args: argparse.Namespace) -> None:
     open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
     if open_deltas:
         print(f"deltas  : {open_deltas} open — fold at milestone close (add.py deltas)")
-    if active:
+    if active and active in tasks:
         ph = tasks[active]["phase"]
         if ph == "done":
             print(f"\nresume  : task '{active}' is done ({tasks[active]['gate']}).")
@@ -879,6 +886,15 @@ def cmd_archive_milestone(args: argparse.Namespace) -> None:
             t = tasks[s]
             print(f"  - {s} (phase={t.get('phase')}, gate={t.get('gate')})", file=sys.stderr)
         _die("milestone_has_incomplete_tasks")
+    # pre-archive snapshot (design-for-failure): the archived record below keeps only a
+    # slug-list, so capture the full milestone + member task records to a .bak BEFORE the
+    # destructive deletes — an accidental archive stays recoverable (phase/gate/waiver/deps
+    # the record drops). Mirrors the .bak the guideline injector writes before mutating.
+    _atomic_write(
+        root / "milestones" / slug / "pre-archive-state.bak.json",
+        json.dumps({"milestone": ms, "tasks": {s: tasks[s] for s in members},
+                    "archived_at": _now()}, indent=2) + "\n",
+    )
     # a slug-list summary (never task bodies) so the active state can't regrow,
     # yet cross-milestone deps on these tasks still resolve (see _archived_task_slugs)
     state.setdefault("archived", []).append({
@@ -916,6 +932,20 @@ def cmd_set_milestone(args: argparse.Namespace) -> None:
     state["tasks"][task]["updated"] = _now()
     save_state(root, state)
     print(f"task '{task}' -> milestone '{new}'" if new else f"task '{task}' -> milestone (none)")
+
+
+def cmd_use(args: argparse.Namespace) -> None:
+    """Set the active task to an EXISTING task (switch focus) without scaffolding a new
+    one or hand-editing state.json. advance/gate/phase still take an explicit slug; `use`
+    just moves the default focus, closing the only gap that forced manual state edits."""
+    root = _require_root()
+    state = load_state(root)
+    slug = args.slug
+    if slug not in state.get("tasks", {}):
+        _die("unknown_task")
+    state["active_task"] = slug
+    save_state(root, state)
+    print(f"active task -> '{slug}' (phase={state['tasks'][slug]['phase']})")
 
 
 def _find_cycle(tasks: dict) -> list[str] | None:
@@ -1416,7 +1446,7 @@ def _write_retro(root: Path, state: dict, mslug: str) -> Path:
     trust the locale default), never mutates state.json."""
     content = render_report(root, state, mslug, width=_DEFAULT_WIDTH, ascii=False)
     path = root / "milestones" / mslug / "RETRO.md"
-    path.write_text(content, encoding="utf-8")
+    _atomic_write(path, content)   # honor the module's atomic-write contract (no half-write)
     return path
 
 
@@ -1728,6 +1758,10 @@ def build_parser() -> argparse.ArgumentParser:
     psm.add_argument("task")
     psm.add_argument("milestone", help="milestone slug, or 'none' to detach")
     psm.set_defaults(func=cmd_set_milestone)
+
+    pu = sub.add_parser("use", help="set the active task to an existing one (switch focus)")
+    pu.add_argument("slug")
+    pu.set_defaults(func=cmd_use)
 
     pam = sub.add_parser("archive-milestone",
                          help="collapse a done milestone out of active state (files stay on disk)")

--- a/.add/tooling/add.py
+++ b/.add/tooling/add.py
@@ -575,6 +575,11 @@ def cmd_status(args: argparse.Namespace) -> None:
         dep_s = f"  deps={','.join(deps)}" if deps else ""
         ms_s = f"  [{t['milestone']}]" if t.get("milestone") else ""
         print(f"  {mark} {slug:<24} phase={t['phase']:<10} gate={t['gate']}{ms_s}{dep_s}")
+    # fold-pressure nudge: surface unfolded competency deltas so emission can't
+    # silently outrun the human fold (read-only; v11). Silent when none are open.
+    open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
+    if open_deltas:
+        print(f"deltas  : {open_deltas} open — fold at milestone close (add.py deltas)")
     if active:
         ph = tasks[active]["phase"]
         if ph == "done":
@@ -844,6 +849,12 @@ def cmd_milestone_done(args: argparse.Namespace) -> None:
     print(f"milestone '{slug}' -> done ({len(members)} tasks complete{tail}).")
     print(f"wrote {retro_path.relative_to(root.parent)}  (milestone exit report)")
     print("Confirm the MILESTONE.md exit criteria are checked, then archive/start the next.")
+    # fold-pressure nudge: milestone close is the natural fold point for open deltas (v11)
+    open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
+    if open_deltas:
+        noun = "delta" if open_deltas == 1 else "deltas"
+        print(f"note: {open_deltas} open competency {noun} to fold into the foundation "
+              f"— review with: add.py deltas")
 
 
 def cmd_archive_milestone(args: argparse.Namespace) -> None:
@@ -1540,18 +1551,32 @@ def _collect_open_deltas(root: Path) -> dict[str, list[dict]]:
         if not block_match:
             continue
         block = block_match.group(1)
+        # Group lines into entries (tag line + continuations) so a multi-line delta —
+        # whose learning wraps and whose (evidence: …) may land on a later line — is read
+        # in FULL, not truncated to its first line. A tag line starts an entry; a line
+        # that does not begin a new "- " list item continues it; a blank/comment or a
+        # new "- " item ends it (a trailing malformed item can't pollute a delta's text).
+        entries: list[list[str]] = []
+        current: list[str] | None = None
         for line in block.splitlines():
-            # Skip HTML-comment lines (<!-- ... -->) and blank lines.
             stripped = line.strip()
             if not stripped or stripped.startswith("<!--"):
+                current = None
                 continue
-            m = _DELTA_RE.match(stripped)
-            if not m:
-                continue  # malformed — skip silently
-            comp, status, tail = m.group(1), m.group(2), m.group(3).strip()
+            if _DELTA_RE.match(stripped):
+                current = [stripped]
+                entries.append(current)
+            elif current is not None and not stripped.startswith("-"):
+                current.append(stripped)  # genuine wrap of the current learning
+            else:
+                current = None             # a new / malformed list item ends the run
+        for unit in entries:
+            m = _DELTA_RE.match(unit[0])
+            comp, status = m.group(1), m.group(2)
             if status != "open":
                 continue
-            # Split off "(evidence: ...)" suffix if present.
+            # Join the tag line's tail with any continuation lines, then split evidence.
+            tail = " ".join([m.group(3).strip(), *unit[1:]]).strip()
             em = _EVIDENCE_RE.match(tail)
             if em:
                 delta_text, evidence = em.group(1).strip(), em.group(2).strip()

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -119,6 +119,7 @@ inside TASK.md):
 ```bash
 python3 .add/tooling/add.py advance            # next phase of the active task
 python3 .add/tooling/add.py gate PASS          # at verify: records PASS, marks done
+python3 .add/tooling/add.py use <slug>         # switch the active task (e.g. across parallel streams)
 ```
 
 ## Depth by stage

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -57,13 +57,21 @@ Load the phase guide **only for the phase you are in** (progressive disclosure):
 | Phase | Guide | Produces (TASK.md section) | Who leads |
 |-------|-------|----------------------------|-----------|
 | setup | `phases/0-setup.md` | `.add/` + survivor files | human |
-| specify | `phases/1-specify.md` | §1 rules + ranked least-sure flag | human + AI (co-specify) |
-| scenarios | `phases/2-scenarios.md` | §2 Given/When/Then | human |
-| contract | `phases/3-contract.md` | §3 frozen shape | human + AI |
-| tests | `phases/4-tests.md` | §4 + red suite in `tests/` | human sets, AI writes |
+| specify | `phases/1-specify.md` | §1 rules + ranked least-sure flag | AI drafts (co-specify)† |
+| scenarios | `phases/2-scenarios.md` | §2 Given/When/Then | AI drafts† |
+| contract | `phases/3-contract.md` | §3 frozen shape | AI drafts → **human approves once** (the seam)† |
+| tests | `phases/4-tests.md` | §4 + red suite in `tests/` | AI drafts† |
 | build | `phases/5-build.md` | code in `src/`, tests green | **AI** |
-| verify | `phases/6-verify.md` | §6 checks + gate record | **human** |
+| verify | `phases/6-verify.md` | §6 checks + gate record | **AI auto-gates on evidence**; human on residue/security‡ |
 | observe | `phases/7-observe.md` | §7 spec delta | human + AI |
+
+† **One-approval front (v7).** §1–§4 are drafted by the AI as a single bundle and frozen
+together; the human gives **one approval, at the contract freeze** (the autonomy seam) — not
+three separate sign-offs. The AI presents the bundle least-sure-first. See `run.md`.
+‡ **Verify auto-gate (v6–v7).** Under `autonomy: auto` (the default) a run may auto-PASS once
+the evidence is complete (all tests green · loops dry · no residue) — recorded as *auto-resolved*,
+an explicit PASS, not a skip. **Security always escalates** (HARD-STOP), as do concurrency /
+architecture residue and `conservative` autonomy. See `run.md`.
 
 In **observe**, also emit **competency deltas** — learnings tagged by which of the five
 (`DDD · SDD · UDD · TDD · ADD`) they improve — so the foundation self-improves across loops.
@@ -71,13 +79,14 @@ You write them as `open`; the human folds them into `PROJECT.md`. Read `deltas.m
 grammar and the status lifecycle. At milestone close (or on demand), run the fold ritual that
 gathers confirmed deltas into a versioned foundation — read `fold.md`.
 
-## The dynamic run (v6)
+## The dynamic run (v6–v7)
 
-Once **§3 CONTRACT is FROZEN**, the build→verify half MAY run as a dynamic, auto-gated run —
-fan-out + in-run convergence — instead of a manual build. Read `run.md` for the trigger, the
-touch-boundary, the evidence auto-gate, and the autonomy dial. The human-led front
-(specify·scenarios·contract) is unchanged; the run never edits a frozen contract and never
-auto-passes a security finding.
+Once **§3 CONTRACT is FROZEN**, the build→verify half runs as a dynamic, auto-gated run —
+fan-out + in-run convergence — instead of a manual build (`autonomy: auto` is the default; lower
+to `conservative` to keep a human at the gate). Read `run.md` for the trigger, the touch-boundary,
+the evidence auto-gate, and the autonomy dial. The human-led front still owns *direction*, but v7
+compresses it to a **single approval at the contract seam**; the run never edits a frozen contract
+and never auto-passes a security finding.
 
 ## Parallel streams — pipelining independent tasks (opt-in)
 

--- a/.claude/skills/add/deltas.md
+++ b/.claude/skills/add/deltas.md
@@ -10,7 +10,7 @@ You (the AI) **emit** deltas as `open`. Only the **human** moves a delta to `fol
 
 ## The grammar (frozen)
 
-Each delta is ONE line, exactly:
+Each delta begins on its own **tag line**; the learning may wrap onto continuation lines:
 
 ```
 - [<COMPETENCY> · <status>] <learning> (evidence: <pointer>)
@@ -18,9 +18,19 @@ Each delta is ONE line, exactly:
 
 - `<COMPETENCY>` — exactly one of the five (below).
 - `<status>` — `open` | `folded` | `rejected`. A **newly emitted delta is `open`**.
-- `<learning>` — the insight, in one phrase ("the domain model missed multi-tenancy").
+- `<learning>` — the insight ("the domain model missed multi-tenancy"). It may run past one line;
+  the `- [COMPETENCY · status]` tag line must come **first**, and the `(evidence: …)` clause must
+  **close** the delta (on its last line).
 - `(evidence: …)` — **required**, non-empty: a failing scenario, a production signal, a review
   note. No evidence → it is an opinion, not a delta.
+
+A long learning may wrap — the lint (`add.py check`) joins continuation lines, so this is **one**
+delta, not two:
+
+```
+- [SDD · open] the export endpoint must reject a tenant-scoped token used cross-tenant,
+  returning `forbidden` (not `not_found`) (evidence: scenario_cross_tenant_export failed)
+```
 
 ## The five competencies (pick exactly one per delta)
 

--- a/.claude/skills/add/phases/5-build.md
+++ b/.claude/skills/add/phases/5-build.md
@@ -36,3 +36,6 @@ change request back to Specify. Honor the feature-specific safety rule named in 
 
 `python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
+
+> Under `autonomy: auto` (the default) Build and Verify run together as one dynamic,
+> evidence-auto-gated run — not two manual stops. See `run.md`.

--- a/.claude/skills/add/phases/6-verify.md
+++ b/.claude/skills/add/phases/6-verify.md
@@ -1,8 +1,16 @@
 # Phase 6 — Verify (evidence + blind-spot checks)
 
 Goal: establish trust and record an outcome. Passing tests are necessary, not
-sufficient. This phase is **human-led** — there is no AI role. Fill **§6** in
-TASK.md including the GATE RECORD.
+sufficient. Fill **§6** in TASK.md including the GATE RECORD.
+
+> **Who resolves this gate depends on the `autonomy:` header (see `run.md`).**
+> Under `autonomy: auto` (the default) a run auto-PASSes once the evidence is
+> complete — every test green, the convergence loops dry, and **no residue**
+> (security · concurrency · architecture) — recording it as *auto-resolved* with
+> the named run as accountable owner: an explicit PASS, not a skip. **Security is
+> always a HARD-STOP and is never auto-passed.** Under `autonomy: conservative`,
+> or whenever residue is found, this phase is **human-led** and the checks below
+> are the human's.
 
 ## Part one — confirm the evidence
 
@@ -30,7 +38,8 @@ If any is false, stop and return to Build — there is nothing to verify yet.
 
 ## Exit gate / Next
 
-- [ ] Evidence confirmed, blind-spots checked, a person approved, outcome recorded.
+- [ ] Evidence confirmed, blind-spots checked, outcome recorded — a person approved, or
+  (under `autonomy: auto` with no residue) the run auto-resolved as the accountable owner.
 
 ```bash
 python3 .add/tooling/add.py gate PASS          # marks the task done

--- a/.claude/skills/add/streams.md
+++ b/.claude/skills/add/streams.md
@@ -65,6 +65,11 @@ never drops to zero (`run.md:22`). That floor is correct; do not engineer around
 
 ## Design for failure (required)
 
+- **Fresh worktree base (verify base == HEAD)** — create each worker's worktree from current
+  `HEAD` **after** you commit the task's frozen front (spec · scenarios · contract · tests). A
+  worktree forked from a stale base forces the worker to recreate the frozen artifacts by hand
+  (the v10 dogfood hit exactly this). Before the worker starts, confirm `git -C <worktree>
+  rev-parse HEAD` equals the orchestrator's `HEAD`; if it drifted, `git merge` the base in first.
 - **Lease + timeout** — record which worker holds which task; if a worker dies, release
   the claim back to READY (re-spawn, do not assume partial work is sound).
 - **Failure isolates** — a worker that hits a STOP-and-escalate (below) blocks only its
@@ -181,7 +186,7 @@ worktree, then points the agent at that directory.
 |-----------|----------|----------------------------------|-----------------------------------------------|
 | spawn a worker | prompt + label | `Task(description=…, prompt=…)` | `cd $WT && <agent> run --prompt-file PROMPT.md` |
 | pick the model | tier → id | `model="opus"\|"sonnet"` | a `--model <id>` flag |
-| isolate | worktree | `isolation="worktree"` | `git worktree add $WT <base>`, then run inside it |
+| isolate | worktree | `isolation="worktree"` | `git worktree add $WT HEAD` (after committing the front; verify base == HEAD), then run inside it |
 | load context | files / cwd | `<context_files>` + repo cwd | run inside `$WT`; paths are relative |
 | domain expertise | skill / preamble | a Claude skill in `<expertise>` | a system-prompt / profile preamble |
 | return a verdict | structured | final message (optionally a schema) | stdout JSON the orchestrator parses |

--- a/02-the-flow.md
+++ b/02-the-flow.md
@@ -6,7 +6,7 @@
 
 ## The flow
 
-AIDD is one repeatable flow of six steps, followed by an observation loop. People perform the first four steps (with AI assistance), the AI performs the fifth (under direction), and people perform the sixth.
+AIDD is one repeatable flow of **seven steps**: six build the feature — Specify → Scenarios → Contract → Tests → Build → Verify — and the seventh, **Observe**, feeds what production teaches back into the next Specify. In the default flow the AI drafts the front (steps 1–4) and a person approves it **once**, at the contract freeze; the AI performs the Build; and Verify is resolved on evidence under `autonomy: auto`, with a person owning any residue. (See [11 Governance](./11-governance.md) for the autonomy dial and the one-approval seam.)
 
 ![The ADD flow — a solid forward spine Specify→Scenarios→Contract→Tests→Build→Verify→Observe, with dashed backward-correction arrows (any phase may return to an earlier one), a Tests⇄Build red/green engine, and Observe looping back to the next Specify](./add-flow.png)
 
@@ -47,6 +47,8 @@ flowchart LR
 
 The shape is deliberate: the human-led steps establish direction, a frozen contract forms the seam in the middle, and the AI-led build runs fast and safely on the far side because everything it needs is already fixed.
 
+> **What changed in v7 (the diagrams above show the structural spine, which is unchanged).** The *steps* and their order are exactly as drawn — only **who resolves them** moved. The AI now drafts the whole front (steps 1–4) and a person approves it **once**, at the contract freeze (not a sign-off at each step); and **Verify is auto-gated on evidence** under `autonomy: auto` (the default), escalating security — always a `HARD-STOP` — and other residue to a person. Lower the dial to `conservative` to keep a human at the Verify gate. See [11 Governance](./11-governance.md).
+
 ## Why the order is the order
 
 Each step produces exactly one artifact, and each artifact is the input to the next step. The order is not a preference; it is a dependency chain.
@@ -68,12 +70,13 @@ The flow runs in two directions under two rules that never conflict. **Backward 
 
 | Step | Person's job | AI's job |
 |------|--------------|----------|
-| 1 Specify | decide and confirm the rules | draft; list assumptions to confirm |
-| 2 Scenarios | decide what "correct" looks like | draft scenarios |
-| 3 Contract | approve and freeze the shape | generate the contract and mocks |
-| 4 Tests | set the targets | generate failing tests |
+| 1 Specify | confirm the rules (part of the one approval) | draft; list assumptions to confirm |
+| 2 Scenarios | confirm what "correct" looks like (part of the one approval) | draft scenarios |
+| 3 Contract | **approve & freeze the whole bundle (§1–§4) once — the seam** | draft the contract and mocks |
+| 4 Tests | confirm the targets (part of the one approval) | draft the failing tests |
 | 5 Build | direct in small batches | implement until tests pass |
-| 6 Verify | confirm via evidence + judgment | (none — this is the human check) |
+| 6 Verify | own the residue (security · concurrency · architecture); approve when `conservative` | gather evidence; **auto-PASS on complete evidence** under `autonomy: auto` |
+| 7 Observe | read the signal; fold confirmed deltas into PROJECT.md | run behind a flag; emit competency deltas |
 
 ## What survives, and what is disposable
 

--- a/04-step-2-scenarios.md
+++ b/04-step-2-scenarios.md
@@ -6,6 +6,8 @@
 > **Produces:** `features/<name>.feature`.
 > **Person's job:** decide what "correct" looks like in concrete situations. **AI's job:** draft the scenarios.
 
+> **Part of the one-approval front (v7).** In the default flow these scenarios are drafted by the AI alongside the spec, contract, and failing tests as **one bundle**, approved by a person **once**, at the contract freeze — not signed off step by step. This chapter is how to get the scenarios *right*; [05 Contract](./05-step-3-contract.md) is where the bundle is frozen. See [11 Governance](./11-governance.md).
+
 ---
 
 ## Why turn rules into scenarios

--- a/05-step-3-contract.md
+++ b/05-step-3-contract.md
@@ -6,6 +6,8 @@
 > **Produces:** `contracts/<name>.md` (plus a mock and contract tests).
 > **Person's job:** approve and freeze the shape. **AI's job:** generate the first draft, the mock, and the contract tests.
 
+> **The one approval lands here (v7).** In the default flow the AI drafts the whole front — spec, scenarios, this contract, and the failing tests — as **one bundle**, and a person gives a **single approval at this freeze**. Freezing the contract is the one human gate of the front, not the third of three sign-offs; reject any part and the whole bundle returns to draft (backward correction, not failure). See [11 Governance](./11-governance.md).
+
 ---
 
 ## The seam of the whole method

--- a/06-step-4-tests.md
+++ b/06-step-4-tests.md
@@ -6,6 +6,8 @@
 > **Produces:** a failing (red) automated test suite.
 > **Person's job:** set the targets and coverage. **AI's job:** generate the tests.
 
+> **Part of the one-approval front (v7).** In the default flow these tests are drafted by the AI as part of the front **bundle** (spec · scenarios · contract · tests) and approved by a person **once**, at the contract freeze — the tests are part of what that single approval covers. They still must be **red before the build**. See [11 Governance](./11-governance.md).
+
 ---
 
 ## Why tests come before code

--- a/08-step-6-verify.md
+++ b/08-step-6-verify.md
@@ -4,7 +4,7 @@
 
 > **Purpose:** confirm the result is correct and safe to release.
 > **Produces:** a reviewed change with a recorded outcome, ready to release.
-> **Person's job:** this entire step. There is no AI role here — it is the human check.
+> **Who resolves it:** set per task by the `autonomy:` header. Under `autonomy: auto` (the default) the run resolves the gate on evidence; under `conservative`, or for any residue, it is the human's check. **Security always escalates to a human.**
 
 ---
 
@@ -13,6 +13,15 @@
 The build produced passing tests. That is necessary but not sufficient. Verification is where a person establishes trust — and the principle governing it is *trust through evidence, not inspection.*
 
 This needs care, because it is easy to misread. "Not by inspection" does not mean "do not look at the code." It means the *basis* of trust is the passing evidence plus a deliberate check of the specific things tests cannot easily catch — not a general impression that the code reads plausibly. Plausibility is exactly the trap: AI code is frequently plausible and wrong. So verification has two parts: confirm the evidence, then check the known blind spots.
+
+## Who resolves Verify — the evidence auto-gate
+
+Verify can be resolved two ways, set per task by the `autonomy:` header (see [governance](./11-governance.md) and the autonomy dial):
+
+- **Auto (the default).** When `autonomy: auto`, the run resolves the gate on **evidence** rather than waiting for a person — but only when *all* of these hold: every test green, coverage not decreased, no test weakened and no contract edited, the convergence loops dry, and **no residue** (security, concurrency, or architecture). It records `PASS` as *auto-resolved*, naming the run as the accountable owner — an explicit pass, not a skip. This is principle 7: a gate may be resolved by evidence when that evidence is sufficient and the result is logged.
+- **Human.** When `autonomy: conservative`, or whenever the run finds residue it cannot judge, the gate stops for a person; the two parts below are theirs.
+
+**Security is always a `HARD-STOP` and is never auto-passed, at any autonomy level.** The two parts that follow — confirm the evidence, then check the blind spots — are what *either* resolver works through; the only question is whether a person or the recorded run signs the outcome.
 
 ## Part one — confirm the evidence
 
@@ -49,7 +58,7 @@ A security finding is always a `HARD-STOP`; it is never waved through with a wai
 - [ ] Concurrency/timing of the risky operation is safe.
 - [ ] No exposed secrets, injection openings, or unexpected dependencies.
 - [ ] Layering and dependencies follow `CONVENTIONS.md`.
-- [ ] A person has reviewed and approved the change.
+- [ ] The change is approved — by a person, **or** (under `autonomy: auto`, no residue) auto-resolved by the run as the recorded accountable owner.
 - [ ] An outcome is recorded (`PASS` / `RISK-ACCEPTED` / `HARD-STOP`).
 
 ## Common mistakes

--- a/09-the-loop.md
+++ b/09-the-loop.md
@@ -33,6 +33,24 @@ Every defect, surprise, or new need is written up as a change to the specificati
 
 This is also where the AI returns to a useful role: summarizing telemetry, clustering errors into themes, and drafting the proposed spec delta for a person to review. But the production decisions — what to roll back, what to prioritize — remain human.
 
+## Competency deltas and the foundation fold
+
+A spec delta feeds the *next feature*. But a loop also teaches the **method itself** — that the domain model missed a boundary, that a whole class of scenario was never tested, that a build convention helped or hurt. AIDD captures those as **competency deltas**: a single tagged learning, written in the Observe step, marking which of the five competencies it sharpens.
+
+| tag | competency | a delta here means you learned something about… |
+|-----|------------|--------------------------------------------------|
+| `DDD` | Domain | the domain model — an entity, rule, or boundary the spec assumed wrong |
+| `SDD` | Spec | what the feature must do or reject — a missing or wrong requirement |
+| `UDD` | UI/UX | the user-facing shape — a flow, affordance, or wording that misled |
+| `TDD` | Test | how we prove correctness — a missing scenario, a flaky or hollow test |
+| `ADD` | AI/build | how the AI builds — a harness, prompt, or convention that helped or hurt |
+
+Each delta is one tagged entry — `- [COMPETENCY · status] the learning (evidence: a pointer)` — and the evidence is **required**: a failing scenario, a production signal, a review note. No evidence means it is an opinion, not a delta. The AI **emits** deltas as `open`; it never folds its own. Folding is judgment, and judgment is the human's — the same verify/observe seam that keeps the AI from grading its own work.
+
+**The fold.** At milestone close (or on demand, when open deltas pile up), a person runs the fold ritual: **gather** every `open` delta across the milestone's tasks, **group** them by competency, **propose** the exact foundation edit for each, **confirm** with the human one by one, then **write** — append-only — flipping each delta to `folded` (merged) or `rejected` (considered and deliberately not merged, left in place so the trail survives), and bumping the `foundation-version:` marker. `DDD`/`SDD`/`UDD` deltas fold into the matching section of `PROJECT.md`; `TDD`/`ADD` fold into `CONVENTIONS.md` (they sharpen the engine, not the product); and **every** fold also appends one row to `PROJECT.md` §Key Decisions — the universal, auditable record of what the foundation learned.
+
+**Tooling.** `add.py deltas` lists every open delta across the project (so nothing waiting to be folded is invisible); `add.py check` lints each delta's well-formedness — known competency tag, valid status, non-empty evidence. There is deliberately **no `add.py fold`**: the engine stays judgment-free, and the ritual lives with the human who owns it.
+
 ## Re-entrancy: the loop is the whole point
 
 Two principles converge here. *The flow is re-entrant* — any step can send you back to an earlier one — and *the flow is a loop* — production feeds the next specification. Together they mean the artifacts you built are never "finished"; they are living documents that the next cycle refines.

--- a/10-setup-and-stages.md
+++ b/10-setup-and-stages.md
@@ -73,3 +73,24 @@ The durable thing is never the code:
 | MVP → Production | nothing | everything; the code is real and is hardened |
 
 The survivor layer thickens as you move right: a prototype leaves you a validated design; a proof of concept adds a proven approach and a contract; the MVP adds real, kept code. By production, you are hardening, not rebuilding.
+
+---
+
+## Parallel streams (opt-in)
+
+The default is one task at a time. But when a milestone holds several tasks whose dependencies are already `PASS` and a reviewer is ready, you may run them **concurrently** — one worker per ready task, each building behind its own frozen contract.
+
+**Be honest about the gain.** With one human reviewer you cannot beat `review_time × N_tasks`; the human-led seams are serial. So the win is **not throughput** — it is that the reviewer is *never blocked waiting on a build*. While a person reviews task A's front, the builds for B, C, and D run behind *their* frozen contracts. You hide build latency under human latency; do not promise more.
+
+**Two queues, no new state** — both read from `add.py status`:
+
+- **READY-QUEUE** — tasks in the active milestone where the phase is not `done` and every dependency already reads `gate=PASS`. These are the only tasks a worker may pick up; a task finishing `PASS` unblocks its dependents on the next `status`.
+- **REVIEW-QUEUE** — the irreducibly serial part: the **one-approval front** (contract freeze) and any **Verify escalation**. One human, one queue, presented one at a time — never a batch that invites a rubber stamp.
+
+**The autonomy dial is the throttle.** At `conservative`, both gates queue on the human (pure pipelining — builds overlap, nothing auto-resolves). At `auto` (the default), only the front seam and residue escalations queue; Verify auto-PASSes on evidence, so real concurrency follows. The floor never drops below **one human approval per task, at the contract seam**.
+
+**Design for failure (required).** Lease each task to its worker with a timeout — if a worker dies, release the claim back to READY rather than trusting partial work. A worker that hits a stop-and-escalate blocks only its own task; siblings keep running. And if several workers fail in one wave, trip a circuit-breaker and fall back to sequential — repeated failure means the scope was wrong, not the parallelism.
+
+**The hard boundary.** The orchestrator owns every shared write — `state.json`, `MILESTONE.md`, and each `add.py advance`/`gate` call (always with the explicit task slug). A worker owns only its own task directory and is isolated in a git worktree, so concurrent builds cannot collide. Merge is **serial**: bring worktrees back one at a time and run an **integration Verify** for the concurrency and architecture conflicts that two-green-in-isolation tasks can still produce — automation never auto-passes that step.
+
+The full, agent-agnostic worker contract (the prompt a worker runs) and the per-runner spawn adapter live in the skill's `streams.md`; this section is the *why* and the safety frame, not the operational recipe.

--- a/14-foundation.md
+++ b/14-foundation.md
@@ -105,7 +105,11 @@ life of the product, owned above any single milestone.
 A milestone is a *version bump* to the foundation, not a fresh start: when it
 closes, fold what it validated into `PROJECT.md` (a decision, a settled domain
 term, a confirmed user journey) and open the next one against the same, now-richer,
-ground.
+ground. The fold is not informal: each loop emits **competency deltas** (tagged
+`DDD · SDD · UDD · TDD · ADD`) in its Observe step, and at milestone close a person
+gathers the open ones and folds them — append-only, with the `foundation-version:`
+bumped — into the foundation. See [09 · The loop](./09-the-loop.md#competency-deltas-and-the-foundation-fold)
+for the grammar, the ritual, and the tooling (`add.py deltas`, `add.py check`).
 
 ## In the tooling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,59 @@ both distribution channels: `@pilotspace/add` (npm) and `pilotspace-add` (PyPI).
 
 _Nothing yet._
 
+## [1.1.0] — 2026-06-04
+
+The **trust-layer-truth** release. Milestones v6–v10 changed how the engine behaves
+(auto-PASS by default, three approvals collapsed to one, deltas/fold/streams shipped)
+but the book and skill still described the pre-v6 manual model. This release makes the
+docs tell the truth, hardens the newest surfaces, and makes both installers
+cross-platform.
+
+### Added
+
+- **`add.py use <slug>`** — switch the active task to an existing one without
+  hand-editing `state.json` (rejects unknown slugs). Closes the gap that forced manual
+  state edits when juggling parallel streams.
+- **Fold-pressure nudge** — `add.py status` and `milestone-done` now surface the open
+  competency-delta count and point at `add.py deltas`, so a fast run's learnings no
+  longer pile up unfolded (rescues the v5 self-improving-foundation premise).
+- **Book chapters for shipped subsystems** — competency deltas, the fold ritual, and
+  foundation versioning (ch. 09/14) plus parallel streams (ch. 10) now have real
+  coverage instead of a single footnote.
+- **pip install path documented** — `GETTING-STARTED.md` teaches
+  `pip install pilotspace-add` → `pilotspace-add init` alongside the npm path, with a
+  Windows `py`-launcher note.
+
+### Changed
+
+- **The book and skill now match the engine.** Verify is the evidence **auto-gate**
+  (auto-PASS by default per the `autonomy:` dial), not "human-only"; the human-led
+  front is **one approval** at the frozen contract, not three; the flow is **seven
+  steps** (Observe is step 7) consistently across ch. 02 and the requirements matrix.
+- **`npx @pilotspace/add init --force`** now performs a **clean replace** of the skill
+  tree rather than a merge, so a re-install can no longer leave orphaned files from a
+  previous version behind — matching the pip installer's behavior.
+
+### Fixed
+
+- **Cross-platform install** — the npm installer now also tries the Windows `py`
+  launcher and prints a platform-correct manual-recovery command when Python is absent.
+- **State engine designs for failure** — a corrupt/unreadable `state.json` exits with a
+  clean `state_invalid` message instead of a raw traceback; `status` survives schema
+  drift and a stale active-task slug; `_write_retro` is atomic; `archive-milestone`
+  writes a recoverable pre-archive snapshot before its destructive deletes.
+- **Multi-line competency deltas** — `add.py check` and the deltas report now read a
+  delta whose `(evidence: …)` wraps onto a continuation line in full, instead of
+  truncating it to the first line.
+
+### Tests
+
+- New regression guards for every change above: trust-layer truth (`test_v11_docs`),
+  the fold-nudge, state-engine hardening, streams safety clauses + slug-routing
+  precedence, the pip quickstart path, the runtime `add_method.__version__` as a third
+  synced version source, and `PyWheelTest` — which builds the real wheel and asserts the
+  bundled skill/docs/tooling ship. The suite grows to **299 green**.
+
 ## [1.0.0] — 2026-06-02
 
 First public release of ADD (AI-Driven Development) as an installable skill plus the

--- a/add-method/GETTING-STARTED.md
+++ b/add-method/GETTING-STARTED.md
@@ -42,20 +42,35 @@ contract → review the result.** Everything between is the agent.
 
 ## 0 · Prerequisites
 
-- **Node.js ≥ 18** (to install) and **Python 3.10+** (the tool is stdlib-only).
+- **Python 3.10+** — required; the tool itself is stdlib-only (no pip dependencies).
+- **One installer**, whichever you already have: **Node.js ≥ 18** (for `npx`) *or*
+  **pip** (Python). Both install the exact same `.add/` runtime.
 - A project folder. It can be empty or an existing repo.
+
+> **Windows:** use `py` wherever this guide writes `python3` (the Python launcher on
+> Windows) — e.g. `py .add\tooling\add.py status`. Both installers handle the install
+> step for you; only the by-hand `add.py` commands below differ.
 
 ---
 
 ## 1 · Install
 
-From your project root:
+From your project root, pick **one** path — both produce the same install:
+
+**Option A — npm (Node.js ≥ 18):**
 
 ```bash
 npx @pilotspace/add init --name "My App" --stage prototype
 ```
 
-This creates `.add/` (your runtime), drops the `add` skill into
+**Option B — pip (Python 3.10+):**
+
+```bash
+pip install pilotspace-add
+pilotspace-add init --name "My App" --stage prototype
+```
+
+Either one creates `.add/` (your runtime), drops the `add` skill into
 `.claude/skills/add/`, and bundles the book into `.add/docs/`. Pick the stage that
 matches your intent — `prototype`, `poc`, `mvp`, or `production`. You can change it
 later with `python3 .add/tooling/add.py stage mvp`.

--- a/add-method/bin/cli.js
+++ b/add-method/bin/cli.js
@@ -39,18 +39,27 @@ function parseArgs(argv) {
   return args;
 }
 
-function copyDir(src, dest, { skipIfExists } = {}) {
+function copyDir(src, dest, { skipIfExists, cleanReplace } = {}) {
   if (!fs.existsSync(src)) fail("missing packaged source: " + src);
   if (skipIfExists && fs.existsSync(dest)) {
     warn(dest + " exists — leaving it untouched");
     return;
+  }
+  // Clean replace: drop a stale dest before copying so a `--force` re-install can
+  // never leave orphaned files from a previous version behind. fs.cpSync merges
+  // (it never removes), so without this `--force` is a merge, not a replace. Mirrors
+  // _installer.py's `shutil.rmtree(skill_dest)` so npm and pip behave identically.
+  if (cleanReplace && fs.existsSync(dest)) {
+    fs.rmSync(dest, { recursive: true, force: true });
   }
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.cpSync(src, dest, { recursive: true });
 }
 
 function hasPython() {
-  for (const py of ["python3", "python"]) {
+  // python3/python cover macOS+Linux; `py` is the Windows Python launcher, where
+  // python3 is often absent and bare `python` may be a no-op Store shim.
+  for (const py of ["python3", "python", "py"]) {
     const r = spawnSync(py, ["--version"], { stdio: "ignore" });
     if (r.status === 0) return py;
   }
@@ -66,7 +75,7 @@ function cmdInit(args) {
   copyDir(
     path.join(PKG_ROOT, "skill", "add"),
     path.join(target, ".claude", "skills", "add"),
-    { skipIfExists: !args.force }
+    { skipIfExists: !args.force, cleanReplace: args.force }
   );
   log("  ✓ skill      -> .claude/skills/add/");
 
@@ -92,9 +101,10 @@ function cmdInit(args) {
   const py = hasPython();
   const addPy = path.join(toolingDest, "add.py");
   if (!py) {
-    warn("python3 not found — skipping `add.py init`.");
-    log("\nFinish setup manually once Python is available:");
-    log("  python3 .add/tooling/add.py init" +
+    const launcher = process.platform === "win32" ? "py" : "python3";
+    warn("Python not found on PATH — skipping `add.py init`.");
+    log("\nInstall Python 3.10+ and finish setup manually:");
+    log(`  ${launcher} .add/tooling/add.py init` +
         (args.name ? ` --name "${args.name}"` : "") + ` --stage ${args.stage}`);
     return;
   }

--- a/add-method/docs/02-the-flow.md
+++ b/add-method/docs/02-the-flow.md
@@ -6,7 +6,7 @@
 
 ## The flow
 
-AIDD is one repeatable flow of six steps, followed by an observation loop. People perform the first four steps (with AI assistance), the AI performs the fifth (under direction), and people perform the sixth.
+AIDD is one repeatable flow of **seven steps**: six build the feature — Specify → Scenarios → Contract → Tests → Build → Verify — and the seventh, **Observe**, feeds what production teaches back into the next Specify. In the default flow the AI drafts the front (steps 1–4) and a person approves it **once**, at the contract freeze; the AI performs the Build; and Verify is resolved on evidence under `autonomy: auto`, with a person owning any residue. (See [11 Governance](./11-governance.md) for the autonomy dial and the one-approval seam.)
 
 ![The ADD flow — a solid forward spine Specify→Scenarios→Contract→Tests→Build→Verify→Observe, with dashed backward-correction arrows (any phase may return to an earlier one), a Tests⇄Build red/green engine, and Observe looping back to the next Specify](./add-flow.png)
 
@@ -47,6 +47,8 @@ flowchart LR
 
 The shape is deliberate: the human-led steps establish direction, a frozen contract forms the seam in the middle, and the AI-led build runs fast and safely on the far side because everything it needs is already fixed.
 
+> **What changed in v7 (the diagrams above show the structural spine, which is unchanged).** The *steps* and their order are exactly as drawn — only **who resolves them** moved. The AI now drafts the whole front (steps 1–4) and a person approves it **once**, at the contract freeze (not a sign-off at each step); and **Verify is auto-gated on evidence** under `autonomy: auto` (the default), escalating security — always a `HARD-STOP` — and other residue to a person. Lower the dial to `conservative` to keep a human at the Verify gate. See [11 Governance](./11-governance.md).
+
 ## Why the order is the order
 
 Each step produces exactly one artifact, and each artifact is the input to the next step. The order is not a preference; it is a dependency chain.
@@ -68,12 +70,13 @@ The flow runs in two directions under two rules that never conflict. **Backward 
 
 | Step | Person's job | AI's job |
 |------|--------------|----------|
-| 1 Specify | decide and confirm the rules | draft; list assumptions to confirm |
-| 2 Scenarios | decide what "correct" looks like | draft scenarios |
-| 3 Contract | approve and freeze the shape | generate the contract and mocks |
-| 4 Tests | set the targets | generate failing tests |
+| 1 Specify | confirm the rules (part of the one approval) | draft; list assumptions to confirm |
+| 2 Scenarios | confirm what "correct" looks like (part of the one approval) | draft scenarios |
+| 3 Contract | **approve & freeze the whole bundle (§1–§4) once — the seam** | draft the contract and mocks |
+| 4 Tests | confirm the targets (part of the one approval) | draft the failing tests |
 | 5 Build | direct in small batches | implement until tests pass |
-| 6 Verify | confirm via evidence + judgment | (none — this is the human check) |
+| 6 Verify | own the residue (security · concurrency · architecture); approve when `conservative` | gather evidence; **auto-PASS on complete evidence** under `autonomy: auto` |
+| 7 Observe | read the signal; fold confirmed deltas into PROJECT.md | run behind a flag; emit competency deltas |
 
 ## What survives, and what is disposable
 

--- a/add-method/docs/04-step-2-scenarios.md
+++ b/add-method/docs/04-step-2-scenarios.md
@@ -6,6 +6,8 @@
 > **Produces:** `features/<name>.feature`.
 > **Person's job:** decide what "correct" looks like in concrete situations. **AI's job:** draft the scenarios.
 
+> **Part of the one-approval front (v7).** In the default flow these scenarios are drafted by the AI alongside the spec, contract, and failing tests as **one bundle**, approved by a person **once**, at the contract freeze — not signed off step by step. This chapter is how to get the scenarios *right*; [05 Contract](./05-step-3-contract.md) is where the bundle is frozen. See [11 Governance](./11-governance.md).
+
 ---
 
 ## Why turn rules into scenarios

--- a/add-method/docs/05-step-3-contract.md
+++ b/add-method/docs/05-step-3-contract.md
@@ -6,6 +6,8 @@
 > **Produces:** `contracts/<name>.md` (plus a mock and contract tests).
 > **Person's job:** approve and freeze the shape. **AI's job:** generate the first draft, the mock, and the contract tests.
 
+> **The one approval lands here (v7).** In the default flow the AI drafts the whole front — spec, scenarios, this contract, and the failing tests — as **one bundle**, and a person gives a **single approval at this freeze**. Freezing the contract is the one human gate of the front, not the third of three sign-offs; reject any part and the whole bundle returns to draft (backward correction, not failure). See [11 Governance](./11-governance.md).
+
 ---
 
 ## The seam of the whole method

--- a/add-method/docs/06-step-4-tests.md
+++ b/add-method/docs/06-step-4-tests.md
@@ -6,6 +6,8 @@
 > **Produces:** a failing (red) automated test suite.
 > **Person's job:** set the targets and coverage. **AI's job:** generate the tests.
 
+> **Part of the one-approval front (v7).** In the default flow these tests are drafted by the AI as part of the front **bundle** (spec · scenarios · contract · tests) and approved by a person **once**, at the contract freeze — the tests are part of what that single approval covers. They still must be **red before the build**. See [11 Governance](./11-governance.md).
+
 ---
 
 ## Why tests come before code

--- a/add-method/docs/08-step-6-verify.md
+++ b/add-method/docs/08-step-6-verify.md
@@ -4,7 +4,7 @@
 
 > **Purpose:** confirm the result is correct and safe to release.
 > **Produces:** a reviewed change with a recorded outcome, ready to release.
-> **Person's job:** this entire step. There is no AI role here — it is the human check.
+> **Who resolves it:** set per task by the `autonomy:` header. Under `autonomy: auto` (the default) the run resolves the gate on evidence; under `conservative`, or for any residue, it is the human's check. **Security always escalates to a human.**
 
 ---
 
@@ -13,6 +13,15 @@
 The build produced passing tests. That is necessary but not sufficient. Verification is where a person establishes trust — and the principle governing it is *trust through evidence, not inspection.*
 
 This needs care, because it is easy to misread. "Not by inspection" does not mean "do not look at the code." It means the *basis* of trust is the passing evidence plus a deliberate check of the specific things tests cannot easily catch — not a general impression that the code reads plausibly. Plausibility is exactly the trap: AI code is frequently plausible and wrong. So verification has two parts: confirm the evidence, then check the known blind spots.
+
+## Who resolves Verify — the evidence auto-gate
+
+Verify can be resolved two ways, set per task by the `autonomy:` header (see [governance](./11-governance.md) and the autonomy dial):
+
+- **Auto (the default).** When `autonomy: auto`, the run resolves the gate on **evidence** rather than waiting for a person — but only when *all* of these hold: every test green, coverage not decreased, no test weakened and no contract edited, the convergence loops dry, and **no residue** (security, concurrency, or architecture). It records `PASS` as *auto-resolved*, naming the run as the accountable owner — an explicit pass, not a skip. This is principle 7: a gate may be resolved by evidence when that evidence is sufficient and the result is logged.
+- **Human.** When `autonomy: conservative`, or whenever the run finds residue it cannot judge, the gate stops for a person; the two parts below are theirs.
+
+**Security is always a `HARD-STOP` and is never auto-passed, at any autonomy level.** The two parts that follow — confirm the evidence, then check the blind spots — are what *either* resolver works through; the only question is whether a person or the recorded run signs the outcome.
 
 ## Part one — confirm the evidence
 
@@ -49,7 +58,7 @@ A security finding is always a `HARD-STOP`; it is never waved through with a wai
 - [ ] Concurrency/timing of the risky operation is safe.
 - [ ] No exposed secrets, injection openings, or unexpected dependencies.
 - [ ] Layering and dependencies follow `CONVENTIONS.md`.
-- [ ] A person has reviewed and approved the change.
+- [ ] The change is approved — by a person, **or** (under `autonomy: auto`, no residue) auto-resolved by the run as the recorded accountable owner.
 - [ ] An outcome is recorded (`PASS` / `RISK-ACCEPTED` / `HARD-STOP`).
 
 ## Common mistakes

--- a/add-method/docs/09-the-loop.md
+++ b/add-method/docs/09-the-loop.md
@@ -33,6 +33,24 @@ Every defect, surprise, or new need is written up as a change to the specificati
 
 This is also where the AI returns to a useful role: summarizing telemetry, clustering errors into themes, and drafting the proposed spec delta for a person to review. But the production decisions — what to roll back, what to prioritize — remain human.
 
+## Competency deltas and the foundation fold
+
+A spec delta feeds the *next feature*. But a loop also teaches the **method itself** — that the domain model missed a boundary, that a whole class of scenario was never tested, that a build convention helped or hurt. AIDD captures those as **competency deltas**: a single tagged learning, written in the Observe step, marking which of the five competencies it sharpens.
+
+| tag | competency | a delta here means you learned something about… |
+|-----|------------|--------------------------------------------------|
+| `DDD` | Domain | the domain model — an entity, rule, or boundary the spec assumed wrong |
+| `SDD` | Spec | what the feature must do or reject — a missing or wrong requirement |
+| `UDD` | UI/UX | the user-facing shape — a flow, affordance, or wording that misled |
+| `TDD` | Test | how we prove correctness — a missing scenario, a flaky or hollow test |
+| `ADD` | AI/build | how the AI builds — a harness, prompt, or convention that helped or hurt |
+
+Each delta is one tagged entry — `- [COMPETENCY · status] the learning (evidence: a pointer)` — and the evidence is **required**: a failing scenario, a production signal, a review note. No evidence means it is an opinion, not a delta. The AI **emits** deltas as `open`; it never folds its own. Folding is judgment, and judgment is the human's — the same verify/observe seam that keeps the AI from grading its own work.
+
+**The fold.** At milestone close (or on demand, when open deltas pile up), a person runs the fold ritual: **gather** every `open` delta across the milestone's tasks, **group** them by competency, **propose** the exact foundation edit for each, **confirm** with the human one by one, then **write** — append-only — flipping each delta to `folded` (merged) or `rejected` (considered and deliberately not merged, left in place so the trail survives), and bumping the `foundation-version:` marker. `DDD`/`SDD`/`UDD` deltas fold into the matching section of `PROJECT.md`; `TDD`/`ADD` fold into `CONVENTIONS.md` (they sharpen the engine, not the product); and **every** fold also appends one row to `PROJECT.md` §Key Decisions — the universal, auditable record of what the foundation learned.
+
+**Tooling.** `add.py deltas` lists every open delta across the project (so nothing waiting to be folded is invisible); `add.py check` lints each delta's well-formedness — known competency tag, valid status, non-empty evidence. There is deliberately **no `add.py fold`**: the engine stays judgment-free, and the ritual lives with the human who owns it.
+
 ## Re-entrancy: the loop is the whole point
 
 Two principles converge here. *The flow is re-entrant* — any step can send you back to an earlier one — and *the flow is a loop* — production feeds the next specification. Together they mean the artifacts you built are never "finished"; they are living documents that the next cycle refines.

--- a/add-method/docs/10-setup-and-stages.md
+++ b/add-method/docs/10-setup-and-stages.md
@@ -73,3 +73,24 @@ The durable thing is never the code:
 | MVP → Production | nothing | everything; the code is real and is hardened |
 
 The survivor layer thickens as you move right: a prototype leaves you a validated design; a proof of concept adds a proven approach and a contract; the MVP adds real, kept code. By production, you are hardening, not rebuilding.
+
+---
+
+## Parallel streams (opt-in)
+
+The default is one task at a time. But when a milestone holds several tasks whose dependencies are already `PASS` and a reviewer is ready, you may run them **concurrently** — one worker per ready task, each building behind its own frozen contract.
+
+**Be honest about the gain.** With one human reviewer you cannot beat `review_time × N_tasks`; the human-led seams are serial. So the win is **not throughput** — it is that the reviewer is *never blocked waiting on a build*. While a person reviews task A's front, the builds for B, C, and D run behind *their* frozen contracts. You hide build latency under human latency; do not promise more.
+
+**Two queues, no new state** — both read from `add.py status`:
+
+- **READY-QUEUE** — tasks in the active milestone where the phase is not `done` and every dependency already reads `gate=PASS`. These are the only tasks a worker may pick up; a task finishing `PASS` unblocks its dependents on the next `status`.
+- **REVIEW-QUEUE** — the irreducibly serial part: the **one-approval front** (contract freeze) and any **Verify escalation**. One human, one queue, presented one at a time — never a batch that invites a rubber stamp.
+
+**The autonomy dial is the throttle.** At `conservative`, both gates queue on the human (pure pipelining — builds overlap, nothing auto-resolves). At `auto` (the default), only the front seam and residue escalations queue; Verify auto-PASSes on evidence, so real concurrency follows. The floor never drops below **one human approval per task, at the contract seam**.
+
+**Design for failure (required).** Lease each task to its worker with a timeout — if a worker dies, release the claim back to READY rather than trusting partial work. A worker that hits a stop-and-escalate blocks only its own task; siblings keep running. And if several workers fail in one wave, trip a circuit-breaker and fall back to sequential — repeated failure means the scope was wrong, not the parallelism.
+
+**The hard boundary.** The orchestrator owns every shared write — `state.json`, `MILESTONE.md`, and each `add.py advance`/`gate` call (always with the explicit task slug). A worker owns only its own task directory and is isolated in a git worktree, so concurrent builds cannot collide. Merge is **serial**: bring worktrees back one at a time and run an **integration Verify** for the concurrency and architecture conflicts that two-green-in-isolation tasks can still produce — automation never auto-passes that step.
+
+The full, agent-agnostic worker contract (the prompt a worker runs) and the per-runner spawn adapter live in the skill's `streams.md`; this section is the *why* and the safety frame, not the operational recipe.

--- a/add-method/docs/14-foundation.md
+++ b/add-method/docs/14-foundation.md
@@ -105,7 +105,11 @@ life of the product, owned above any single milestone.
 A milestone is a *version bump* to the foundation, not a fresh start: when it
 closes, fold what it validated into `PROJECT.md` (a decision, a settled domain
 term, a confirmed user journey) and open the next one against the same, now-richer,
-ground.
+ground. The fold is not informal: each loop emits **competency deltas** (tagged
+`DDD · SDD · UDD · TDD · ADD`) in its Observe step, and at milestone close a person
+gathers the open ones and folds them — append-only, with the `foundation-version:`
+bumped — into the foundation. See [09 · The loop](./09-the-loop.md#competency-deltas-and-the-foundation-fold)
+for the grammar, the ritual, and the tooling (`add.py deltas`, `add.py check`).
 
 ## In the tooling
 

--- a/add-method/docs/appendix-f-requirements-matrix.md
+++ b/add-method/docs/appendix-f-requirements-matrix.md
@@ -12,7 +12,7 @@ This appendix maps every AIDD document to a three-level project hierarchy, so th
 |-------|-----------|--------------|-------|
 | **Project** | the whole product or engagement | the survivor layer — documents created once and kept for the life of the product | all milestones |
 | **Milestone** | a stage or release | one pass of the flow at a chosen depth: Prototype, POC, MVP, or Production-Ready; groups many tasks | many tasks |
-| **Task** | one feature through the flow | a single pass of Specify → … → Verify; the smallest unit with its own gate records | the six steps |
+| **Task** | one feature through the flow | a single pass of Specify → … → Verify → Observe; the smallest unit with its own gate records | the seven steps |
 
 A **project** sets up the survivor-layer documents once. A **milestone** is a depth-bounded goal that groups tasks and has its own entry and exit document gates. A **task** is one feature, and it produces the per-feature artifacts.
 
@@ -87,7 +87,7 @@ Which documents must exist, and at what depth, to **exit** each milestone. Depth
 
 ---
 
-## Matrix 3 — Documents required per task (the six steps)
+## Matrix 3 — Documents required per task (the seven steps)
 
 Every task, regardless of milestone, produces this artifact chain. The depth varies by milestone (Matrix 2); the *sequence and exit gate* do not.
 
@@ -98,9 +98,10 @@ Every task, regardless of milestone, produces this artifact chain. The depth var
 | 3 Contract | `contracts/<task>.md` | frozen + contract tests green | [05](./05-step-3-contract.md) |
 | 4 Tests | `tests/<task>_*` | one test per scenario, red first | [06](./06-step-4-tests.md) |
 | 5 Build | source code + evidence bundle | all tests green, nothing weakened | [07](./07-step-5-build.md) |
-| 6 Verify | gate outcome record | `PASS` / `RISK-ACCEPTED` / `HARD-STOP` | [08](./08-step-6-verify.md) |
+| 6 Verify | gate outcome record | `PASS` / `RISK-ACCEPTED` / `HARD-STOP` (auto-resolved on evidence under `autonomy: auto`; security always escalates) | [08](./08-step-6-verify.md) |
+| 7 Observe | `TASK.md` §7 OBSERVE block | released behind a flag; scenario-monitors live; spec delta + competency deltas captured | [09](./09-the-loop.md) |
 
-A task is **done** only when all six documents exist and the Verify record reads `PASS` (or a signed `RISK-ACCEPTED`). See the master shippable checklist in [Appendix E](./appendix-e-checklists.md).
+A task is **done** when the build's documents exist and the Verify record reads `PASS` (or a signed `RISK-ACCEPTED`); the seventh step — **Observe** (§7) — then runs in production and feeds the next loop's Specify. See the master shippable checklist in [Appendix E](./appendix-e-checklists.md).
 
 ---
 

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ADD (AI-Driven Development) — a minimal, state-tracked Claude Code skill that drives every feature through Specify → Scenarios → Contract → Tests → Build → Verify → Observe. Ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.0.0"
+version = "1.1.0"
 description = "ADD (AI-Driven Development) — install the ADD skill, tooling, and AIDD book into any project"
 readme = "README.md"
 license = "MIT"

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -119,6 +119,7 @@ inside TASK.md):
 ```bash
 python3 .add/tooling/add.py advance            # next phase of the active task
 python3 .add/tooling/add.py gate PASS          # at verify: records PASS, marks done
+python3 .add/tooling/add.py use <slug>         # switch the active task (e.g. across parallel streams)
 ```
 
 ## Depth by stage

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -57,13 +57,21 @@ Load the phase guide **only for the phase you are in** (progressive disclosure):
 | Phase | Guide | Produces (TASK.md section) | Who leads |
 |-------|-------|----------------------------|-----------|
 | setup | `phases/0-setup.md` | `.add/` + survivor files | human |
-| specify | `phases/1-specify.md` | §1 rules + ranked least-sure flag | human + AI (co-specify) |
-| scenarios | `phases/2-scenarios.md` | §2 Given/When/Then | human |
-| contract | `phases/3-contract.md` | §3 frozen shape | human + AI |
-| tests | `phases/4-tests.md` | §4 + red suite in `tests/` | human sets, AI writes |
+| specify | `phases/1-specify.md` | §1 rules + ranked least-sure flag | AI drafts (co-specify)† |
+| scenarios | `phases/2-scenarios.md` | §2 Given/When/Then | AI drafts† |
+| contract | `phases/3-contract.md` | §3 frozen shape | AI drafts → **human approves once** (the seam)† |
+| tests | `phases/4-tests.md` | §4 + red suite in `tests/` | AI drafts† |
 | build | `phases/5-build.md` | code in `src/`, tests green | **AI** |
-| verify | `phases/6-verify.md` | §6 checks + gate record | **human** |
+| verify | `phases/6-verify.md` | §6 checks + gate record | **AI auto-gates on evidence**; human on residue/security‡ |
 | observe | `phases/7-observe.md` | §7 spec delta | human + AI |
+
+† **One-approval front (v7).** §1–§4 are drafted by the AI as a single bundle and frozen
+together; the human gives **one approval, at the contract freeze** (the autonomy seam) — not
+three separate sign-offs. The AI presents the bundle least-sure-first. See `run.md`.
+‡ **Verify auto-gate (v6–v7).** Under `autonomy: auto` (the default) a run may auto-PASS once
+the evidence is complete (all tests green · loops dry · no residue) — recorded as *auto-resolved*,
+an explicit PASS, not a skip. **Security always escalates** (HARD-STOP), as do concurrency /
+architecture residue and `conservative` autonomy. See `run.md`.
 
 In **observe**, also emit **competency deltas** — learnings tagged by which of the five
 (`DDD · SDD · UDD · TDD · ADD`) they improve — so the foundation self-improves across loops.
@@ -71,13 +79,14 @@ You write them as `open`; the human folds them into `PROJECT.md`. Read `deltas.m
 grammar and the status lifecycle. At milestone close (or on demand), run the fold ritual that
 gathers confirmed deltas into a versioned foundation — read `fold.md`.
 
-## The dynamic run (v6)
+## The dynamic run (v6–v7)
 
-Once **§3 CONTRACT is FROZEN**, the build→verify half MAY run as a dynamic, auto-gated run —
-fan-out + in-run convergence — instead of a manual build. Read `run.md` for the trigger, the
-touch-boundary, the evidence auto-gate, and the autonomy dial. The human-led front
-(specify·scenarios·contract) is unchanged; the run never edits a frozen contract and never
-auto-passes a security finding.
+Once **§3 CONTRACT is FROZEN**, the build→verify half runs as a dynamic, auto-gated run —
+fan-out + in-run convergence — instead of a manual build (`autonomy: auto` is the default; lower
+to `conservative` to keep a human at the gate). Read `run.md` for the trigger, the touch-boundary,
+the evidence auto-gate, and the autonomy dial. The human-led front still owns *direction*, but v7
+compresses it to a **single approval at the contract seam**; the run never edits a frozen contract
+and never auto-passes a security finding.
 
 ## Parallel streams — pipelining independent tasks (opt-in)
 

--- a/add-method/skill/add/deltas.md
+++ b/add-method/skill/add/deltas.md
@@ -10,7 +10,7 @@ You (the AI) **emit** deltas as `open`. Only the **human** moves a delta to `fol
 
 ## The grammar (frozen)
 
-Each delta is ONE line, exactly:
+Each delta begins on its own **tag line**; the learning may wrap onto continuation lines:
 
 ```
 - [<COMPETENCY> · <status>] <learning> (evidence: <pointer>)
@@ -18,9 +18,19 @@ Each delta is ONE line, exactly:
 
 - `<COMPETENCY>` — exactly one of the five (below).
 - `<status>` — `open` | `folded` | `rejected`. A **newly emitted delta is `open`**.
-- `<learning>` — the insight, in one phrase ("the domain model missed multi-tenancy").
+- `<learning>` — the insight ("the domain model missed multi-tenancy"). It may run past one line;
+  the `- [COMPETENCY · status]` tag line must come **first**, and the `(evidence: …)` clause must
+  **close** the delta (on its last line).
 - `(evidence: …)` — **required**, non-empty: a failing scenario, a production signal, a review
   note. No evidence → it is an opinion, not a delta.
+
+A long learning may wrap — the lint (`add.py check`) joins continuation lines, so this is **one**
+delta, not two:
+
+```
+- [SDD · open] the export endpoint must reject a tenant-scoped token used cross-tenant,
+  returning `forbidden` (not `not_found`) (evidence: scenario_cross_tenant_export failed)
+```
 
 ## The five competencies (pick exactly one per delta)
 

--- a/add-method/skill/add/phases/5-build.md
+++ b/add-method/skill/add/phases/5-build.md
@@ -36,3 +36,6 @@ change request back to Specify. Honor the feature-specific safety rule named in 
 
 `python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
+
+> Under `autonomy: auto` (the default) Build and Verify run together as one dynamic,
+> evidence-auto-gated run — not two manual stops. See `run.md`.

--- a/add-method/skill/add/phases/6-verify.md
+++ b/add-method/skill/add/phases/6-verify.md
@@ -1,8 +1,16 @@
 # Phase 6 — Verify (evidence + blind-spot checks)
 
 Goal: establish trust and record an outcome. Passing tests are necessary, not
-sufficient. This phase is **human-led** — there is no AI role. Fill **§6** in
-TASK.md including the GATE RECORD.
+sufficient. Fill **§6** in TASK.md including the GATE RECORD.
+
+> **Who resolves this gate depends on the `autonomy:` header (see `run.md`).**
+> Under `autonomy: auto` (the default) a run auto-PASSes once the evidence is
+> complete — every test green, the convergence loops dry, and **no residue**
+> (security · concurrency · architecture) — recording it as *auto-resolved* with
+> the named run as accountable owner: an explicit PASS, not a skip. **Security is
+> always a HARD-STOP and is never auto-passed.** Under `autonomy: conservative`,
+> or whenever residue is found, this phase is **human-led** and the checks below
+> are the human's.
 
 ## Part one — confirm the evidence
 
@@ -30,7 +38,8 @@ If any is false, stop and return to Build — there is nothing to verify yet.
 
 ## Exit gate / Next
 
-- [ ] Evidence confirmed, blind-spots checked, a person approved, outcome recorded.
+- [ ] Evidence confirmed, blind-spots checked, outcome recorded — a person approved, or
+  (under `autonomy: auto` with no residue) the run auto-resolved as the accountable owner.
 
 ```bash
 python3 .add/tooling/add.py gate PASS          # marks the task done

--- a/add-method/skill/add/streams.md
+++ b/add-method/skill/add/streams.md
@@ -65,6 +65,11 @@ never drops to zero (`run.md:22`). That floor is correct; do not engineer around
 
 ## Design for failure (required)
 
+- **Fresh worktree base (verify base == HEAD)** — create each worker's worktree from current
+  `HEAD` **after** you commit the task's frozen front (spec · scenarios · contract · tests). A
+  worktree forked from a stale base forces the worker to recreate the frozen artifacts by hand
+  (the v10 dogfood hit exactly this). Before the worker starts, confirm `git -C <worktree>
+  rev-parse HEAD` equals the orchestrator's `HEAD`; if it drifted, `git merge` the base in first.
 - **Lease + timeout** — record which worker holds which task; if a worker dies, release
   the claim back to READY (re-spawn, do not assume partial work is sound).
 - **Failure isolates** — a worker that hits a STOP-and-escalate (below) blocks only its
@@ -181,7 +186,7 @@ worktree, then points the agent at that directory.
 |-----------|----------|----------------------------------|-----------------------------------------------|
 | spawn a worker | prompt + label | `Task(description=…, prompt=…)` | `cd $WT && <agent> run --prompt-file PROMPT.md` |
 | pick the model | tier → id | `model="opus"\|"sonnet"` | a `--model <id>` flag |
-| isolate | worktree | `isolation="worktree"` | `git worktree add $WT <base>`, then run inside it |
+| isolate | worktree | `isolation="worktree"` | `git worktree add $WT HEAD` (after committing the front; verify base == HEAD), then run inside it |
 | load context | files / cwd | `<context_files>` + repo cwd | run inside `$WT`; paths are relative |
 | domain expertise | skill / preamble | a Claude skill in `<expertise>` | a system-prompt / profile preamble |
 | return a verdict | structured | final message (optionally a schema) | stdout JSON the orchestrator parses |

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -13,4 +13,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/add-method/src/add_method/_bundled/docs/02-the-flow.md
+++ b/add-method/src/add_method/_bundled/docs/02-the-flow.md
@@ -6,7 +6,7 @@
 
 ## The flow
 
-AIDD is one repeatable flow of six steps, followed by an observation loop. People perform the first four steps (with AI assistance), the AI performs the fifth (under direction), and people perform the sixth.
+AIDD is one repeatable flow of **seven steps**: six build the feature — Specify → Scenarios → Contract → Tests → Build → Verify — and the seventh, **Observe**, feeds what production teaches back into the next Specify. In the default flow the AI drafts the front (steps 1–4) and a person approves it **once**, at the contract freeze; the AI performs the Build; and Verify is resolved on evidence under `autonomy: auto`, with a person owning any residue. (See [11 Governance](./11-governance.md) for the autonomy dial and the one-approval seam.)
 
 ![The ADD flow — a solid forward spine Specify→Scenarios→Contract→Tests→Build→Verify→Observe, with dashed backward-correction arrows (any phase may return to an earlier one), a Tests⇄Build red/green engine, and Observe looping back to the next Specify](./add-flow.png)
 
@@ -47,6 +47,8 @@ flowchart LR
 
 The shape is deliberate: the human-led steps establish direction, a frozen contract forms the seam in the middle, and the AI-led build runs fast and safely on the far side because everything it needs is already fixed.
 
+> **What changed in v7 (the diagrams above show the structural spine, which is unchanged).** The *steps* and their order are exactly as drawn — only **who resolves them** moved. The AI now drafts the whole front (steps 1–4) and a person approves it **once**, at the contract freeze (not a sign-off at each step); and **Verify is auto-gated on evidence** under `autonomy: auto` (the default), escalating security — always a `HARD-STOP` — and other residue to a person. Lower the dial to `conservative` to keep a human at the Verify gate. See [11 Governance](./11-governance.md).
+
 ## Why the order is the order
 
 Each step produces exactly one artifact, and each artifact is the input to the next step. The order is not a preference; it is a dependency chain.
@@ -68,12 +70,13 @@ The flow runs in two directions under two rules that never conflict. **Backward 
 
 | Step | Person's job | AI's job |
 |------|--------------|----------|
-| 1 Specify | decide and confirm the rules | draft; list assumptions to confirm |
-| 2 Scenarios | decide what "correct" looks like | draft scenarios |
-| 3 Contract | approve and freeze the shape | generate the contract and mocks |
-| 4 Tests | set the targets | generate failing tests |
+| 1 Specify | confirm the rules (part of the one approval) | draft; list assumptions to confirm |
+| 2 Scenarios | confirm what "correct" looks like (part of the one approval) | draft scenarios |
+| 3 Contract | **approve & freeze the whole bundle (§1–§4) once — the seam** | draft the contract and mocks |
+| 4 Tests | confirm the targets (part of the one approval) | draft the failing tests |
 | 5 Build | direct in small batches | implement until tests pass |
-| 6 Verify | confirm via evidence + judgment | (none — this is the human check) |
+| 6 Verify | own the residue (security · concurrency · architecture); approve when `conservative` | gather evidence; **auto-PASS on complete evidence** under `autonomy: auto` |
+| 7 Observe | read the signal; fold confirmed deltas into PROJECT.md | run behind a flag; emit competency deltas |
 
 ## What survives, and what is disposable
 

--- a/add-method/src/add_method/_bundled/docs/04-step-2-scenarios.md
+++ b/add-method/src/add_method/_bundled/docs/04-step-2-scenarios.md
@@ -6,6 +6,8 @@
 > **Produces:** `features/<name>.feature`.
 > **Person's job:** decide what "correct" looks like in concrete situations. **AI's job:** draft the scenarios.
 
+> **Part of the one-approval front (v7).** In the default flow these scenarios are drafted by the AI alongside the spec, contract, and failing tests as **one bundle**, approved by a person **once**, at the contract freeze — not signed off step by step. This chapter is how to get the scenarios *right*; [05 Contract](./05-step-3-contract.md) is where the bundle is frozen. See [11 Governance](./11-governance.md).
+
 ---
 
 ## Why turn rules into scenarios

--- a/add-method/src/add_method/_bundled/docs/05-step-3-contract.md
+++ b/add-method/src/add_method/_bundled/docs/05-step-3-contract.md
@@ -6,6 +6,8 @@
 > **Produces:** `contracts/<name>.md` (plus a mock and contract tests).
 > **Person's job:** approve and freeze the shape. **AI's job:** generate the first draft, the mock, and the contract tests.
 
+> **The one approval lands here (v7).** In the default flow the AI drafts the whole front — spec, scenarios, this contract, and the failing tests — as **one bundle**, and a person gives a **single approval at this freeze**. Freezing the contract is the one human gate of the front, not the third of three sign-offs; reject any part and the whole bundle returns to draft (backward correction, not failure). See [11 Governance](./11-governance.md).
+
 ---
 
 ## The seam of the whole method

--- a/add-method/src/add_method/_bundled/docs/06-step-4-tests.md
+++ b/add-method/src/add_method/_bundled/docs/06-step-4-tests.md
@@ -6,6 +6,8 @@
 > **Produces:** a failing (red) automated test suite.
 > **Person's job:** set the targets and coverage. **AI's job:** generate the tests.
 
+> **Part of the one-approval front (v7).** In the default flow these tests are drafted by the AI as part of the front **bundle** (spec · scenarios · contract · tests) and approved by a person **once**, at the contract freeze — the tests are part of what that single approval covers. They still must be **red before the build**. See [11 Governance](./11-governance.md).
+
 ---
 
 ## Why tests come before code

--- a/add-method/src/add_method/_bundled/docs/08-step-6-verify.md
+++ b/add-method/src/add_method/_bundled/docs/08-step-6-verify.md
@@ -4,7 +4,7 @@
 
 > **Purpose:** confirm the result is correct and safe to release.
 > **Produces:** a reviewed change with a recorded outcome, ready to release.
-> **Person's job:** this entire step. There is no AI role here — it is the human check.
+> **Who resolves it:** set per task by the `autonomy:` header. Under `autonomy: auto` (the default) the run resolves the gate on evidence; under `conservative`, or for any residue, it is the human's check. **Security always escalates to a human.**
 
 ---
 
@@ -13,6 +13,15 @@
 The build produced passing tests. That is necessary but not sufficient. Verification is where a person establishes trust — and the principle governing it is *trust through evidence, not inspection.*
 
 This needs care, because it is easy to misread. "Not by inspection" does not mean "do not look at the code." It means the *basis* of trust is the passing evidence plus a deliberate check of the specific things tests cannot easily catch — not a general impression that the code reads plausibly. Plausibility is exactly the trap: AI code is frequently plausible and wrong. So verification has two parts: confirm the evidence, then check the known blind spots.
+
+## Who resolves Verify — the evidence auto-gate
+
+Verify can be resolved two ways, set per task by the `autonomy:` header (see [governance](./11-governance.md) and the autonomy dial):
+
+- **Auto (the default).** When `autonomy: auto`, the run resolves the gate on **evidence** rather than waiting for a person — but only when *all* of these hold: every test green, coverage not decreased, no test weakened and no contract edited, the convergence loops dry, and **no residue** (security, concurrency, or architecture). It records `PASS` as *auto-resolved*, naming the run as the accountable owner — an explicit pass, not a skip. This is principle 7: a gate may be resolved by evidence when that evidence is sufficient and the result is logged.
+- **Human.** When `autonomy: conservative`, or whenever the run finds residue it cannot judge, the gate stops for a person; the two parts below are theirs.
+
+**Security is always a `HARD-STOP` and is never auto-passed, at any autonomy level.** The two parts that follow — confirm the evidence, then check the blind spots — are what *either* resolver works through; the only question is whether a person or the recorded run signs the outcome.
 
 ## Part one — confirm the evidence
 
@@ -49,7 +58,7 @@ A security finding is always a `HARD-STOP`; it is never waved through with a wai
 - [ ] Concurrency/timing of the risky operation is safe.
 - [ ] No exposed secrets, injection openings, or unexpected dependencies.
 - [ ] Layering and dependencies follow `CONVENTIONS.md`.
-- [ ] A person has reviewed and approved the change.
+- [ ] The change is approved — by a person, **or** (under `autonomy: auto`, no residue) auto-resolved by the run as the recorded accountable owner.
 - [ ] An outcome is recorded (`PASS` / `RISK-ACCEPTED` / `HARD-STOP`).
 
 ## Common mistakes

--- a/add-method/src/add_method/_bundled/docs/09-the-loop.md
+++ b/add-method/src/add_method/_bundled/docs/09-the-loop.md
@@ -33,6 +33,24 @@ Every defect, surprise, or new need is written up as a change to the specificati
 
 This is also where the AI returns to a useful role: summarizing telemetry, clustering errors into themes, and drafting the proposed spec delta for a person to review. But the production decisions — what to roll back, what to prioritize — remain human.
 
+## Competency deltas and the foundation fold
+
+A spec delta feeds the *next feature*. But a loop also teaches the **method itself** — that the domain model missed a boundary, that a whole class of scenario was never tested, that a build convention helped or hurt. AIDD captures those as **competency deltas**: a single tagged learning, written in the Observe step, marking which of the five competencies it sharpens.
+
+| tag | competency | a delta here means you learned something about… |
+|-----|------------|--------------------------------------------------|
+| `DDD` | Domain | the domain model — an entity, rule, or boundary the spec assumed wrong |
+| `SDD` | Spec | what the feature must do or reject — a missing or wrong requirement |
+| `UDD` | UI/UX | the user-facing shape — a flow, affordance, or wording that misled |
+| `TDD` | Test | how we prove correctness — a missing scenario, a flaky or hollow test |
+| `ADD` | AI/build | how the AI builds — a harness, prompt, or convention that helped or hurt |
+
+Each delta is one tagged entry — `- [COMPETENCY · status] the learning (evidence: a pointer)` — and the evidence is **required**: a failing scenario, a production signal, a review note. No evidence means it is an opinion, not a delta. The AI **emits** deltas as `open`; it never folds its own. Folding is judgment, and judgment is the human's — the same verify/observe seam that keeps the AI from grading its own work.
+
+**The fold.** At milestone close (or on demand, when open deltas pile up), a person runs the fold ritual: **gather** every `open` delta across the milestone's tasks, **group** them by competency, **propose** the exact foundation edit for each, **confirm** with the human one by one, then **write** — append-only — flipping each delta to `folded` (merged) or `rejected` (considered and deliberately not merged, left in place so the trail survives), and bumping the `foundation-version:` marker. `DDD`/`SDD`/`UDD` deltas fold into the matching section of `PROJECT.md`; `TDD`/`ADD` fold into `CONVENTIONS.md` (they sharpen the engine, not the product); and **every** fold also appends one row to `PROJECT.md` §Key Decisions — the universal, auditable record of what the foundation learned.
+
+**Tooling.** `add.py deltas` lists every open delta across the project (so nothing waiting to be folded is invisible); `add.py check` lints each delta's well-formedness — known competency tag, valid status, non-empty evidence. There is deliberately **no `add.py fold`**: the engine stays judgment-free, and the ritual lives with the human who owns it.
+
 ## Re-entrancy: the loop is the whole point
 
 Two principles converge here. *The flow is re-entrant* — any step can send you back to an earlier one — and *the flow is a loop* — production feeds the next specification. Together they mean the artifacts you built are never "finished"; they are living documents that the next cycle refines.

--- a/add-method/src/add_method/_bundled/docs/10-setup-and-stages.md
+++ b/add-method/src/add_method/_bundled/docs/10-setup-and-stages.md
@@ -73,3 +73,24 @@ The durable thing is never the code:
 | MVP → Production | nothing | everything; the code is real and is hardened |
 
 The survivor layer thickens as you move right: a prototype leaves you a validated design; a proof of concept adds a proven approach and a contract; the MVP adds real, kept code. By production, you are hardening, not rebuilding.
+
+---
+
+## Parallel streams (opt-in)
+
+The default is one task at a time. But when a milestone holds several tasks whose dependencies are already `PASS` and a reviewer is ready, you may run them **concurrently** — one worker per ready task, each building behind its own frozen contract.
+
+**Be honest about the gain.** With one human reviewer you cannot beat `review_time × N_tasks`; the human-led seams are serial. So the win is **not throughput** — it is that the reviewer is *never blocked waiting on a build*. While a person reviews task A's front, the builds for B, C, and D run behind *their* frozen contracts. You hide build latency under human latency; do not promise more.
+
+**Two queues, no new state** — both read from `add.py status`:
+
+- **READY-QUEUE** — tasks in the active milestone where the phase is not `done` and every dependency already reads `gate=PASS`. These are the only tasks a worker may pick up; a task finishing `PASS` unblocks its dependents on the next `status`.
+- **REVIEW-QUEUE** — the irreducibly serial part: the **one-approval front** (contract freeze) and any **Verify escalation**. One human, one queue, presented one at a time — never a batch that invites a rubber stamp.
+
+**The autonomy dial is the throttle.** At `conservative`, both gates queue on the human (pure pipelining — builds overlap, nothing auto-resolves). At `auto` (the default), only the front seam and residue escalations queue; Verify auto-PASSes on evidence, so real concurrency follows. The floor never drops below **one human approval per task, at the contract seam**.
+
+**Design for failure (required).** Lease each task to its worker with a timeout — if a worker dies, release the claim back to READY rather than trusting partial work. A worker that hits a stop-and-escalate blocks only its own task; siblings keep running. And if several workers fail in one wave, trip a circuit-breaker and fall back to sequential — repeated failure means the scope was wrong, not the parallelism.
+
+**The hard boundary.** The orchestrator owns every shared write — `state.json`, `MILESTONE.md`, and each `add.py advance`/`gate` call (always with the explicit task slug). A worker owns only its own task directory and is isolated in a git worktree, so concurrent builds cannot collide. Merge is **serial**: bring worktrees back one at a time and run an **integration Verify** for the concurrency and architecture conflicts that two-green-in-isolation tasks can still produce — automation never auto-passes that step.
+
+The full, agent-agnostic worker contract (the prompt a worker runs) and the per-runner spawn adapter live in the skill's `streams.md`; this section is the *why* and the safety frame, not the operational recipe.

--- a/add-method/src/add_method/_bundled/docs/14-foundation.md
+++ b/add-method/src/add_method/_bundled/docs/14-foundation.md
@@ -105,7 +105,11 @@ life of the product, owned above any single milestone.
 A milestone is a *version bump* to the foundation, not a fresh start: when it
 closes, fold what it validated into `PROJECT.md` (a decision, a settled domain
 term, a confirmed user journey) and open the next one against the same, now-richer,
-ground.
+ground. The fold is not informal: each loop emits **competency deltas** (tagged
+`DDD · SDD · UDD · TDD · ADD`) in its Observe step, and at milestone close a person
+gathers the open ones and folds them — append-only, with the `foundation-version:`
+bumped — into the foundation. See [09 · The loop](./09-the-loop.md#competency-deltas-and-the-foundation-fold)
+for the grammar, the ritual, and the tooling (`add.py deltas`, `add.py check`).
 
 ## In the tooling
 

--- a/add-method/src/add_method/_bundled/docs/appendix-f-requirements-matrix.md
+++ b/add-method/src/add_method/_bundled/docs/appendix-f-requirements-matrix.md
@@ -12,7 +12,7 @@ This appendix maps every AIDD document to a three-level project hierarchy, so th
 |-------|-----------|--------------|-------|
 | **Project** | the whole product or engagement | the survivor layer — documents created once and kept for the life of the product | all milestones |
 | **Milestone** | a stage or release | one pass of the flow at a chosen depth: Prototype, POC, MVP, or Production-Ready; groups many tasks | many tasks |
-| **Task** | one feature through the flow | a single pass of Specify → … → Verify; the smallest unit with its own gate records | the six steps |
+| **Task** | one feature through the flow | a single pass of Specify → … → Verify → Observe; the smallest unit with its own gate records | the seven steps |
 
 A **project** sets up the survivor-layer documents once. A **milestone** is a depth-bounded goal that groups tasks and has its own entry and exit document gates. A **task** is one feature, and it produces the per-feature artifacts.
 
@@ -87,7 +87,7 @@ Which documents must exist, and at what depth, to **exit** each milestone. Depth
 
 ---
 
-## Matrix 3 — Documents required per task (the six steps)
+## Matrix 3 — Documents required per task (the seven steps)
 
 Every task, regardless of milestone, produces this artifact chain. The depth varies by milestone (Matrix 2); the *sequence and exit gate* do not.
 
@@ -98,9 +98,10 @@ Every task, regardless of milestone, produces this artifact chain. The depth var
 | 3 Contract | `contracts/<task>.md` | frozen + contract tests green | [05](./05-step-3-contract.md) |
 | 4 Tests | `tests/<task>_*` | one test per scenario, red first | [06](./06-step-4-tests.md) |
 | 5 Build | source code + evidence bundle | all tests green, nothing weakened | [07](./07-step-5-build.md) |
-| 6 Verify | gate outcome record | `PASS` / `RISK-ACCEPTED` / `HARD-STOP` | [08](./08-step-6-verify.md) |
+| 6 Verify | gate outcome record | `PASS` / `RISK-ACCEPTED` / `HARD-STOP` (auto-resolved on evidence under `autonomy: auto`; security always escalates) | [08](./08-step-6-verify.md) |
+| 7 Observe | `TASK.md` §7 OBSERVE block | released behind a flag; scenario-monitors live; spec delta + competency deltas captured | [09](./09-the-loop.md) |
 
-A task is **done** only when all six documents exist and the Verify record reads `PASS` (or a signed `RISK-ACCEPTED`). See the master shippable checklist in [Appendix E](./appendix-e-checklists.md).
+A task is **done** when the build's documents exist and the Verify record reads `PASS` (or a signed `RISK-ACCEPTED`); the seventh step — **Observe** (§7) — then runs in production and feeds the next loop's Specify. See the master shippable checklist in [Appendix E](./appendix-e-checklists.md).
 
 ---
 

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -119,6 +119,7 @@ inside TASK.md):
 ```bash
 python3 .add/tooling/add.py advance            # next phase of the active task
 python3 .add/tooling/add.py gate PASS          # at verify: records PASS, marks done
+python3 .add/tooling/add.py use <slug>         # switch the active task (e.g. across parallel streams)
 ```
 
 ## Depth by stage

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -57,13 +57,21 @@ Load the phase guide **only for the phase you are in** (progressive disclosure):
 | Phase | Guide | Produces (TASK.md section) | Who leads |
 |-------|-------|----------------------------|-----------|
 | setup | `phases/0-setup.md` | `.add/` + survivor files | human |
-| specify | `phases/1-specify.md` | §1 rules + ranked least-sure flag | human + AI (co-specify) |
-| scenarios | `phases/2-scenarios.md` | §2 Given/When/Then | human |
-| contract | `phases/3-contract.md` | §3 frozen shape | human + AI |
-| tests | `phases/4-tests.md` | §4 + red suite in `tests/` | human sets, AI writes |
+| specify | `phases/1-specify.md` | §1 rules + ranked least-sure flag | AI drafts (co-specify)† |
+| scenarios | `phases/2-scenarios.md` | §2 Given/When/Then | AI drafts† |
+| contract | `phases/3-contract.md` | §3 frozen shape | AI drafts → **human approves once** (the seam)† |
+| tests | `phases/4-tests.md` | §4 + red suite in `tests/` | AI drafts† |
 | build | `phases/5-build.md` | code in `src/`, tests green | **AI** |
-| verify | `phases/6-verify.md` | §6 checks + gate record | **human** |
+| verify | `phases/6-verify.md` | §6 checks + gate record | **AI auto-gates on evidence**; human on residue/security‡ |
 | observe | `phases/7-observe.md` | §7 spec delta | human + AI |
+
+† **One-approval front (v7).** §1–§4 are drafted by the AI as a single bundle and frozen
+together; the human gives **one approval, at the contract freeze** (the autonomy seam) — not
+three separate sign-offs. The AI presents the bundle least-sure-first. See `run.md`.
+‡ **Verify auto-gate (v6–v7).** Under `autonomy: auto` (the default) a run may auto-PASS once
+the evidence is complete (all tests green · loops dry · no residue) — recorded as *auto-resolved*,
+an explicit PASS, not a skip. **Security always escalates** (HARD-STOP), as do concurrency /
+architecture residue and `conservative` autonomy. See `run.md`.
 
 In **observe**, also emit **competency deltas** — learnings tagged by which of the five
 (`DDD · SDD · UDD · TDD · ADD`) they improve — so the foundation self-improves across loops.
@@ -71,13 +79,14 @@ You write them as `open`; the human folds them into `PROJECT.md`. Read `deltas.m
 grammar and the status lifecycle. At milestone close (or on demand), run the fold ritual that
 gathers confirmed deltas into a versioned foundation — read `fold.md`.
 
-## The dynamic run (v6)
+## The dynamic run (v6–v7)
 
-Once **§3 CONTRACT is FROZEN**, the build→verify half MAY run as a dynamic, auto-gated run —
-fan-out + in-run convergence — instead of a manual build. Read `run.md` for the trigger, the
-touch-boundary, the evidence auto-gate, and the autonomy dial. The human-led front
-(specify·scenarios·contract) is unchanged; the run never edits a frozen contract and never
-auto-passes a security finding.
+Once **§3 CONTRACT is FROZEN**, the build→verify half runs as a dynamic, auto-gated run —
+fan-out + in-run convergence — instead of a manual build (`autonomy: auto` is the default; lower
+to `conservative` to keep a human at the gate). Read `run.md` for the trigger, the touch-boundary,
+the evidence auto-gate, and the autonomy dial. The human-led front still owns *direction*, but v7
+compresses it to a **single approval at the contract seam**; the run never edits a frozen contract
+and never auto-passes a security finding.
 
 ## Parallel streams — pipelining independent tasks (opt-in)
 

--- a/add-method/src/add_method/_bundled/skill/add/deltas.md
+++ b/add-method/src/add_method/_bundled/skill/add/deltas.md
@@ -10,7 +10,7 @@ You (the AI) **emit** deltas as `open`. Only the **human** moves a delta to `fol
 
 ## The grammar (frozen)
 
-Each delta is ONE line, exactly:
+Each delta begins on its own **tag line**; the learning may wrap onto continuation lines:
 
 ```
 - [<COMPETENCY> · <status>] <learning> (evidence: <pointer>)
@@ -18,9 +18,19 @@ Each delta is ONE line, exactly:
 
 - `<COMPETENCY>` — exactly one of the five (below).
 - `<status>` — `open` | `folded` | `rejected`. A **newly emitted delta is `open`**.
-- `<learning>` — the insight, in one phrase ("the domain model missed multi-tenancy").
+- `<learning>` — the insight ("the domain model missed multi-tenancy"). It may run past one line;
+  the `- [COMPETENCY · status]` tag line must come **first**, and the `(evidence: …)` clause must
+  **close** the delta (on its last line).
 - `(evidence: …)` — **required**, non-empty: a failing scenario, a production signal, a review
   note. No evidence → it is an opinion, not a delta.
+
+A long learning may wrap — the lint (`add.py check`) joins continuation lines, so this is **one**
+delta, not two:
+
+```
+- [SDD · open] the export endpoint must reject a tenant-scoped token used cross-tenant,
+  returning `forbidden` (not `not_found`) (evidence: scenario_cross_tenant_export failed)
+```
 
 ## The five competencies (pick exactly one per delta)
 

--- a/add-method/src/add_method/_bundled/skill/add/phases/5-build.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/5-build.md
@@ -36,3 +36,6 @@ change request back to Specify. Honor the feature-specific safety rule named in 
 
 `python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
+
+> Under `autonomy: auto` (the default) Build and Verify run together as one dynamic,
+> evidence-auto-gated run — not two manual stops. See `run.md`.

--- a/add-method/src/add_method/_bundled/skill/add/phases/6-verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/6-verify.md
@@ -1,8 +1,16 @@
 # Phase 6 — Verify (evidence + blind-spot checks)
 
 Goal: establish trust and record an outcome. Passing tests are necessary, not
-sufficient. This phase is **human-led** — there is no AI role. Fill **§6** in
-TASK.md including the GATE RECORD.
+sufficient. Fill **§6** in TASK.md including the GATE RECORD.
+
+> **Who resolves this gate depends on the `autonomy:` header (see `run.md`).**
+> Under `autonomy: auto` (the default) a run auto-PASSes once the evidence is
+> complete — every test green, the convergence loops dry, and **no residue**
+> (security · concurrency · architecture) — recording it as *auto-resolved* with
+> the named run as accountable owner: an explicit PASS, not a skip. **Security is
+> always a HARD-STOP and is never auto-passed.** Under `autonomy: conservative`,
+> or whenever residue is found, this phase is **human-led** and the checks below
+> are the human's.
 
 ## Part one — confirm the evidence
 
@@ -30,7 +38,8 @@ If any is false, stop and return to Build — there is nothing to verify yet.
 
 ## Exit gate / Next
 
-- [ ] Evidence confirmed, blind-spots checked, a person approved, outcome recorded.
+- [ ] Evidence confirmed, blind-spots checked, outcome recorded — a person approved, or
+  (under `autonomy: auto` with no residue) the run auto-resolved as the accountable owner.
 
 ```bash
 python3 .add/tooling/add.py gate PASS          # marks the task done

--- a/add-method/src/add_method/_bundled/skill/add/streams.md
+++ b/add-method/src/add_method/_bundled/skill/add/streams.md
@@ -65,6 +65,11 @@ never drops to zero (`run.md:22`). That floor is correct; do not engineer around
 
 ## Design for failure (required)
 
+- **Fresh worktree base (verify base == HEAD)** — create each worker's worktree from current
+  `HEAD` **after** you commit the task's frozen front (spec · scenarios · contract · tests). A
+  worktree forked from a stale base forces the worker to recreate the frozen artifacts by hand
+  (the v10 dogfood hit exactly this). Before the worker starts, confirm `git -C <worktree>
+  rev-parse HEAD` equals the orchestrator's `HEAD`; if it drifted, `git merge` the base in first.
 - **Lease + timeout** — record which worker holds which task; if a worker dies, release
   the claim back to READY (re-spawn, do not assume partial work is sound).
 - **Failure isolates** — a worker that hits a STOP-and-escalate (below) blocks only its
@@ -181,7 +186,7 @@ worktree, then points the agent at that directory.
 |-----------|----------|----------------------------------|-----------------------------------------------|
 | spawn a worker | prompt + label | `Task(description=…, prompt=…)` | `cd $WT && <agent> run --prompt-file PROMPT.md` |
 | pick the model | tier → id | `model="opus"\|"sonnet"` | a `--model <id>` flag |
-| isolate | worktree | `isolation="worktree"` | `git worktree add $WT <base>`, then run inside it |
+| isolate | worktree | `isolation="worktree"` | `git worktree add $WT HEAD` (after committing the front; verify base == HEAD), then run inside it |
 | load context | files / cwd | `<context_files>` + repo cwd | run inside `$WT`; paths are relative |
 | domain expertise | skill / preamble | a Claude skill in `<expertise>` | a system-prompt / profile preamble |
 | return a verdict | structured | final message (optionally a schema) | stdout JSON the orchestrator parses |

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -162,7 +162,14 @@ def _require_root() -> Path:
 
 
 def load_state(root: Path) -> dict:
-    return json.loads((root / STATE_FILE).read_text(encoding="utf-8"))
+    """Load + parse state.json, failing CLOSED. A corrupt or unreadable state file
+    dies with a clean 'state_invalid' message (never a raw traceback), so every
+    command that loads state degrades gracefully (design-for-failure)."""
+    try:
+        return json.loads((root / STATE_FILE).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        _die(f"state_invalid: {root / STATE_FILE} is corrupt or unreadable "
+             f"({e.__class__.__name__}) — restore it from git or a backup")
 
 
 def _load_state_for_json() -> tuple[Path, dict]:
@@ -531,8 +538,8 @@ def cmd_status(args: argparse.Namespace) -> None:
     state = load_state(root)
     active = state.get("active_task")
     tasks = state.get("tasks", {})
-    print(f"project : {state['project']}")
-    print(f"stage   : {state['stage']}")
+    print(f"project : {state.get('project', '(unknown)')}")
+    print(f"stage   : {state.get('stage', '(unknown)')}")
     # foundation pointer — read the cross-milestone context first (anti-rot)
     if (root / "PROJECT.md").exists():
         print("context : .add/PROJECT.md  (foundation: domain · spec · UI/UX — read first)")
@@ -580,7 +587,7 @@ def cmd_status(args: argparse.Namespace) -> None:
     open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
     if open_deltas:
         print(f"deltas  : {open_deltas} open — fold at milestone close (add.py deltas)")
-    if active:
+    if active and active in tasks:
         ph = tasks[active]["phase"]
         if ph == "done":
             print(f"\nresume  : task '{active}' is done ({tasks[active]['gate']}).")
@@ -879,6 +886,15 @@ def cmd_archive_milestone(args: argparse.Namespace) -> None:
             t = tasks[s]
             print(f"  - {s} (phase={t.get('phase')}, gate={t.get('gate')})", file=sys.stderr)
         _die("milestone_has_incomplete_tasks")
+    # pre-archive snapshot (design-for-failure): the archived record below keeps only a
+    # slug-list, so capture the full milestone + member task records to a .bak BEFORE the
+    # destructive deletes — an accidental archive stays recoverable (phase/gate/waiver/deps
+    # the record drops). Mirrors the .bak the guideline injector writes before mutating.
+    _atomic_write(
+        root / "milestones" / slug / "pre-archive-state.bak.json",
+        json.dumps({"milestone": ms, "tasks": {s: tasks[s] for s in members},
+                    "archived_at": _now()}, indent=2) + "\n",
+    )
     # a slug-list summary (never task bodies) so the active state can't regrow,
     # yet cross-milestone deps on these tasks still resolve (see _archived_task_slugs)
     state.setdefault("archived", []).append({
@@ -916,6 +932,20 @@ def cmd_set_milestone(args: argparse.Namespace) -> None:
     state["tasks"][task]["updated"] = _now()
     save_state(root, state)
     print(f"task '{task}' -> milestone '{new}'" if new else f"task '{task}' -> milestone (none)")
+
+
+def cmd_use(args: argparse.Namespace) -> None:
+    """Set the active task to an EXISTING task (switch focus) without scaffolding a new
+    one or hand-editing state.json. advance/gate/phase still take an explicit slug; `use`
+    just moves the default focus, closing the only gap that forced manual state edits."""
+    root = _require_root()
+    state = load_state(root)
+    slug = args.slug
+    if slug not in state.get("tasks", {}):
+        _die("unknown_task")
+    state["active_task"] = slug
+    save_state(root, state)
+    print(f"active task -> '{slug}' (phase={state['tasks'][slug]['phase']})")
 
 
 def _find_cycle(tasks: dict) -> list[str] | None:
@@ -1416,7 +1446,7 @@ def _write_retro(root: Path, state: dict, mslug: str) -> Path:
     trust the locale default), never mutates state.json."""
     content = render_report(root, state, mslug, width=_DEFAULT_WIDTH, ascii=False)
     path = root / "milestones" / mslug / "RETRO.md"
-    path.write_text(content, encoding="utf-8")
+    _atomic_write(path, content)   # honor the module's atomic-write contract (no half-write)
     return path
 
 
@@ -1728,6 +1758,10 @@ def build_parser() -> argparse.ArgumentParser:
     psm.add_argument("task")
     psm.add_argument("milestone", help="milestone slug, or 'none' to detach")
     psm.set_defaults(func=cmd_set_milestone)
+
+    pu = sub.add_parser("use", help="set the active task to an existing one (switch focus)")
+    pu.add_argument("slug")
+    pu.set_defaults(func=cmd_use)
 
     pam = sub.add_parser("archive-milestone",
                          help="collapse a done milestone out of active state (files stay on disk)")

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -575,6 +575,11 @@ def cmd_status(args: argparse.Namespace) -> None:
         dep_s = f"  deps={','.join(deps)}" if deps else ""
         ms_s = f"  [{t['milestone']}]" if t.get("milestone") else ""
         print(f"  {mark} {slug:<24} phase={t['phase']:<10} gate={t['gate']}{ms_s}{dep_s}")
+    # fold-pressure nudge: surface unfolded competency deltas so emission can't
+    # silently outrun the human fold (read-only; v11). Silent when none are open.
+    open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
+    if open_deltas:
+        print(f"deltas  : {open_deltas} open — fold at milestone close (add.py deltas)")
     if active:
         ph = tasks[active]["phase"]
         if ph == "done":
@@ -844,6 +849,12 @@ def cmd_milestone_done(args: argparse.Namespace) -> None:
     print(f"milestone '{slug}' -> done ({len(members)} tasks complete{tail}).")
     print(f"wrote {retro_path.relative_to(root.parent)}  (milestone exit report)")
     print("Confirm the MILESTONE.md exit criteria are checked, then archive/start the next.")
+    # fold-pressure nudge: milestone close is the natural fold point for open deltas (v11)
+    open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
+    if open_deltas:
+        noun = "delta" if open_deltas == 1 else "deltas"
+        print(f"note: {open_deltas} open competency {noun} to fold into the foundation "
+              f"— review with: add.py deltas")
 
 
 def cmd_archive_milestone(args: argparse.Namespace) -> None:
@@ -1540,18 +1551,32 @@ def _collect_open_deltas(root: Path) -> dict[str, list[dict]]:
         if not block_match:
             continue
         block = block_match.group(1)
+        # Group lines into entries (tag line + continuations) so a multi-line delta —
+        # whose learning wraps and whose (evidence: …) may land on a later line — is read
+        # in FULL, not truncated to its first line. A tag line starts an entry; a line
+        # that does not begin a new "- " list item continues it; a blank/comment or a
+        # new "- " item ends it (a trailing malformed item can't pollute a delta's text).
+        entries: list[list[str]] = []
+        current: list[str] | None = None
         for line in block.splitlines():
-            # Skip HTML-comment lines (<!-- ... -->) and blank lines.
             stripped = line.strip()
             if not stripped or stripped.startswith("<!--"):
+                current = None
                 continue
-            m = _DELTA_RE.match(stripped)
-            if not m:
-                continue  # malformed — skip silently
-            comp, status, tail = m.group(1), m.group(2), m.group(3).strip()
+            if _DELTA_RE.match(stripped):
+                current = [stripped]
+                entries.append(current)
+            elif current is not None and not stripped.startswith("-"):
+                current.append(stripped)  # genuine wrap of the current learning
+            else:
+                current = None             # a new / malformed list item ends the run
+        for unit in entries:
+            m = _DELTA_RE.match(unit[0])
+            comp, status = m.group(1), m.group(2)
             if status != "open":
                 continue
-            # Split off "(evidence: ...)" suffix if present.
+            # Join the tag line's tail with any continuation lines, then split evidence.
+            tail = " ".join([m.group(3).strip(), *unit[1:]]).strip()
             em = _EVIDENCE_RE.match(tail)
             if em:
                 delta_text, evidence = em.group(1).strip(), em.group(2).strip()

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -162,7 +162,14 @@ def _require_root() -> Path:
 
 
 def load_state(root: Path) -> dict:
-    return json.loads((root / STATE_FILE).read_text(encoding="utf-8"))
+    """Load + parse state.json, failing CLOSED. A corrupt or unreadable state file
+    dies with a clean 'state_invalid' message (never a raw traceback), so every
+    command that loads state degrades gracefully (design-for-failure)."""
+    try:
+        return json.loads((root / STATE_FILE).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        _die(f"state_invalid: {root / STATE_FILE} is corrupt or unreadable "
+             f"({e.__class__.__name__}) — restore it from git or a backup")
 
 
 def _load_state_for_json() -> tuple[Path, dict]:
@@ -531,8 +538,8 @@ def cmd_status(args: argparse.Namespace) -> None:
     state = load_state(root)
     active = state.get("active_task")
     tasks = state.get("tasks", {})
-    print(f"project : {state['project']}")
-    print(f"stage   : {state['stage']}")
+    print(f"project : {state.get('project', '(unknown)')}")
+    print(f"stage   : {state.get('stage', '(unknown)')}")
     # foundation pointer — read the cross-milestone context first (anti-rot)
     if (root / "PROJECT.md").exists():
         print("context : .add/PROJECT.md  (foundation: domain · spec · UI/UX — read first)")
@@ -580,7 +587,7 @@ def cmd_status(args: argparse.Namespace) -> None:
     open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
     if open_deltas:
         print(f"deltas  : {open_deltas} open — fold at milestone close (add.py deltas)")
-    if active:
+    if active and active in tasks:
         ph = tasks[active]["phase"]
         if ph == "done":
             print(f"\nresume  : task '{active}' is done ({tasks[active]['gate']}).")
@@ -879,6 +886,15 @@ def cmd_archive_milestone(args: argparse.Namespace) -> None:
             t = tasks[s]
             print(f"  - {s} (phase={t.get('phase')}, gate={t.get('gate')})", file=sys.stderr)
         _die("milestone_has_incomplete_tasks")
+    # pre-archive snapshot (design-for-failure): the archived record below keeps only a
+    # slug-list, so capture the full milestone + member task records to a .bak BEFORE the
+    # destructive deletes — an accidental archive stays recoverable (phase/gate/waiver/deps
+    # the record drops). Mirrors the .bak the guideline injector writes before mutating.
+    _atomic_write(
+        root / "milestones" / slug / "pre-archive-state.bak.json",
+        json.dumps({"milestone": ms, "tasks": {s: tasks[s] for s in members},
+                    "archived_at": _now()}, indent=2) + "\n",
+    )
     # a slug-list summary (never task bodies) so the active state can't regrow,
     # yet cross-milestone deps on these tasks still resolve (see _archived_task_slugs)
     state.setdefault("archived", []).append({
@@ -916,6 +932,20 @@ def cmd_set_milestone(args: argparse.Namespace) -> None:
     state["tasks"][task]["updated"] = _now()
     save_state(root, state)
     print(f"task '{task}' -> milestone '{new}'" if new else f"task '{task}' -> milestone (none)")
+
+
+def cmd_use(args: argparse.Namespace) -> None:
+    """Set the active task to an EXISTING task (switch focus) without scaffolding a new
+    one or hand-editing state.json. advance/gate/phase still take an explicit slug; `use`
+    just moves the default focus, closing the only gap that forced manual state edits."""
+    root = _require_root()
+    state = load_state(root)
+    slug = args.slug
+    if slug not in state.get("tasks", {}):
+        _die("unknown_task")
+    state["active_task"] = slug
+    save_state(root, state)
+    print(f"active task -> '{slug}' (phase={state['tasks'][slug]['phase']})")
 
 
 def _find_cycle(tasks: dict) -> list[str] | None:
@@ -1416,7 +1446,7 @@ def _write_retro(root: Path, state: dict, mslug: str) -> Path:
     trust the locale default), never mutates state.json."""
     content = render_report(root, state, mslug, width=_DEFAULT_WIDTH, ascii=False)
     path = root / "milestones" / mslug / "RETRO.md"
-    path.write_text(content, encoding="utf-8")
+    _atomic_write(path, content)   # honor the module's atomic-write contract (no half-write)
     return path
 
 
@@ -1728,6 +1758,10 @@ def build_parser() -> argparse.ArgumentParser:
     psm.add_argument("task")
     psm.add_argument("milestone", help="milestone slug, or 'none' to detach")
     psm.set_defaults(func=cmd_set_milestone)
+
+    pu = sub.add_parser("use", help="set the active task to an existing one (switch focus)")
+    pu.add_argument("slug")
+    pu.set_defaults(func=cmd_use)
 
     pam = sub.add_parser("archive-milestone",
                          help="collapse a done milestone out of active state (files stay on disk)")

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -575,6 +575,11 @@ def cmd_status(args: argparse.Namespace) -> None:
         dep_s = f"  deps={','.join(deps)}" if deps else ""
         ms_s = f"  [{t['milestone']}]" if t.get("milestone") else ""
         print(f"  {mark} {slug:<24} phase={t['phase']:<10} gate={t['gate']}{ms_s}{dep_s}")
+    # fold-pressure nudge: surface unfolded competency deltas so emission can't
+    # silently outrun the human fold (read-only; v11). Silent when none are open.
+    open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
+    if open_deltas:
+        print(f"deltas  : {open_deltas} open — fold at milestone close (add.py deltas)")
     if active:
         ph = tasks[active]["phase"]
         if ph == "done":
@@ -844,6 +849,12 @@ def cmd_milestone_done(args: argparse.Namespace) -> None:
     print(f"milestone '{slug}' -> done ({len(members)} tasks complete{tail}).")
     print(f"wrote {retro_path.relative_to(root.parent)}  (milestone exit report)")
     print("Confirm the MILESTONE.md exit criteria are checked, then archive/start the next.")
+    # fold-pressure nudge: milestone close is the natural fold point for open deltas (v11)
+    open_deltas = sum(len(v) for v in _collect_open_deltas(root).values())
+    if open_deltas:
+        noun = "delta" if open_deltas == 1 else "deltas"
+        print(f"note: {open_deltas} open competency {noun} to fold into the foundation "
+              f"— review with: add.py deltas")
 
 
 def cmd_archive_milestone(args: argparse.Namespace) -> None:
@@ -1540,18 +1551,32 @@ def _collect_open_deltas(root: Path) -> dict[str, list[dict]]:
         if not block_match:
             continue
         block = block_match.group(1)
+        # Group lines into entries (tag line + continuations) so a multi-line delta —
+        # whose learning wraps and whose (evidence: …) may land on a later line — is read
+        # in FULL, not truncated to its first line. A tag line starts an entry; a line
+        # that does not begin a new "- " list item continues it; a blank/comment or a
+        # new "- " item ends it (a trailing malformed item can't pollute a delta's text).
+        entries: list[list[str]] = []
+        current: list[str] | None = None
         for line in block.splitlines():
-            # Skip HTML-comment lines (<!-- ... -->) and blank lines.
             stripped = line.strip()
             if not stripped or stripped.startswith("<!--"):
+                current = None
                 continue
-            m = _DELTA_RE.match(stripped)
-            if not m:
-                continue  # malformed — skip silently
-            comp, status, tail = m.group(1), m.group(2), m.group(3).strip()
+            if _DELTA_RE.match(stripped):
+                current = [stripped]
+                entries.append(current)
+            elif current is not None and not stripped.startswith("-"):
+                current.append(stripped)  # genuine wrap of the current learning
+            else:
+                current = None             # a new / malformed list item ends the run
+        for unit in entries:
+            m = _DELTA_RE.match(unit[0])
+            comp, status = m.group(1), m.group(2)
             if status != "open":
                 continue
-            # Split off "(evidence: ...)" suffix if present.
+            # Join the tag line's tail with any continuation lines, then split evidence.
+            tail = " ".join([m.group(3).strip(), *unit[1:]]).strip()
             em = _EVIDENCE_RE.match(tail)
             if em:
                 delta_text, evidence = em.group(1).strip(), em.group(2).strip()

--- a/add-method/tooling/test_deltas_lint.py
+++ b/add-method/tooling/test_deltas_lint.py
@@ -108,6 +108,16 @@ class DeltasLintTest(unittest.TestCase):
         self.assertEqual(code, 0, "folded history must be skipped, not re-validated")
         self.assertNotIn("no_evidence", out)
 
+    def test_unreadable_task_emits_no_check(self):
+        # design-for-failure: an existing-but-unreadable TASK.md yields no lint check
+        # (None), never a crash/traceback.
+        from unittest import mock
+        self._add_deltas("a", "- [TDD · open] one (evidence: e)")
+        root = add.find_root()
+        with mock.patch.object(Path, "read_text", side_effect=OSError("boom")):
+            result = add._lint_task_deltas(root, "a")
+        self.assertIsNone(result, "unreadable TASK.md must yield no check (None), not a crash")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/add-method/tooling/test_deltas_report.py
+++ b/add-method/tooling/test_deltas_report.py
@@ -110,6 +110,32 @@ class DeltasReportTest(unittest.TestCase):
         self.assertEqual(code, 0, "a malformed line must not crash the report")
         self.assertIn("valid-open-one", out)
 
+    def test_multiline_open_delta_not_truncated(self):
+        # Regression: a delta whose learning wraps onto a continuation line — with the
+        # (evidence: …) clause on the last line — must be reported in full, not truncated
+        # to its first line, and its evidence must not be lost. (The lint already groups
+        # continuations; the report did not — they must agree on the multi-line shape.)
+        self._add_deltas("a",
+                         "- [SDD · open] the export endpoint must reject a cross-tenant token,",
+                         "  returning forbidden not not_found (evidence: scenario_cross_tenant_export failed)")
+        code, out, _ = _run(["deltas", "--json"])
+        self.assertEqual(code, 0)
+        entry = json.loads(out)["by_competency"]["SDD"][0]
+        self.assertIn("returning forbidden", entry["text"],
+                      "multi-line delta truncated — continuation text dropped")
+        self.assertEqual(entry["evidence"], "scenario_cross_tenant_export failed",
+                         "evidence on the continuation line was lost")
+
+    def test_unreadable_task_skipped_not_fatal(self):
+        # design-for-failure: an existing-but-unreadable TASK.md is skipped, never crashes.
+        from unittest import mock
+        self._add_deltas("a", "- [TDD · open] one (evidence: e)")
+        root = add.find_root()
+        with mock.patch.object(Path, "read_text", side_effect=OSError("boom")):
+            by_comp = add._collect_open_deltas(root)
+        self.assertEqual(sum(len(v) for v in by_comp.values()), 0,
+                         "unreadable task must be skipped (no crash, no deltas)")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/add-method/tooling/test_flow_diagram.py
+++ b/add-method/tooling/test_flow_diagram.py
@@ -26,7 +26,8 @@ CHAPTER = ROOT / "add-method" / "docs" / "02-the-flow.md"   # the tested content
 CHECKLIST = ROOT / "add-method" / "diagrams" / "CHECKLIST.md"  # the reusable pipeline
 
 # Phases the FLOW depicts = PHASES minus the terminal bookkeeping state "done".
-# ch02 is "six steps, then an observation loop"; "done" is an engine state, not a step.
+# ch02 is "seven steps" (six build the feature, Observe is the seventh); "done" is an
+# engine state, not a step — so the FLOW depicts every phase except the terminal "done".
 FLOW_PHASES = [p for p in add.PHASES if p != "done"]
 
 

--- a/add-method/tooling/test_fold_nudge.py
+++ b/add-method/tooling/test_fold_nudge.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Behavioral proof of the fold-nudge (task: v11 fold-nudge).
+
+Emission and folding of competency deltas are decoupled — a fast run accumulates
+open deltas that sit unfolded because nothing surfaces them (the v6 RETRO flagged
+this; the v5 convergence-signal task was cut). v11 wires the already-shipped
+_collect_open_deltas into `status` (a passive count) and `milestone-done` (a fold
+reminder at the natural fold point). Read-only and additive: silent at zero.
+Run: python3 -m unittest test_fold_nudge -v
+"""
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import add
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    code = 0
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            add.main(argv)
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
+    return code, out.getvalue(), err.getvalue()
+
+
+class FoldNudgeTest(unittest.TestCase):
+    def setUp(self):
+        self._cwd = Path.cwd()
+        self.tmp = tempfile.mkdtemp(prefix="add-fold-nudge-")
+        os.chdir(self.tmp)
+        add.main(["init", "--name", "demo"])
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+
+    def _add_delta(self, slug, line):
+        p = Path(self.tmp) / ".add" / "tasks" / slug / "TASK.md"
+        text = p.read_text(encoding="utf-8")
+        marker = "### Competency deltas"
+        idx = text.index(marker) + len(marker)
+        p.write_text(text[:idx] + "\n" + line + "\n" + text[idx:], encoding="utf-8")
+
+    def _complete_task_in_milestone(self, ms, slug):
+        add.main(["new-milestone", ms, "--goal", "g", "--stage", "mvp"])
+        add.main(["new-task", slug])
+        add.main(["phase", "verify", slug])   # escape hatch: scaffold straight to verify
+        add.main(["gate", "PASS", slug])      # task is now done
+
+    # --- status: a passive nudge --------------------------------------------
+    def test_status_nudges_when_open_deltas(self):
+        add.main(["new-task", "a"])
+        self._add_delta("a", "- [TDD · open] a learning (evidence: e)")
+        _, out, _ = _run(["status"])
+        self.assertRegex(out, r"deltas\s*:\s*1 open",
+                         "status must surface the open-delta count")
+        self.assertIn("add.py deltas", out)
+
+    def test_status_silent_when_no_open_deltas(self):
+        add.main(["new-task", "a"])  # task exists, but no deltas
+        _, out, _ = _run(["status"])
+        self.assertNotRegex(out, r"deltas\s*:\s*\d+ open",
+                            "status must NOT nudge when there are no open deltas")
+
+    def test_status_silent_when_only_folded(self):
+        add.main(["new-task", "a"])
+        self._add_delta("a", "- [TDD · folded] historical (evidence: e)")
+        _, out, _ = _run(["status"])
+        self.assertNotRegex(out, r"deltas\s*:\s*\d+ open",
+                            "folded deltas are not open — no nudge")
+
+    # --- milestone-done: a fold reminder at the natural fold point ----------
+    def test_milestone_done_nudges_open_deltas(self):
+        self._complete_task_in_milestone("mvp", "t")
+        self._add_delta("t", "- [DDD · open] domain gap found (evidence: prod signal)")
+        code, out, _ = _run(["milestone-done", "mvp"])
+        self.assertEqual(code, 0)
+        self.assertIn("open", out)
+        self.assertIn("add.py deltas", out, "milestone-done must point at the fold")
+
+    def test_milestone_done_silent_when_no_open_deltas(self):
+        self._complete_task_in_milestone("mvp", "t")
+        code, out, _ = _run(["milestone-done", "mvp"])
+        self.assertEqual(code, 0)
+        self.assertNotIn("add.py deltas", out,
+                         "no fold nudge when there are no open deltas")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/add-method/tooling/test_foundation_update_loop.py
+++ b/add-method/tooling/test_foundation_update_loop.py
@@ -136,8 +136,17 @@ class FoundationUpdateLoopTest(unittest.TestCase):
         # Change-request test 12 (frozen @ v2): the contract ships a "Foundation version" glossary
         # entry across three doc trees; v5 built it but left it unguarded. Guard its PRESENCE here
         # (byte-parity stays test_bundle_parity.py's job — no redundant md5 check).
-        for tree in GLOSSARY_TREES:
-            self.assertTrue(tree.exists(), f"missing glossary tree {tree}")
+        #
+        # The third tree (.add/docs) is the dogfood install, which is gitignored and
+        # regenerated on `add.py init` — so it is ABSENT on a clean checkout / CI. Guard
+        # the PRESENT trees and require the two tracked sources (canonical + bundle),
+        # mirroring test_flow_diagram's present-trees pattern. Asserting all three exist
+        # would fail in CI on a directory that is never a committed source.
+        present = [t for t in GLOSSARY_TREES if t.exists()]
+        self.assertGreaterEqual(
+            len(present), 2,
+            "expected at least the canonical + bundled glossary trees to be present")
+        for tree in present:
             self.assertIsNotNone(
                 re.search(r"\*\*Foundation version\*\*", tree.read_text(encoding="utf-8"),
                           re.IGNORECASE),

--- a/add-method/tooling/test_min_pillar.py
+++ b/add-method/tooling/test_min_pillar.py
@@ -46,6 +46,7 @@ LIFECYCLE = [
     ["guide"],
     ["stage", "mvp"],
     ["set-milestone", "t", "none"], ["set-milestone", "t", "mvp"],
+    ["use", "t"],                              # set active_task to an existing slug (read/writes state, not docs/)
     ["phase", "specify", "t"],
     ["advance", "t"], ["advance", "t"], ["advance", "t"],
     ["advance", "t"], ["advance", "t"],        # specify -> ... -> verify

--- a/add-method/tooling/test_packaging.py
+++ b/add-method/tooling/test_packaging.py
@@ -7,13 +7,26 @@ bytecode (__pycache__/*.pyc), no .DS_Store, and no test_*.py source leaks in. Th
 npm-coupled checks SKIP cleanly when npm is absent (honest, never a false green);
 the engines floor reads package.json directly so it always runs.
 
+The PyPI side has the same risk and its own ground truth: build the wheel with the
+real setuptools backend and read its namelist. _bundled/ ships only because
+MANIFEST.in + [tool.setuptools.package-data] agree — a single drift and the wheel
+installs but `pilotspace-add init` finds no skill/docs/tooling to copy. PyWheelTest
+catches that the same way NpmTarballTest catches an npm leak. Skips honestly when
+setuptools is absent.
+
 Run: python3 -m unittest test_packaging -v
 """
+import contextlib
+import importlib.util
+import io
 import json
+import os
 import re
 import shutil
 import subprocess
+import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 PKG_ROOT = Path(__file__).resolve().parent.parent      # add-method/ (holds package.json)
@@ -72,6 +85,94 @@ class PackageConfigTest(unittest.TestCase):
         pkg = json.loads((PKG_ROOT / "package.json").read_text(encoding="utf-8"))
         self.assertEqual(pkg.get("engines", {}).get("node"), ">=18",
                          "cli.js uses fs.cpSync (Node 16.7+); 16 is EOL — floor must be >=18")
+
+
+def _setuptools_backend():
+    """Return setuptools.build_meta (the PEP 517 backend) or None if unavailable.
+
+    We drive the backend in-process rather than shelling to `python -m build`: build
+    is an optional dep, but setuptools is always present in a build/test env, so this
+    runs the SAME backend a real `pip install` from sdist/source would, without the
+    extra dependency or a subprocess to time out."""
+    if importlib.util.find_spec("setuptools") is None:
+        return None
+    from setuptools import build_meta
+    return build_meta
+
+
+_BUNDLE_PREFIXES = (
+    "add_method/_bundled/docs/",
+    "add_method/_bundled/skill/add/",
+    "add_method/_bundled/tooling/",
+)
+_PKG_MODULES = (
+    "add_method/__init__.py", "add_method/_cli.py", "add_method/_installer.py",
+)
+# the wheel members carry no "test_" prefix segment and no compiled/OS junk
+_WHEEL_TEST_SRC = re.compile(r"(^|/)test_.*\.py$")
+
+
+@unittest.skipUnless(_setuptools_backend() is not None,
+                     "setuptools not importable — wheel build check skipped (honest skip)")
+class PyWheelTest(unittest.TestCase):
+    """Build the real wheel and assert _bundled/ ships intact — the PyPI analog of
+    NpmTarballTest. Builds from a COPY of the sources so the repo tree stays clean
+    (setuptools writes build/ + *.egg-info into the build root)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.mkdtemp(prefix="add-pywheel-")
+        srcroot = Path(cls._tmp) / "srcroot"
+        outdir = Path(cls._tmp) / "out"
+        srcroot.mkdir()
+        outdir.mkdir()
+        # minimal faithful source set for a wheel build (README/LICENSE are referenced
+        # by pyproject; GETTING-STARTED silences a MANIFEST warning but isn't in the wheel)
+        for fname in ("pyproject.toml", "README.md", "LICENSE", "MANIFEST.in",
+                      "GETTING-STARTED.md"):
+            src = PKG_ROOT / fname
+            if src.exists():
+                shutil.copy2(src, srcroot / fname)
+        shutil.copytree(PKG_ROOT / "src", srcroot / "src")
+        # strip any pre-existing build residue from the copy so it cannot mask a gap
+        for junk in srcroot.glob("src/*.egg-info"):
+            shutil.rmtree(junk, ignore_errors=True)
+        for cache in srcroot.glob("src/**/__pycache__"):
+            shutil.rmtree(cache, ignore_errors=True)
+
+        backend = _setuptools_backend()
+        prev = os.getcwd()
+        os.chdir(srcroot)
+        try:
+            sink = io.StringIO()
+            with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+                wheel_name = backend.build_wheel(str(outdir))
+        finally:
+            os.chdir(prev)
+        cls.names = zipfile.ZipFile(outdir / wheel_name).namelist()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._tmp, ignore_errors=True)
+
+    def test_bundled_data_ships(self):
+        for prefix in _BUNDLE_PREFIXES:
+            self.assertTrue(
+                any(n.startswith(prefix) for n in self.names),
+                f"the wheel ships NO file under {prefix} — _bundled is broken; "
+                f"`pilotspace-add init` would find nothing to install",
+            )
+        self.assertTrue(any(n.endswith("_bundled/tooling/add.py") for n in self.names),
+                        "the wheel must ship the add.py scaffolder")
+
+    def test_package_modules_ship(self):
+        missing = [m for m in _PKG_MODULES if m not in self.names]
+        self.assertEqual(missing, [], f"the importable package surface must ship: {missing}")
+
+    def test_no_test_sources_or_junk(self):
+        leaks = [n for n in self.names
+                 if _WHEEL_TEST_SRC.search(n) or _JUNK.search(n)]
+        self.assertEqual(leaks, [], f"no dev test source or compiled/OS junk may ship: {leaks}")
 
 
 if __name__ == "__main__":

--- a/add-method/tooling/test_quickstart.py
+++ b/add-method/tooling/test_quickstart.py
@@ -17,7 +17,9 @@ import add
 GUIDE = Path(__file__).resolve().parent.parent / "GETTING-STARTED.md"
 
 REQUIRED_STRINGS = [
-    "npx @pilotspace/add init",
+    "npx @pilotspace/add init",      # npm install path
+    "pip install pilotspace-add",    # PyPI install path — must be documented too
+    "pilotspace-add init",           # the console-script the pip package exposes
     "add.py status",
     "add.py new-task",
     "add.py advance",

--- a/add-method/tooling/test_state_hardening.py
+++ b/add-method/tooling/test_state_hardening.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Design-for-failure proofs for the state engine (task: v11 state-engine hardening).
+
+The brief's CRITICAL RULE demands every IO path design for failure. These pin:
+  - load_state fails CLOSED — a corrupt/unreadable state.json dies with a clean
+    'state_invalid' message, never a raw Python traceback (affects every command).
+  - cmd_status survives a schema-shifted state (missing key) and a stale active_task
+    slug without a KeyError traceback.
+  - `add.py use <slug>` switches the active task without hand-editing state.json.
+  - _write_retro is atomic (temp + os.replace) per the module's own contract — a
+    crash mid-write leaves no half-written RETRO.md and the milestone still active.
+  - archive-milestone writes a recoverable pre-archive snapshot before its destructive
+    deletes (the archived record keeps only a slug-list).
+Run: python3 -m unittest test_state_hardening -v
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import add
+
+
+def _run(argv):
+    """Run add.main, capturing (code, out, err). Non-SystemExit exceptions propagate
+    (so a bare traceback shows up as a test ERROR — exactly what we are guarding against)."""
+    out, err = io.StringIO(), io.StringIO()
+    code = 0
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            add.main(argv)
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
+    return code, out.getvalue(), err.getvalue()
+
+
+class StateHardeningTest(unittest.TestCase):
+    def setUp(self):
+        self._cwd = Path.cwd()
+        self.tmp = tempfile.mkdtemp(prefix="add-state-harden-")
+        os.chdir(self.tmp)
+        add.main(["init", "--name", "demo"])
+        self.state_path = Path(self.tmp) / ".add" / "state.json"
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+
+    def _poke_state(self, mutate):
+        st = json.loads(self.state_path.read_text(encoding="utf-8"))
+        mutate(st)
+        self.state_path.write_text(json.dumps(st, indent=2) + "\n", encoding="utf-8")
+
+    def _complete_task_in_milestone(self, ms, slug):
+        add.main(["new-milestone", ms, "--goal", "g", "--stage", "mvp"])
+        add.main(["new-task", slug])
+        add.main(["phase", "verify", slug])
+        add.main(["gate", "PASS", slug])
+
+    # --- load_state fails closed --------------------------------------------
+    def test_corrupt_state_dies_clean_not_traceback(self):
+        self.state_path.write_text("{ this is not valid json", encoding="utf-8")
+        code, out, err = _run(["status"])
+        self.assertEqual(code, 1, "a corrupt state.json must exit 1, not raise a traceback")
+        self.assertIn("state_invalid", err)
+        self.assertNotIn("Traceback", out + err)
+
+    # --- cmd_status survives schema drift -----------------------------------
+    def test_status_survives_missing_project_key(self):
+        add.main(["new-task", "a"])
+        self._poke_state(lambda st: st.pop("project", None))
+        code, out, _ = _run(["status"])
+        self.assertEqual(code, 0, "status must not KeyError on a missing 'project' key")
+        self.assertIn("project", out)  # the labelled line still prints (with a fallback)
+
+    def test_status_survives_stale_active_task(self):
+        add.main(["new-task", "a"])
+        self._poke_state(lambda st: st.__setitem__("active_task", "ghost"))
+        code, _, err = _run(["status"])
+        self.assertEqual(code, 0, "a stale active_task slug must not crash status")
+        self.assertNotIn("Traceback", err)
+
+    # --- add.py use <slug> ---------------------------------------------------
+    def test_use_switches_active_task(self):
+        add.main(["new-task", "a"])
+        add.main(["new-task", "b"])  # active_task is now 'b'
+        code, out, _ = _run(["use", "a"])
+        self.assertEqual(code, 0)
+        st = json.loads(self.state_path.read_text(encoding="utf-8"))
+        self.assertEqual(st["active_task"], "a", "use must set active_task to the named task")
+
+    def test_use_rejects_unknown_task(self):
+        add.main(["new-task", "a"])
+        code, _, err = _run(["use", "ghost"])
+        self.assertEqual(code, 1)
+        self.assertIn("unknown_task", err)
+        st = json.loads(self.state_path.read_text(encoding="utf-8"))
+        self.assertEqual(st["active_task"], "a", "a rejected use must not change active_task")
+
+    # --- _write_retro is atomic ---------------------------------------------
+    def test_retro_write_is_atomic(self):
+        self._complete_task_in_milestone("mvp", "t")
+        retro = Path(self.tmp) / ".add" / "milestones" / "mvp" / "RETRO.md"
+        self.assertFalse(retro.exists())
+        # A crash at the os.replace step must leave NO half-written RETRO.md, and the
+        # milestone must remain active (the close aborts before the status flip).
+        with mock.patch("add.os.replace", side_effect=OSError("disk full")):
+            code, _, err = _run(["milestone-done", "mvp"])
+        self.assertEqual(code, 1)
+        self.assertIn("retro_write_failed", err)
+        self.assertFalse(retro.exists(), "a failed atomic write must leave no partial RETRO.md")
+        st = json.loads(self.state_path.read_text(encoding="utf-8"))
+        self.assertEqual(st["milestones"]["mvp"]["status"], "active",
+                         "milestone must stay active when the retro write fails")
+
+    # --- archive writes a recoverable snapshot ------------------------------
+    def test_archive_writes_pre_archive_snapshot(self):
+        self._complete_task_in_milestone("mvp", "t")
+        add.main(["milestone-done", "mvp"])
+        code, _, _ = _run(["archive-milestone", "mvp"])
+        self.assertEqual(code, 0)
+        snap = Path(self.tmp) / ".add" / "milestones" / "mvp" / "pre-archive-state.bak.json"
+        self.assertTrue(snap.exists(), "archive must write a pre-archive snapshot")
+        data = json.loads(snap.read_text(encoding="utf-8"))
+        self.assertIn("t", data["tasks"], "snapshot must capture member task records")
+        self.assertEqual(data["tasks"]["t"]["phase"], "done")
+        self.assertEqual(data["tasks"]["t"]["gate"], "PASS",
+                         "snapshot must preserve gate data the archived record drops")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/add-method/tooling/test_streams.py
+++ b/add-method/tooling/test_streams.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""v11 — parallel-streams safety: the rubric's clauses + the engine behavior it leans on.
+
+streams.md is the opt-in concurrency rubric. It changes NO add.py code, so its safety
+guarantees live in two places that must not drift apart:
+
+  1. The PROSE clauses a human/orchestrator reads — the design-for-failure rules
+     (slug-routing, fresh worktree base, lease+timeout, circuit-breaker, failure
+     isolation, serial integration-merge, the irreducible human floor, "a worker
+     never writes shared state"). Words-exist guards so a refactor cannot quietly
+     drop a safety rule from the rubric.
+  2. The ENGINE behavior clause #1 depends on — advance/gate/phase route to the
+     EXPLICIT <slug> and act on it; omitting the slug falls back to the single
+     active_task. streams.md tells the orchestrator to "name the task every time"
+     precisely because the fallback races once more than one stream is live. If
+     that precedence ever flipped, every parallel orchestration would corrupt the
+     wrong task while the rubric still told you it was safe.
+
+Run: python3 -m unittest test_streams -v
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import add
+
+_TOOLING = Path(__file__).resolve().parent
+_ADD_METHOD = _TOOLING.parent
+SKILL = _ADD_METHOD / "skill" / "add"
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    code = 0
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            add.main(argv)
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
+    return code, out.getvalue(), err.getvalue()
+
+
+class StreamsSafetyClausesTest(unittest.TestCase):
+    """Each design-for-failure clause in streams.md must survive a refactor.
+
+    Pins the SAFETY CONCEPT (distinctive lowercased substrings), not whole sentences,
+    so wording can evolve but a deleted guarantee fails loudly."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.low = (SKILL / "streams.md").read_text(encoding="utf-8").lower()
+
+    def test_slug_routing_names_the_task_every_time(self):
+        self.assertIn("explicit", self.low)
+        self.assertIn("name the task every time", self.low,
+                      "the rubric must keep the always-pass-the-slug rule")
+        self.assertIn("race", self.low,
+                      "the rubric must keep the WHY: the active_task fallback races across streams")
+
+    def test_fresh_worktree_base_clause(self):
+        self.assertIn("fresh worktree base", self.low,
+                      "the worktree-base safety step must remain")
+        self.assertIn("base == head", self.low,
+                      "must keep the concrete check: worker base == orchestrator HEAD")
+
+    def test_lease_and_timeout_clause(self):
+        self.assertIn("lease", self.low)
+        self.assertIn("timeout", self.low,
+                      "a dead worker's claim must be releasable — lease + timeout")
+
+    def test_circuit_breaker_clause(self):
+        self.assertIn("circuit-breaker", self.low,
+                      "repeated worker failure must fall back to sequential, not keep fanning out")
+
+    def test_failure_isolation_clause(self):
+        self.assertIn("failure isolates", self.low,
+                      "a STOP-and-escalate must block only its own task, not siblings")
+
+    def test_serial_integration_merge_clause(self):
+        self.assertIn("merge is serial", self.low)
+        self.assertIn("integration", self.low,
+                      "merged-green tasks can still conflict — the integration Verify must stay")
+
+    def test_irreducible_human_floor_clause(self):
+        self.assertIn("one human approval per task", self.low,
+                      "the contract-seam floor must never be engineered away")
+        self.assertIn("never drops to zero", self.low)
+
+    def test_worker_never_writes_shared_state(self):
+        self.assertIn("never write shared state", self.low,
+                      "the worker/orchestrator write boundary is the core race guard")
+
+
+class SlugRoutingPrecedenceTest(unittest.TestCase):
+    """advance/gate/phase act on the EXPLICIT slug; omitting it uses active_task.
+
+    This is the engine contract streams.md §'Who writes what' depends on. Two tasks
+    exist; 'b' is active (created last). Naming 'a' must mutate ONLY 'a' and must
+    leave active_task untouched — proving the orchestrator can drive any stream
+    without first switching focus."""
+
+    def setUp(self):
+        self._cwd = Path.cwd()
+        self.tmp = tempfile.mkdtemp(prefix="add-streams-route-")
+        os.chdir(self.tmp)
+        add.main(["init", "--name", "demo"])
+        add.main(["new-milestone", "mvp", "--goal", "g", "--stage", "mvp"])
+        add.main(["new-task", "a"])   # auto-linked to mvp
+        add.main(["new-task", "b"])   # active_task is now 'b'
+        self.state_path = Path(self.tmp) / ".add" / "state.json"
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+
+    def _state(self):
+        return json.loads(self.state_path.read_text(encoding="utf-8"))
+
+    def test_active_task_is_b_after_setup(self):
+        # premise check: the LAST-created task is active, so naming 'a' is the non-trivial path
+        self.assertEqual(self._state()["active_task"], "b")
+
+    def test_phase_routes_to_explicit_slug_not_active(self):
+        code, _, _ = _run(["phase", "verify", "a"])
+        self.assertEqual(code, 0)
+        st = self._state()
+        self.assertEqual(st["tasks"]["a"]["phase"], "verify", "the NAMED task must change")
+        self.assertEqual(st["tasks"]["b"]["phase"], "specify", "the active task must NOT change")
+        self.assertEqual(st["active_task"], "b", "phase <slug> must not steal focus from active_task")
+
+    def test_advance_routes_to_explicit_slug_not_active(self):
+        code, _, _ = _run(["advance", "a"])
+        self.assertEqual(code, 0)
+        st = self._state()
+        self.assertEqual(st["tasks"]["a"]["phase"], "scenarios", "advance must step the NAMED task")
+        self.assertEqual(st["tasks"]["b"]["phase"], "specify", "the active task must NOT step")
+        self.assertEqual(st["active_task"], "b")
+
+    def test_gate_routes_to_explicit_slug_not_active(self):
+        _run(["phase", "verify", "a"])          # bring 'a' to verify so PASS is legal
+        code, _, _ = _run(["gate", "PASS", "a"])
+        self.assertEqual(code, 0)
+        st = self._state()
+        self.assertEqual(st["tasks"]["a"]["phase"], "done")
+        self.assertEqual(st["tasks"]["a"]["gate"], "PASS", "gate must record on the NAMED task")
+        self.assertEqual(st["tasks"]["b"]["phase"], "specify", "the active task must be untouched")
+        self.assertEqual(st["tasks"]["b"].get("gate", "none"), "none", "no gate may land on 'b'")
+        self.assertEqual(st["active_task"], "b")
+
+    def test_omitted_slug_falls_back_to_active_task(self):
+        # the documented fallback (and the race premise): no slug => act on active_task ('b')
+        code, _, _ = _run(["advance"])
+        self.assertEqual(code, 0)
+        st = self._state()
+        self.assertEqual(st["tasks"]["b"]["phase"], "scenarios", "omitted slug must step the active task")
+        self.assertEqual(st["tasks"]["a"]["phase"], "specify", "the non-active task must be untouched")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/add-method/tooling/test_v11_docs.py
+++ b/add-method/tooling/test_v11_docs.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""v11 — trust-layer truth: the book + skill must say what the engine does.
+
+These guards pin the contradictions v11 fixed so they cannot silently regress.
+For each, we assert BOTH that the corrected claim is present AND that the stale,
+contradicted claim is gone (words-exist alone catches deletion, not contradiction):
+
+  - Verify is no longer "human only" — auto-PASS on evidence is the default.
+  - The human-led front is ONE approval at the contract seam, not three.
+  - The flow is SEVEN steps (Observe is step 7), reconciled across ch02 + Matrix 3.
+  - Competency deltas / the fold ritual / parallel streams now have book coverage.
+
+Run: python3 -m unittest test_v11_docs -v
+"""
+import unittest
+from pathlib import Path
+
+_TOOLING = Path(__file__).resolve().parent
+_ADD_METHOD = _TOOLING.parent
+DOCS = _ADD_METHOD / "docs"
+SKILL = _ADD_METHOD / "skill" / "add"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+class VerifyBothBranchTest(unittest.TestCase):
+    """Verify is auto-gated by default; the 'no AI role' contradiction is gone."""
+
+    def test_verify_chapter_describes_auto_gate(self):
+        raw = _read(DOCS / "08-step-6-verify.md")
+        low = raw.lower()
+        self.assertNotIn("there is no ai role", low,
+                         "08-verify still claims Verify has no AI role (contradicts the auto-gate)")
+        self.assertIn("auto", low, "08-verify must describe the evidence auto-gate")
+        self.assertIn("autonomy", low, "08-verify must name the autonomy dial")
+        self.assertIn("hard-stop", low, "08-verify must keep security as a HARD-STOP escalation")
+
+    def test_verify_phase_guide_describes_auto_gate(self):
+        low = _read(SKILL / "phases" / "6-verify.md").lower()
+        self.assertNotIn("there is no ai role", low,
+                         "phases/6-verify.md still says 'no AI role' (contradicts run.md)")
+        self.assertIn("autonomy", low)
+        self.assertIn("auto", low)
+
+
+class OneApprovalFrontTest(unittest.TestCase):
+    """The front is one approval at the contract seam; SKILL header is current."""
+
+    def test_skill_router_states_one_approval(self):
+        raw = _read(SKILL / "SKILL.md")
+        self.assertIn("one approval", raw.lower(), "SKILL.md must name the one-approval front")
+        self.assertIn("v6–v7", raw, "the dynamic-run header must be bumped past bare v6")
+
+    def test_step_chapters_name_the_bundle(self):
+        for ch in ("04-step-2-scenarios.md", "05-step-3-contract.md", "06-step-4-tests.md"):
+            low = _read(DOCS / ch).lower()
+            self.assertIn("bundle", low, f"{ch} must mention the one-approval bundle")
+            self.assertTrue("one approval" in low or "one-approval" in low,
+                            f"{ch} must mention the single (one-)approval front")
+
+
+class SevenStepsTest(unittest.TestCase):
+    """The flow is seven steps; the six-step framing is gone, Observe is in Matrix 3."""
+
+    def test_flow_chapter_says_seven_steps(self):
+        low = _read(DOCS / "02-the-flow.md").lower()
+        self.assertIn("seven steps", low)
+        self.assertNotIn("flow of six steps", low,
+                         "02-the-flow still frames the flow as six steps")
+
+    def test_matrix3_has_observe_row(self):
+        low = _read(DOCS / "appendix-f-requirements-matrix.md").lower()
+        self.assertIn("seven steps", low)
+        self.assertIn("observe", low, "Matrix 3 must include the Observe step")
+        self.assertNotIn("(the six steps)", low,
+                         "Matrix 3 header still says six steps")
+
+
+class ShippedFeatureChaptersTest(unittest.TestCase):
+    """deltas/fold and parallel-streams now have human-readable book coverage."""
+
+    def test_loop_chapter_covers_deltas_and_fold(self):
+        low = _read(DOCS / "09-the-loop.md").lower()
+        self.assertIn("competency delta", low)
+        self.assertIn("udd", low, "the five-competency tagging must appear (UDD is distinctive)")
+        self.assertIn("fold", low, "09 must describe the foundation fold")
+        self.assertIn("add.py deltas", low, "09 must name the deltas tooling")
+
+    def test_setup_chapter_covers_parallel_streams(self):
+        low = _read(DOCS / "10-setup-and-stages.md").lower()
+        self.assertIn("parallel streams", low)
+        self.assertIn("ready-queue", low)
+        self.assertIn("review-queue", low)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/add-method/tooling/test_version_sync.py
+++ b/add-method/tooling/test_version_sync.py
@@ -17,6 +17,7 @@ from pathlib import Path
 _PKG_ROOT = Path(__file__).resolve().parent.parent      # add-method/
 _PACKAGE_JSON = _PKG_ROOT / "package.json"
 _PYPROJECT = _PKG_ROOT / "pyproject.toml"
+_INIT = _PKG_ROOT / "src" / "add_method" / "__init__.py"  # runtime __version__
 
 _SEMVER = re.compile(r"^\d+\.\d+\.\d+([.-].+)?$")
 
@@ -33,17 +34,32 @@ def _pypi_version() -> str:
     return m.group(1)
 
 
+def _init_version() -> str:
+    # the runtime version the PyPI package reports (add_method.__version__). It is a
+    # THIRD source that can drift independently of pyproject's build version, so the
+    # guard must include it — not just the two manifests.
+    m = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', _INIT.read_text(encoding="utf-8"))
+    assert m, "src/add_method/__init__.py has no `__version__ = \"...\"` line"
+    return m.group(1)
+
+
 class VersionSyncTest(unittest.TestCase):
     def test_both_manifests_exist(self):
         self.assertTrue(_PACKAGE_JSON.is_file(), "package.json missing")
         self.assertTrue(_PYPROJECT.is_file(), "pyproject.toml missing")
+        self.assertTrue(_INIT.is_file(), "src/add_method/__init__.py missing")
 
     def test_versions_are_identical(self):
-        npm, pypi = _npm_version(), _pypi_version()
+        npm, pypi, runtime = _npm_version(), _pypi_version(), _init_version()
         self.assertEqual(
             npm, pypi,
             f"version drift: package.json={npm!r} but pyproject.toml={pypi!r}. "
             f"One tag publishes both registries — they must agree.",
+        )
+        self.assertEqual(
+            pypi, runtime,
+            f"version drift: pyproject.toml={pypi!r} but add_method.__version__={runtime!r}. "
+            f"The runtime version the package reports must match what it was built as.",
         )
 
     def test_version_is_semver(self):

--- a/appendix-f-requirements-matrix.md
+++ b/appendix-f-requirements-matrix.md
@@ -12,7 +12,7 @@ This appendix maps every AIDD document to a three-level project hierarchy, so th
 |-------|-----------|--------------|-------|
 | **Project** | the whole product or engagement | the survivor layer — documents created once and kept for the life of the product | all milestones |
 | **Milestone** | a stage or release | one pass of the flow at a chosen depth: Prototype, POC, MVP, or Production-Ready; groups many tasks | many tasks |
-| **Task** | one feature through the flow | a single pass of Specify → … → Verify; the smallest unit with its own gate records | the six steps |
+| **Task** | one feature through the flow | a single pass of Specify → … → Verify → Observe; the smallest unit with its own gate records | the seven steps |
 
 A **project** sets up the survivor-layer documents once. A **milestone** is a depth-bounded goal that groups tasks and has its own entry and exit document gates. A **task** is one feature, and it produces the per-feature artifacts.
 
@@ -87,7 +87,7 @@ Which documents must exist, and at what depth, to **exit** each milestone. Depth
 
 ---
 
-## Matrix 3 — Documents required per task (the six steps)
+## Matrix 3 — Documents required per task (the seven steps)
 
 Every task, regardless of milestone, produces this artifact chain. The depth varies by milestone (Matrix 2); the *sequence and exit gate* do not.
 
@@ -98,9 +98,10 @@ Every task, regardless of milestone, produces this artifact chain. The depth var
 | 3 Contract | `contracts/<task>.md` | frozen + contract tests green | [05](./05-step-3-contract.md) |
 | 4 Tests | `tests/<task>_*` | one test per scenario, red first | [06](./06-step-4-tests.md) |
 | 5 Build | source code + evidence bundle | all tests green, nothing weakened | [07](./07-step-5-build.md) |
-| 6 Verify | gate outcome record | `PASS` / `RISK-ACCEPTED` / `HARD-STOP` | [08](./08-step-6-verify.md) |
+| 6 Verify | gate outcome record | `PASS` / `RISK-ACCEPTED` / `HARD-STOP` (auto-resolved on evidence under `autonomy: auto`; security always escalates) | [08](./08-step-6-verify.md) |
+| 7 Observe | `TASK.md` §7 OBSERVE block | released behind a flag; scenario-monitors live; spec delta + competency deltas captured | [09](./09-the-loop.md) |
 
-A task is **done** only when all six documents exist and the Verify record reads `PASS` (or a signed `RISK-ACCEPTED`). See the master shippable checklist in [Appendix E](./appendix-e-checklists.md).
+A task is **done** when the build's documents exist and the Verify record reads `PASS` (or a signed `RISK-ACCEPTED`); the seventh step — **Observe** (§7) — then runs in production and feeds the next loop's Specify. See the master shippable checklist in [Appendix E](./appendix-e-checklists.md).
 
 ---
 


### PR DESCRIPTION
## v11 — Trust-layer truth + foundation hardening (release v1.1.0)

ADD's **engine raced ahead of its trust layer.** Milestones v6→v10 changed the actual
behavior — auto-PASS became the default, three approvals collapsed into one, deltas /
fold / streams shipped — but the book and skill still described the pre-v6 manual model,
and the newest surfaces were under-hardened and under-tested. A multi-lens adversarial
review surfaced **32 candidates → 27 confirmed**; this PR implements all **24** P0–P2
findings (3 consciously deferred — see below) across six commits, each ending at a
green-tested checkpoint.

### What changed, by wave

| Commit | Wave | What |
|---|---|---|
| `67459c5` | W1 · P0 trust-layer truth | Book + skill now match the engine: Verify is the evidence **auto-gate** (not "human-only"), the front is **one approval** (not three), the flow is **seven steps** (Observe = step 7) across ch.02 + the requirements matrix. New chapters for competency deltas, the fold ritual, foundation versioning, and parallel streams. `streams.md` worktree-base guard + `deltas.md` multi-line grammar. (`test_v11_docs`) |
| `80bb013` | W2 · P0 fold bottleneck | `status` + `milestone-done` surface the open-delta count and point at `add.py deltas`; `_collect_open_deltas` reads multi-line deltas in full. (`test_fold_nudge`, TDD) |
| `59c6e2e` | W3 · P1 state-engine | Design-for-failure: corrupt `state.json` → clean `state_invalid` (no traceback); `status` survives schema drift + stale active-task; `add.py use <slug>`; atomic `_write_retro`; pre-archive snapshot. (`test_state_hardening`, TDD) |
| `d0bfa1d` | W4 · P1 streams | Words-exist guards on every streams safety clause + behavioral slug-routing precedence proof (advance/gate/phase act on the explicit slug, never steal active focus). (`test_streams`) |
| `40df88e` | W5 · P2 packaging | `--force` is a clean replace (not a merge); Windows `py` launcher + platform-correct messages; pip install path in GETTING-STARTED; `__version__` is a third synced source; `PyWheelTest` builds the real wheel and asserts `_bundled/` ships. |
| `c8857ef` | release | Coordinated bump 1.0.0 → **1.1.0** (package.json · pyproject.toml · `__init__.py`) + CHANGELOG `[1.1.0]`. **No git tag** — tagging triggers the autonomous publish CI and stays a human-gated action. |

### Deferred (3, by design)
- **enforcement-as-engine** → backlog: architecturally blocked by the frozen invariant *"the dial stays a rubric, not an `add.py` flag"* (`v7/MILESTONE.md:39`).
- **worktree-base duplicate** → already implemented once (W1 `streams.md`); two lenses had surfaced the same finding.
- **`_DELTA_RE` dedup** → skipped: the two regexes are intentionally different.

### Verification
- **299 tests green** (multi-tree parity intact: `add.py`/skill/docs synced across `add-method/`, `.add/`, and the PyPI `_bundled/` tree).
- Every code change is red/green TDD; cli.js validated by a darwin smoke test (planted stale file removed by `--force`, real `SKILL.md` preserved); the version-sync guard red-proven on a forced drift.

### Release note
This bumps the version but does **not** tag. To publish v1.1.0 to npm + PyPI, push tag `v1.1.0` (triggers `.github/workflows/publish.yml`).
