### PR TITLE
feat: independent context-isolated verifier auto-gate (Generator–Verifier split)

### DIFF
--- a/.add/tooling/add.py
+++ b/.add/tooling/add.py
@@ -37,6 +37,18 @@ GRADUATION_CUE = "MVP covered → propose graduation"
 PHASES = ("specify", "scenarios", "contract", "tests", "build", "verify", "observe", "done")
 GATES = ("none", "PASS", "RISK-ACCEPTED", "HARD-STOP")
 
+# --- independent verification (Generator–Verifier separation) ----------------
+# In-context self-critique is unreliable: a model favours its own output
+# (self-enhancement bias) and repeats its own errors, so an in-context
+# "skeptic" approves it uncritically. The auto-gate decision is therefore computed by the
+# engine from STRUCTURED verdicts produced by fresh, context-isolated verifier
+# subagents (one per lens) — see skill/add/verify-critic.md. The engine validates
+# shape and computes the deterministic decision; it never judges the code itself.
+VERDICT_VALUES = ("pass", "fail", "risk")
+VERIFY_LENSES = ("wiring", "concurrency-security", "contract-conformance")
+MIN_CONSENSUS_LENSES = 3            # distinct lenses required for an auto-PASS (self-consistency)
+VERDICT_LEDGER = "verdicts.jsonl"  # append-only, per-task; verdicts are durable, labelled data
+
 
 def _phase_index(name: str) -> int:
     """Ordinal of a phase in PHASES; used to enforce forward-skip rules."""
@@ -650,6 +662,208 @@ def cmd_reopen(args: argparse.Namespace) -> None:
     _sync_task_marker(root, slug, target)
     save_state(root, state)
     print(f"task '{slug}' reopened: done -> {target} (reason recorded); gate reset to none")
+
+
+# --- independent verification: schema · consensus · ledger · eval ------------
+
+def _validate_verdict(obj: object) -> list[str]:
+    """Return a list of shape errors for one verifier verdict ([] == valid).
+
+    A verdict is DATA, not free-form prose: a lens (which independent verifier),
+    a call (pass|fail|risk), and non-empty evidence (no shallow 'looks good'). This
+    is the structured-output guard — it is what stops a vague auto-PASS."""
+    if not isinstance(obj, dict):
+        return ["verdict must be a JSON object"]
+    errs: list[str] = []
+    lens = obj.get("lens")
+    if not isinstance(lens, str) or not lens.strip():
+        errs.append("lens: required non-empty string (which independent verifier)")
+    if obj.get("verdict") not in VERDICT_VALUES:
+        errs.append(f"verdict: must be one of {', '.join(VERDICT_VALUES)}")
+    ev = obj.get("evidence")
+    if not isinstance(ev, str) or not ev.strip():
+        errs.append("evidence: required non-empty string (no shallow verify)")
+    if "security" in obj and not isinstance(obj["security"], bool):
+        errs.append("security: must be a boolean")
+    if "refutation" in obj and not isinstance(obj["refutation"], str):
+        errs.append("refutation: must be a string")
+    return errs
+
+
+def _consensus(verdicts: list[dict],
+               min_lenses: int = MIN_CONSENSUS_LENSES) -> tuple[str, str]:
+    """The deterministic auto-gate decision over recorded verdicts → (outcome, reason).
+
+    outcome ∈ {PASS, HARD-STOP, ESCALATE}. The rule, in priority order:
+      1. ANY security finding (fail|risk) → HARD-STOP — security is never auto-passed.
+      2. ANY refutation (a `fail`)        → HARD-STOP — return to Build.
+      3. ANY residue (a `risk`)           → ESCALATE  — human-led gate (principle 2).
+      4. all `pass` but < min distinct lenses → ESCALATE — independence too thin.
+      5. all `pass` across ≥ min distinct lenses → PASS — self-consistent agreement.
+    The engine computes this from data; the resolver still records the gate."""
+    if not verdicts:
+        return "ESCALATE", "no independent verdicts recorded — an auto-PASS needs evidence"
+    for vd in verdicts:
+        if vd.get("security") and vd.get("verdict") in ("fail", "risk"):
+            return "HARD-STOP", (f"security finding from lens '{vd.get('lens')}' — "
+                                 "never auto-passed")
+    fails = [vd for vd in verdicts if vd.get("verdict") == "fail"]
+    if fails:
+        return "HARD-STOP", f"lens '{fails[0].get('lens')}' refuted the build — return to Build"
+    risks = [vd for vd in verdicts if vd.get("verdict") == "risk"]
+    if risks:
+        return "ESCALATE", f"lens '{risks[0].get('lens')}' flagged residue — human-led gate"
+    distinct = {str(vd.get("lens", "")).strip()
+                for vd in verdicts if str(vd.get("lens", "")).strip()}
+    if len(distinct) < min_lenses:
+        return "ESCALATE", (f"insufficient independent coverage: {len(distinct)}/{min_lenses} "
+                            "distinct lenses passed")
+    return "PASS", f"{len(distinct)} independent lenses agree, none refuted"
+
+
+def _verdict_ledger_path(root: Path, slug: str) -> Path:
+    return root / "tasks" / slug / VERDICT_LEDGER
+
+
+def _load_verdicts(root: Path, slug: str) -> list[dict]:
+    """Read the append-only verdict ledger, failing closed on a corrupt line."""
+    p = _verdict_ledger_path(root, slug)
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    try:
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    except (OSError, json.JSONDecodeError) as e:
+        _die(f"verdict_ledger_invalid: {p} is unreadable or corrupt ({e.__class__.__name__})")
+    return out
+
+
+def cmd_verdict(args: argparse.Namespace) -> None:
+    """Append one (or, via --file, many) structured verifier verdict(s) to the task ledger.
+
+    The agent records a fresh, context-isolated verifier's call here; the engine
+    validates SHAPE before writing (fail closed — a malformed verdict is never stored)."""
+    root = _require_root()
+    state = load_state(root)
+    slug = _resolve_task(state, args.slug)
+    if args.file:
+        try:
+            raw = sys.stdin.read() if args.file == "-" else Path(args.file).read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as e:
+            _die(f"verdict_input_invalid: {e.__class__.__name__}: {e}")
+        records = data if isinstance(data, list) else [data]
+    else:
+        if args.lens is None or args.verdict is None or args.evidence is None:
+            _die("verdict_incomplete: supply --lens, --verdict and --evidence (or --file)")
+        rec: dict = {"lens": args.lens, "verdict": args.verdict, "evidence": args.evidence}
+        if args.refutation is not None:
+            rec["refutation"] = args.refutation
+        if args.security:
+            rec["security"] = True
+        records = [rec]
+    # validate EVERY record before writing ANY (no partial ledger)
+    for i, rec in enumerate(records):
+        errs = _validate_verdict(rec)
+        if errs:
+            _die(f"verdict_invalid (record {i}): " + "; ".join(errs))
+    now = _now()
+    p = _verdict_ledger_path(root, slug)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a", encoding="utf-8") as fh:        # append-only ledger
+        for rec in records:
+            rec = dict(rec)
+            rec.setdefault("at", now)
+            fh.write(json.dumps(rec, separators=(",", ":")) + "\n")
+    print(f"recorded {len(records)} verdict(s) for '{slug}' -> tasks/{slug}/{VERDICT_LEDGER}")
+
+
+def cmd_consensus(args: argparse.Namespace) -> None:
+    """Read-only: compute the auto-gate decision from the recorded independent verdicts.
+
+    The run consults this before `gate`: PASS → `gate PASS`; HARD-STOP → `gate HARD-STOP`
+    (return to Build); ESCALATE → human-led gate (no auto-PASS)."""
+    root = _require_root()
+    state = load_state(root)
+    slug = _resolve_task(state, args.slug)
+    verdicts = _load_verdicts(root, slug)
+    outcome, reason = _consensus(verdicts, args.min_lenses)
+    lenses = sorted({str(v.get("lens", "")).strip()
+                     for v in verdicts if str(v.get("lens", "")).strip()})
+    if getattr(args, "json", False):
+        print(json.dumps({"slug": slug, "outcome": outcome, "reason": reason,
+                          "verdicts": len(verdicts), "lenses": lenses},
+                         separators=(",", ":")))
+    else:
+        print(f"consensus for '{slug}': {outcome} — {reason}")
+        print(f"  {len(verdicts)} verdict(s) across {len(lenses)} lens(es): "
+              f"{', '.join(lenses) or '(none)'}")
+
+
+def cmd_eval(args: argparse.Namespace) -> None:
+    """Read-only: score the consensus decision logic against labeled verdict fixtures.
+
+    Each fixture is `{ "verdicts": [...], "label": "PASS|HARD-STOP|ESCALATE" }` — the
+    decision the gate SHOULD make for a known build (e.g. a seeded-bad build → HARD-STOP).
+    Reports exact accuracy plus a binary 'should-block' confusion: `recall` is the safety
+    metric — every seeded-bad build must be caught (fn = 0). This is red/green TDD applied
+    to the AI gate's own judgment, not just to the code."""
+    root = find_root()
+    explicit = args.fixtures is not None
+    fixtures_dir = Path(args.fixtures) if explicit else (root / "eval" if root else None)
+    files = sorted(fixtures_dir.glob("*.json")) if (fixtures_dir and fixtures_dir.exists()) else []
+    if not files:
+        # An explicit --fixtures that resolves to nothing is a user error (fail closed).
+        # The bare default (no fixtures laid down yet) is a clean no-op, not a failure.
+        if explicit:
+            _die(f"eval_no_fixtures: no *.json fixtures at {fixtures_dir} — check --fixtures")
+        print("eval: no fixtures (default .add/eval/ is empty) — nothing to score")
+        return
+    valid_labels = ("PASS", "HARD-STOP", "ESCALATE")
+    tp = fp = tn = fn = correct = 0
+    rows: list[tuple] = []
+    for f in files:
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            _die(f"eval_fixture_invalid: {f.name}: {e.__class__.__name__}")
+        label = data.get("label")
+        if label not in valid_labels:
+            _die(f"eval_fixture_invalid: {f.name}: label must be one of {', '.join(valid_labels)}")
+        outcome, reason = _consensus(data.get("verdicts", []), args.min_lenses)
+        ok = (outcome == label)
+        correct += ok
+        should_block = (label != "PASS")        # binary safety view: did NOT auto-pass
+        did_block = (outcome != "PASS")
+        if should_block and did_block:
+            tp += 1
+        elif should_block and not did_block:
+            fn += 1                              # the dangerous miss: a bad build auto-passed
+        elif not should_block and did_block:
+            fp += 1                              # a false alarm: a good build blocked
+        else:
+            tn += 1
+        rows.append((f.name, label, outcome, ok, reason))
+    n = len(files)
+    accuracy = correct / n
+    precision = tp / (tp + fp) if (tp + fp) else 1.0
+    recall = tp / (tp + fn) if (tp + fn) else 1.0
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "fixtures": n, "accuracy": accuracy, "precision": precision, "recall": recall,
+            "tp": tp, "fp": fp, "tn": tn, "fn": fn,
+            "rows": [{"fixture": r[0], "label": r[1], "outcome": r[2], "match": r[3]}
+                     for r in rows],
+        }, separators=(",", ":")))
+    else:
+        for name, label, outcome, ok, _reason in rows:
+            mark = "ok" if ok else "MISMATCH"
+            print(f"  {mark:>8}  {name:<28} label={label:<11} consensus={outcome}")
+        print(f"eval: {correct}/{n} exact ({accuracy:.0%}) · catch precision={precision:.0%} "
+              f"recall={recall:.0%} · missed-bad(fn)={fn}")
 
 
 def cmd_lock(args: argparse.Namespace) -> None:
@@ -2884,6 +3098,43 @@ def build_parser() -> argparse.ArgumentParser:
 
     ppj = sub.add_parser("project", help="print .add/PROJECT.md (the read-first foundation)")
     ppj.set_defaults(func=cmd_project)
+
+    # --- independent verification (Generator–Verifier auto-gate) -------------
+    pvd = sub.add_parser("verdict",
+                         help="record an independent verifier's structured verdict "
+                              "(append-only ledger; validated before write)")
+    pvd.add_argument("slug", nargs="?", default=None)
+    pvd.add_argument("--lens", default=None,
+                     help="which independent verifier (e.g. wiring, concurrency-security, "
+                          "contract-conformance)")
+    pvd.add_argument("--verdict", choices=VERDICT_VALUES, default=None, help="this lens's call")
+    pvd.add_argument("--evidence", default=None,
+                     help="what the verifier observed (required — no shallow verify)")
+    pvd.add_argument("--refutation", default=None,
+                     help="the strongest counter-argument it tried and the result")
+    pvd.add_argument("--security", action="store_true",
+                     help="mark this a security finding (forces HARD-STOP, never auto-passed)")
+    pvd.add_argument("--file", default=None,
+                     help="read a verdict object or JSON array from a file ('-' = stdin)")
+    pvd.set_defaults(func=cmd_verdict)
+
+    pcs = sub.add_parser("consensus",
+                         help="read-only: compute the auto-gate decision "
+                              "(PASS · HARD-STOP · ESCALATE) from recorded verdicts")
+    pcs.add_argument("slug", nargs="?", default=None)
+    pcs.add_argument("--min-lenses", type=int, default=MIN_CONSENSUS_LENSES, dest="min_lenses",
+                     help="distinct lenses required for an auto-PASS (self-consistency)")
+    pcs.add_argument("--json", action="store_true", help="machine-readable JSON output")
+    pcs.set_defaults(func=cmd_consensus)
+
+    pev = sub.add_parser("eval",
+                         help="read-only: score the consensus decision logic against "
+                              "labeled verdict fixtures (recall = no seeded-bad build slips through)")
+    pev.add_argument("--fixtures", default=None,
+                     help="dir of *.json fixtures ({verdicts, label}); default .add/eval/")
+    pev.add_argument("--min-lenses", type=int, default=MIN_CONSENSUS_LENSES, dest="min_lenses")
+    pev.add_argument("--json", action="store_true", help="machine-readable JSON output")
+    pev.set_defaults(func=cmd_eval)
 
     return p
 

--- a/.claude/skills/add/phases/6-verify.md
+++ b/.claude/skills/add/phases/6-verify.md
@@ -31,6 +31,23 @@ If any is false, stop and return to Build — there is nothing to verify yet.
   note reviewed by the auto-gate is an audit finding (`unescalated_security_note`).
 - **Architecture** — does it respect layering/dependency rules in CONVENTIONS.md?
 
+## Part two-and-a-half — independent verification (auto runs)
+
+Under `autonomy: auto`, the adversarial check is **not role-played in this
+context** — it is delegated to fresh, **context-isolated** verifier subagents that
+see only the contract, tests, and diff (never the build conversation). In-context
+self-critique is biased and unreliable; independence is what makes the skeptic
+trustworthy. See `verify-critic.md`.
+
+Run ≥3 lenses, record each structured verdict with `add.py verdict`, then:
+
+```bash
+add.py consensus <slug>          # PASS | HARD-STOP | ESCALATE
+```
+
+Auto-PASS requires `consensus` == `PASS` over ≥3 independent lenses; **security is
+never auto-passed**. Map HARD-STOP → return to Build, ESCALATE → human-led gate.
+
 ## Part three — the deep check (do not skim)
 
 Green tests prove behavior on the inputs you thought of. They do not prove the change

--- a/.claude/skills/add/run.md
+++ b/.claude/skills/add/run.md
@@ -82,8 +82,11 @@ on a trustworthy result with three loops:
 
 - **loop-until-dry** — keep hunting failures and gaps until N consecutive passes find nothing new.
   Stopping at the first green is how defects survive; the run stops only when the well runs dry.
-- **adversarial verify** — for every "done" claim, an independent skeptic tries to REFUTE it. The
-  claim survives only if it withstands refutation, not because one pass looked plausible.
+- **adversarial verify (structurally independent)** — for every "done" claim, the skeptic is a
+  FRESH, **context-isolated** subagent that sees only the contract, tests, and diff — never the
+  build transcript (in-context self-critique is biased and approves uncritically). Run ≥3 lenses, record each
+  with `add.py verdict`, and let `add.py consensus` decide. The claim survives only if it withstands
+  refutation. See `verify-critic.md`.
 - **completeness-critic** — a final pass that asks "what did we NOT cover — a scenario, a non-functional risk,
   an unstated assumption?" Whatever it finds re-enters the run.
 
@@ -99,8 +102,10 @@ sufficient and the result is recorded (principle 7, reframed: an automated, reco
 explicit pass, not a skip).
 
 - **Auto-PASS requires ALL of:** every test green; coverage not decreased; no test weakened and no
-  contract edited; the convergence loops dry; the completeness-critic found nothing open; and the
-  deep check below recorded.
+  contract edited; the convergence loops dry; the completeness-critic found nothing open; the
+  deep check below recorded; and **`add.py consensus` == `PASS`** — agreement across ≥3 fresh,
+  **context-isolated** verifier lenses (`verify-critic.md`). A green suite alone never auto-passes;
+  structural independence is the evidence.
 - **The deep check (every gate, no skim).** Deep check — do not skim. If the task produced code, record
   that every new symbol is referenced (wiring) and that no new dead/unused code was introduced. If it
   produced prose or non-code, record a semantic read — what you read in full and what it confirmed.

--- a/.claude/skills/add/verify-critic.md
+++ b/.claude/skills/add/verify-critic.md
@@ -1,0 +1,73 @@
+# Verify — independent verification (Generator–Verifier separation)
+
+Self-critique in the same context that wrote the code is unreliable: a model
+favours its own output (self-enhancement bias) and repeats its own errors, so
+an in-context "skeptic" approves it uncritically. ADD makes the skeptic **structurally
+independent** — the auto-gate decision is computed by the engine from structured
+verdicts produced by **fresh, context-isolated verifier subagents**, not by the
+builder reconsidering its own work.
+
+## How the auto-gate verifies (`autonomy: auto`)
+
+Spawn each verifier as a **fresh subagent with an isolated context**. Give it
+ONLY:
+
+- §3 CONTRACT · §4 TESTS · the diff / `src/` · CONVENTIONS.md.
+
+Never give it the build conversation, your reasoning, or why you think the code is
+right. Its job is to **refute**, not to agree.
+
+Run **three independent lenses** (one subagent each — they do not see each other):
+
+- `wiring` — is every new symbol referenced and reachable? any dead end left behind?
+- `concurrency-security` — races/timing under parallel use; secrets, injection,
+  invented/unexpected dependencies. A security finding is **always** HARD-STOP.
+- `contract-conformance` — does observable behaviour match §3 exactly, including
+  every rejection path?
+
+Each subagent returns exactly **one structured verdict**:
+
+<verdict>
+{ "lens": "wiring",
+  "verdict": "pass" | "fail" | "risk",
+  "evidence": "what it actually observed (required — no shallow 'looks good')",
+  "refutation": "the strongest counter-argument it tried, and the result",
+  "security": false }
+</verdict>
+
+Record each verdict, then read the decision — **the engine computes it, never you:**
+
+```bash
+add.py verdict <slug> --lens wiring --verdict pass \
+  --evidence "every new symbol is called; dead-code scan clean" \
+  --refutation "looked for an unreachable export — none"
+add.py verdict <slug> --lens concurrency-security --verdict pass --evidence "..."
+add.py verdict <slug> --lens contract-conformance --verdict pass --evidence "..."
+
+add.py consensus <slug>          # PASS | HARD-STOP | ESCALATE
+```
+
+Map the consensus to the gate — do not second-guess it:
+
+| `consensus` | Meaning | Action |
+|-------------|---------|--------|
+| `PASS` | ≥3 independent lenses agree, none refuted | `add.py gate PASS` |
+| `HARD-STOP` | any refutation, or any security finding | `add.py gate HARD-STOP` → return to Build |
+| `ESCALATE` | residue (a `risk`) or coverage too thin | human-led gate — **no auto-PASS** |
+
+**Auto-PASS requires `add.py consensus` == `PASS`.** A green test suite alone never
+auto-passes — structural independence is the evidence the run still owes.
+
+## Measuring the gate itself (data layer)
+
+Recorded verdicts are durable, labelled data — not throwaway chat. Score the
+decision logic against known-good and seeded-bad fixtures:
+
+```bash
+add.py eval --fixtures .add/eval
+```
+
+A fixture is `{ "verdicts": [...], "label": "PASS|HARD-STOP|ESCALATE" }` — the
+decision the gate *should* make for a known build. `recall` is the safety metric:
+every seeded-bad build must be caught (`missed-bad(fn) = 0`). This is red/green TDD
+applied to the AI gate's own judgment, not just to the code.

--- a/add-method/eval/README.md
+++ b/add-method/eval/README.md
@@ -1,0 +1,32 @@
+# Auto-gate eval fixtures
+
+Labeled fixtures for `add.py eval` — they score the **consensus decision logic**
+(the deterministic part of the independent-verifier auto-gate) against builds whose
+correct verdict is known. This is red/green TDD applied to the AI gate's own
+judgment, not just to the code.
+
+Each fixture is one JSON file:
+
+```json
+{
+  "verdicts": [
+    { "lens": "wiring", "verdict": "pass", "evidence": "..." },
+    { "lens": "concurrency-security", "verdict": "fail", "evidence": "race on balance", "security": false },
+    { "lens": "contract-conformance", "verdict": "pass", "evidence": "..." }
+  ],
+  "label": "HARD-STOP"
+}
+```
+
+- `verdicts` — the structured verdicts the three independent lenses would emit.
+- `label` — the decision the gate **should** make: `PASS` · `HARD-STOP` · `ESCALATE`.
+
+Run:
+
+```bash
+add.py eval --fixtures add-method/eval
+```
+
+`recall` is the safety metric: every seeded-bad build must be caught
+(`missed-bad(fn) = 0`). Add a new fixture every time a real build slips through or
+is wrongly blocked — the fixture set is how the gate's judgment is regression-tested.

--- a/add-method/eval/good-build.json
+++ b/add-method/eval/good-build.json
@@ -1,0 +1,8 @@
+{
+  "verdicts": [
+    { "lens": "wiring", "verdict": "pass", "evidence": "transfer() is called from the route; dead-code scan clean", "refutation": "looked for an unreachable export — none" },
+    { "lens": "concurrency-security", "verdict": "pass", "evidence": "balance update is atomic under a row lock; no secrets in diff", "refutation": "tried a double-spend interleaving — rejected" },
+    { "lens": "contract-conformance", "verdict": "pass", "evidence": "all §3 shapes and the insufficient-funds rejection match", "refutation": "probed the rejection path — conforms" }
+  ],
+  "label": "PASS"
+}

--- a/add-method/eval/seeded-bad-race.json
+++ b/add-method/eval/seeded-bad-race.json
@@ -1,0 +1,8 @@
+{
+  "verdicts": [
+    { "lens": "wiring", "verdict": "pass", "evidence": "transfer() is reachable and called" },
+    { "lens": "concurrency-security", "verdict": "fail", "evidence": "read-modify-write on balance with no lock; two concurrent transfers double-spend", "refutation": "tried to argue the ORM serializes it — it does not", "security": false },
+    { "lens": "contract-conformance", "verdict": "pass", "evidence": "single-threaded behaviour matches §3" }
+  ],
+  "label": "HARD-STOP"
+}

--- a/add-method/skill/add/phases/6-verify.md
+++ b/add-method/skill/add/phases/6-verify.md
@@ -31,6 +31,23 @@ If any is false, stop and return to Build — there is nothing to verify yet.
   note reviewed by the auto-gate is an audit finding (`unescalated_security_note`).
 - **Architecture** — does it respect layering/dependency rules in CONVENTIONS.md?
 
+## Part two-and-a-half — independent verification (auto runs)
+
+Under `autonomy: auto`, the adversarial check is **not role-played in this
+context** — it is delegated to fresh, **context-isolated** verifier subagents that
+see only the contract, tests, and diff (never the build conversation). In-context
+self-critique is biased and unreliable; independence is what makes the skeptic
+trustworthy. See `verify-critic.md`.
+
+Run ≥3 lenses, record each structured verdict with `add.py verdict`, then:
+
+```bash
+add.py consensus <slug>          # PASS | HARD-STOP | ESCALATE
+```
+
+Auto-PASS requires `consensus` == `PASS` over ≥3 independent lenses; **security is
+never auto-passed**. Map HARD-STOP → return to Build, ESCALATE → human-led gate.
+
 ## Part three — the deep check (do not skim)
 
 Green tests prove behavior on the inputs you thought of. They do not prove the change

--- a/add-method/skill/add/run.md
+++ b/add-method/skill/add/run.md
@@ -82,8 +82,11 @@ on a trustworthy result with three loops:
 
 - **loop-until-dry** — keep hunting failures and gaps until N consecutive passes find nothing new.
   Stopping at the first green is how defects survive; the run stops only when the well runs dry.
-- **adversarial verify** — for every "done" claim, an independent skeptic tries to REFUTE it. The
-  claim survives only if it withstands refutation, not because one pass looked plausible.
+- **adversarial verify (structurally independent)** — for every "done" claim, the skeptic is a
+  FRESH, **context-isolated** subagent that sees only the contract, tests, and diff — never the
+  build transcript (in-context self-critique is biased and approves uncritically). Run ≥3 lenses, record each
+  with `add.py verdict`, and let `add.py consensus` decide. The claim survives only if it withstands
+  refutation. See `verify-critic.md`.
 - **completeness-critic** — a final pass that asks "what did we NOT cover — a scenario, a non-functional risk,
   an unstated assumption?" Whatever it finds re-enters the run.
 
@@ -99,8 +102,10 @@ sufficient and the result is recorded (principle 7, reframed: an automated, reco
 explicit pass, not a skip).
 
 - **Auto-PASS requires ALL of:** every test green; coverage not decreased; no test weakened and no
-  contract edited; the convergence loops dry; the completeness-critic found nothing open; and the
-  deep check below recorded.
+  contract edited; the convergence loops dry; the completeness-critic found nothing open; the
+  deep check below recorded; and **`add.py consensus` == `PASS`** — agreement across ≥3 fresh,
+  **context-isolated** verifier lenses (`verify-critic.md`). A green suite alone never auto-passes;
+  structural independence is the evidence.
 - **The deep check (every gate, no skim).** Deep check — do not skim. If the task produced code, record
   that every new symbol is referenced (wiring) and that no new dead/unused code was introduced. If it
   produced prose or non-code, record a semantic read — what you read in full and what it confirmed.

--- a/add-method/skill/add/verify-critic.md
+++ b/add-method/skill/add/verify-critic.md
@@ -1,0 +1,73 @@
+# Verify — independent verification (Generator–Verifier separation)
+
+Self-critique in the same context that wrote the code is unreliable: a model
+favours its own output (self-enhancement bias) and repeats its own errors, so
+an in-context "skeptic" approves it uncritically. ADD makes the skeptic **structurally
+independent** — the auto-gate decision is computed by the engine from structured
+verdicts produced by **fresh, context-isolated verifier subagents**, not by the
+builder reconsidering its own work.
+
+## How the auto-gate verifies (`autonomy: auto`)
+
+Spawn each verifier as a **fresh subagent with an isolated context**. Give it
+ONLY:
+
+- §3 CONTRACT · §4 TESTS · the diff / `src/` · CONVENTIONS.md.
+
+Never give it the build conversation, your reasoning, or why you think the code is
+right. Its job is to **refute**, not to agree.
+
+Run **three independent lenses** (one subagent each — they do not see each other):
+
+- `wiring` — is every new symbol referenced and reachable? any dead end left behind?
+- `concurrency-security` — races/timing under parallel use; secrets, injection,
+  invented/unexpected dependencies. A security finding is **always** HARD-STOP.
+- `contract-conformance` — does observable behaviour match §3 exactly, including
+  every rejection path?
+
+Each subagent returns exactly **one structured verdict**:
+
+<verdict>
+{ "lens": "wiring",
+  "verdict": "pass" | "fail" | "risk",
+  "evidence": "what it actually observed (required — no shallow 'looks good')",
+  "refutation": "the strongest counter-argument it tried, and the result",
+  "security": false }
+</verdict>
+
+Record each verdict, then read the decision — **the engine computes it, never you:**
+
+```bash
+add.py verdict <slug> --lens wiring --verdict pass \
+  --evidence "every new symbol is called; dead-code scan clean" \
+  --refutation "looked for an unreachable export — none"
+add.py verdict <slug> --lens concurrency-security --verdict pass --evidence "..."
+add.py verdict <slug> --lens contract-conformance --verdict pass --evidence "..."
+
+add.py consensus <slug>          # PASS | HARD-STOP | ESCALATE
+```
+
+Map the consensus to the gate — do not second-guess it:
+
+| `consensus` | Meaning | Action |
+|-------------|---------|--------|
+| `PASS` | ≥3 independent lenses agree, none refuted | `add.py gate PASS` |
+| `HARD-STOP` | any refutation, or any security finding | `add.py gate HARD-STOP` → return to Build |
+| `ESCALATE` | residue (a `risk`) or coverage too thin | human-led gate — **no auto-PASS** |
+
+**Auto-PASS requires `add.py consensus` == `PASS`.** A green test suite alone never
+auto-passes — structural independence is the evidence the run still owes.
+
+## Measuring the gate itself (data layer)
+
+Recorded verdicts are durable, labelled data — not throwaway chat. Score the
+decision logic against known-good and seeded-bad fixtures:
+
+```bash
+add.py eval --fixtures .add/eval
+```
+
+A fixture is `{ "verdicts": [...], "label": "PASS|HARD-STOP|ESCALATE" }` — the
+decision the gate *should* make for a known build. `recall` is the safety metric:
+every seeded-bad build must be caught (`missed-bad(fn) = 0`). This is red/green TDD
+applied to the AI gate's own judgment, not just to the code.

--- a/add-method/src/add_method/_bundled/skill/add/phases/6-verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/6-verify.md
@@ -31,6 +31,23 @@ If any is false, stop and return to Build — there is nothing to verify yet.
   note reviewed by the auto-gate is an audit finding (`unescalated_security_note`).
 - **Architecture** — does it respect layering/dependency rules in CONVENTIONS.md?
 
+## Part two-and-a-half — independent verification (auto runs)
+
+Under `autonomy: auto`, the adversarial check is **not role-played in this
+context** — it is delegated to fresh, **context-isolated** verifier subagents that
+see only the contract, tests, and diff (never the build conversation). In-context
+self-critique is biased and unreliable; independence is what makes the skeptic
+trustworthy. See `verify-critic.md`.
+
+Run ≥3 lenses, record each structured verdict with `add.py verdict`, then:
+
+```bash
+add.py consensus <slug>          # PASS | HARD-STOP | ESCALATE
+```
+
+Auto-PASS requires `consensus` == `PASS` over ≥3 independent lenses; **security is
+never auto-passed**. Map HARD-STOP → return to Build, ESCALATE → human-led gate.
+
 ## Part three — the deep check (do not skim)
 
 Green tests prove behavior on the inputs you thought of. They do not prove the change

--- a/add-method/src/add_method/_bundled/skill/add/run.md
+++ b/add-method/src/add_method/_bundled/skill/add/run.md
@@ -82,8 +82,11 @@ on a trustworthy result with three loops:
 
 - **loop-until-dry** — keep hunting failures and gaps until N consecutive passes find nothing new.
   Stopping at the first green is how defects survive; the run stops only when the well runs dry.
-- **adversarial verify** — for every "done" claim, an independent skeptic tries to REFUTE it. The
-  claim survives only if it withstands refutation, not because one pass looked plausible.
+- **adversarial verify (structurally independent)** — for every "done" claim, the skeptic is a
+  FRESH, **context-isolated** subagent that sees only the contract, tests, and diff — never the
+  build transcript (in-context self-critique is biased and approves uncritically). Run ≥3 lenses, record each
+  with `add.py verdict`, and let `add.py consensus` decide. The claim survives only if it withstands
+  refutation. See `verify-critic.md`.
 - **completeness-critic** — a final pass that asks "what did we NOT cover — a scenario, a non-functional risk,
   an unstated assumption?" Whatever it finds re-enters the run.
 
@@ -99,8 +102,10 @@ sufficient and the result is recorded (principle 7, reframed: an automated, reco
 explicit pass, not a skip).
 
 - **Auto-PASS requires ALL of:** every test green; coverage not decreased; no test weakened and no
-  contract edited; the convergence loops dry; the completeness-critic found nothing open; and the
-  deep check below recorded.
+  contract edited; the convergence loops dry; the completeness-critic found nothing open; the
+  deep check below recorded; and **`add.py consensus` == `PASS`** — agreement across ≥3 fresh,
+  **context-isolated** verifier lenses (`verify-critic.md`). A green suite alone never auto-passes;
+  structural independence is the evidence.
 - **The deep check (every gate, no skim).** Deep check — do not skim. If the task produced code, record
   that every new symbol is referenced (wiring) and that no new dead/unused code was introduced. If it
   produced prose or non-code, record a semantic read — what you read in full and what it confirmed.

--- a/add-method/src/add_method/_bundled/skill/add/verify-critic.md
+++ b/add-method/src/add_method/_bundled/skill/add/verify-critic.md
@@ -1,0 +1,73 @@
+# Verify — independent verification (Generator–Verifier separation)
+
+Self-critique in the same context that wrote the code is unreliable: a model
+favours its own output (self-enhancement bias) and repeats its own errors, so
+an in-context "skeptic" approves it uncritically. ADD makes the skeptic **structurally
+independent** — the auto-gate decision is computed by the engine from structured
+verdicts produced by **fresh, context-isolated verifier subagents**, not by the
+builder reconsidering its own work.
+
+## How the auto-gate verifies (`autonomy: auto`)
+
+Spawn each verifier as a **fresh subagent with an isolated context**. Give it
+ONLY:
+
+- §3 CONTRACT · §4 TESTS · the diff / `src/` · CONVENTIONS.md.
+
+Never give it the build conversation, your reasoning, or why you think the code is
+right. Its job is to **refute**, not to agree.
+
+Run **three independent lenses** (one subagent each — they do not see each other):
+
+- `wiring` — is every new symbol referenced and reachable? any dead end left behind?
+- `concurrency-security` — races/timing under parallel use; secrets, injection,
+  invented/unexpected dependencies. A security finding is **always** HARD-STOP.
+- `contract-conformance` — does observable behaviour match §3 exactly, including
+  every rejection path?
+
+Each subagent returns exactly **one structured verdict**:
+
+<verdict>
+{ "lens": "wiring",
+  "verdict": "pass" | "fail" | "risk",
+  "evidence": "what it actually observed (required — no shallow 'looks good')",
+  "refutation": "the strongest counter-argument it tried, and the result",
+  "security": false }
+</verdict>
+
+Record each verdict, then read the decision — **the engine computes it, never you:**
+
+```bash
+add.py verdict <slug> --lens wiring --verdict pass \
+  --evidence "every new symbol is called; dead-code scan clean" \
+  --refutation "looked for an unreachable export — none"
+add.py verdict <slug> --lens concurrency-security --verdict pass --evidence "..."
+add.py verdict <slug> --lens contract-conformance --verdict pass --evidence "..."
+
+add.py consensus <slug>          # PASS | HARD-STOP | ESCALATE
+```
+
+Map the consensus to the gate — do not second-guess it:
+
+| `consensus` | Meaning | Action |
+|-------------|---------|--------|
+| `PASS` | ≥3 independent lenses agree, none refuted | `add.py gate PASS` |
+| `HARD-STOP` | any refutation, or any security finding | `add.py gate HARD-STOP` → return to Build |
+| `ESCALATE` | residue (a `risk`) or coverage too thin | human-led gate — **no auto-PASS** |
+
+**Auto-PASS requires `add.py consensus` == `PASS`.** A green test suite alone never
+auto-passes — structural independence is the evidence the run still owes.
+
+## Measuring the gate itself (data layer)
+
+Recorded verdicts are durable, labelled data — not throwaway chat. Score the
+decision logic against known-good and seeded-bad fixtures:
+
+```bash
+add.py eval --fixtures .add/eval
+```
+
+A fixture is `{ "verdicts": [...], "label": "PASS|HARD-STOP|ESCALATE" }` — the
+decision the gate *should* make for a known build. `recall` is the safety metric:
+every seeded-bad build must be caught (`missed-bad(fn) = 0`). This is red/green TDD
+applied to the AI gate's own judgment, not just to the code.

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -37,6 +37,18 @@ GRADUATION_CUE = "MVP covered → propose graduation"
 PHASES = ("specify", "scenarios", "contract", "tests", "build", "verify", "observe", "done")
 GATES = ("none", "PASS", "RISK-ACCEPTED", "HARD-STOP")
 
+# --- independent verification (Generator–Verifier separation) ----------------
+# In-context self-critique is unreliable: a model favours its own output
+# (self-enhancement bias) and repeats its own errors, so an in-context
+# "skeptic" approves it uncritically. The auto-gate decision is therefore computed by the
+# engine from STRUCTURED verdicts produced by fresh, context-isolated verifier
+# subagents (one per lens) — see skill/add/verify-critic.md. The engine validates
+# shape and computes the deterministic decision; it never judges the code itself.
+VERDICT_VALUES = ("pass", "fail", "risk")
+VERIFY_LENSES = ("wiring", "concurrency-security", "contract-conformance")
+MIN_CONSENSUS_LENSES = 3            # distinct lenses required for an auto-PASS (self-consistency)
+VERDICT_LEDGER = "verdicts.jsonl"  # append-only, per-task; verdicts are durable, labelled data
+
 
 def _phase_index(name: str) -> int:
     """Ordinal of a phase in PHASES; used to enforce forward-skip rules."""
@@ -650,6 +662,208 @@ def cmd_reopen(args: argparse.Namespace) -> None:
     _sync_task_marker(root, slug, target)
     save_state(root, state)
     print(f"task '{slug}' reopened: done -> {target} (reason recorded); gate reset to none")
+
+
+# --- independent verification: schema · consensus · ledger · eval ------------
+
+def _validate_verdict(obj: object) -> list[str]:
+    """Return a list of shape errors for one verifier verdict ([] == valid).
+
+    A verdict is DATA, not free-form prose: a lens (which independent verifier),
+    a call (pass|fail|risk), and non-empty evidence (no shallow 'looks good'). This
+    is the structured-output guard — it is what stops a vague auto-PASS."""
+    if not isinstance(obj, dict):
+        return ["verdict must be a JSON object"]
+    errs: list[str] = []
+    lens = obj.get("lens")
+    if not isinstance(lens, str) or not lens.strip():
+        errs.append("lens: required non-empty string (which independent verifier)")
+    if obj.get("verdict") not in VERDICT_VALUES:
+        errs.append(f"verdict: must be one of {', '.join(VERDICT_VALUES)}")
+    ev = obj.get("evidence")
+    if not isinstance(ev, str) or not ev.strip():
+        errs.append("evidence: required non-empty string (no shallow verify)")
+    if "security" in obj and not isinstance(obj["security"], bool):
+        errs.append("security: must be a boolean")
+    if "refutation" in obj and not isinstance(obj["refutation"], str):
+        errs.append("refutation: must be a string")
+    return errs
+
+
+def _consensus(verdicts: list[dict],
+               min_lenses: int = MIN_CONSENSUS_LENSES) -> tuple[str, str]:
+    """The deterministic auto-gate decision over recorded verdicts → (outcome, reason).
+
+    outcome ∈ {PASS, HARD-STOP, ESCALATE}. The rule, in priority order:
+      1. ANY security finding (fail|risk) → HARD-STOP — security is never auto-passed.
+      2. ANY refutation (a `fail`)        → HARD-STOP — return to Build.
+      3. ANY residue (a `risk`)           → ESCALATE  — human-led gate (principle 2).
+      4. all `pass` but < min distinct lenses → ESCALATE — independence too thin.
+      5. all `pass` across ≥ min distinct lenses → PASS — self-consistent agreement.
+    The engine computes this from data; the resolver still records the gate."""
+    if not verdicts:
+        return "ESCALATE", "no independent verdicts recorded — an auto-PASS needs evidence"
+    for vd in verdicts:
+        if vd.get("security") and vd.get("verdict") in ("fail", "risk"):
+            return "HARD-STOP", (f"security finding from lens '{vd.get('lens')}' — "
+                                 "never auto-passed")
+    fails = [vd for vd in verdicts if vd.get("verdict") == "fail"]
+    if fails:
+        return "HARD-STOP", f"lens '{fails[0].get('lens')}' refuted the build — return to Build"
+    risks = [vd for vd in verdicts if vd.get("verdict") == "risk"]
+    if risks:
+        return "ESCALATE", f"lens '{risks[0].get('lens')}' flagged residue — human-led gate"
+    distinct = {str(vd.get("lens", "")).strip()
+                for vd in verdicts if str(vd.get("lens", "")).strip()}
+    if len(distinct) < min_lenses:
+        return "ESCALATE", (f"insufficient independent coverage: {len(distinct)}/{min_lenses} "
+                            "distinct lenses passed")
+    return "PASS", f"{len(distinct)} independent lenses agree, none refuted"
+
+
+def _verdict_ledger_path(root: Path, slug: str) -> Path:
+    return root / "tasks" / slug / VERDICT_LEDGER
+
+
+def _load_verdicts(root: Path, slug: str) -> list[dict]:
+    """Read the append-only verdict ledger, failing closed on a corrupt line."""
+    p = _verdict_ledger_path(root, slug)
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    try:
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    except (OSError, json.JSONDecodeError) as e:
+        _die(f"verdict_ledger_invalid: {p} is unreadable or corrupt ({e.__class__.__name__})")
+    return out
+
+
+def cmd_verdict(args: argparse.Namespace) -> None:
+    """Append one (or, via --file, many) structured verifier verdict(s) to the task ledger.
+
+    The agent records a fresh, context-isolated verifier's call here; the engine
+    validates SHAPE before writing (fail closed — a malformed verdict is never stored)."""
+    root = _require_root()
+    state = load_state(root)
+    slug = _resolve_task(state, args.slug)
+    if args.file:
+        try:
+            raw = sys.stdin.read() if args.file == "-" else Path(args.file).read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as e:
+            _die(f"verdict_input_invalid: {e.__class__.__name__}: {e}")
+        records = data if isinstance(data, list) else [data]
+    else:
+        if args.lens is None or args.verdict is None or args.evidence is None:
+            _die("verdict_incomplete: supply --lens, --verdict and --evidence (or --file)")
+        rec: dict = {"lens": args.lens, "verdict": args.verdict, "evidence": args.evidence}
+        if args.refutation is not None:
+            rec["refutation"] = args.refutation
+        if args.security:
+            rec["security"] = True
+        records = [rec]
+    # validate EVERY record before writing ANY (no partial ledger)
+    for i, rec in enumerate(records):
+        errs = _validate_verdict(rec)
+        if errs:
+            _die(f"verdict_invalid (record {i}): " + "; ".join(errs))
+    now = _now()
+    p = _verdict_ledger_path(root, slug)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a", encoding="utf-8") as fh:        # append-only ledger
+        for rec in records:
+            rec = dict(rec)
+            rec.setdefault("at", now)
+            fh.write(json.dumps(rec, separators=(",", ":")) + "\n")
+    print(f"recorded {len(records)} verdict(s) for '{slug}' -> tasks/{slug}/{VERDICT_LEDGER}")
+
+
+def cmd_consensus(args: argparse.Namespace) -> None:
+    """Read-only: compute the auto-gate decision from the recorded independent verdicts.
+
+    The run consults this before `gate`: PASS → `gate PASS`; HARD-STOP → `gate HARD-STOP`
+    (return to Build); ESCALATE → human-led gate (no auto-PASS)."""
+    root = _require_root()
+    state = load_state(root)
+    slug = _resolve_task(state, args.slug)
+    verdicts = _load_verdicts(root, slug)
+    outcome, reason = _consensus(verdicts, args.min_lenses)
+    lenses = sorted({str(v.get("lens", "")).strip()
+                     for v in verdicts if str(v.get("lens", "")).strip()})
+    if getattr(args, "json", False):
+        print(json.dumps({"slug": slug, "outcome": outcome, "reason": reason,
+                          "verdicts": len(verdicts), "lenses": lenses},
+                         separators=(",", ":")))
+    else:
+        print(f"consensus for '{slug}': {outcome} — {reason}")
+        print(f"  {len(verdicts)} verdict(s) across {len(lenses)} lens(es): "
+              f"{', '.join(lenses) or '(none)'}")
+
+
+def cmd_eval(args: argparse.Namespace) -> None:
+    """Read-only: score the consensus decision logic against labeled verdict fixtures.
+
+    Each fixture is `{ "verdicts": [...], "label": "PASS|HARD-STOP|ESCALATE" }` — the
+    decision the gate SHOULD make for a known build (e.g. a seeded-bad build → HARD-STOP).
+    Reports exact accuracy plus a binary 'should-block' confusion: `recall` is the safety
+    metric — every seeded-bad build must be caught (fn = 0). This is red/green TDD applied
+    to the AI gate's own judgment, not just to the code."""
+    root = find_root()
+    explicit = args.fixtures is not None
+    fixtures_dir = Path(args.fixtures) if explicit else (root / "eval" if root else None)
+    files = sorted(fixtures_dir.glob("*.json")) if (fixtures_dir and fixtures_dir.exists()) else []
+    if not files:
+        # An explicit --fixtures that resolves to nothing is a user error (fail closed).
+        # The bare default (no fixtures laid down yet) is a clean no-op, not a failure.
+        if explicit:
+            _die(f"eval_no_fixtures: no *.json fixtures at {fixtures_dir} — check --fixtures")
+        print("eval: no fixtures (default .add/eval/ is empty) — nothing to score")
+        return
+    valid_labels = ("PASS", "HARD-STOP", "ESCALATE")
+    tp = fp = tn = fn = correct = 0
+    rows: list[tuple] = []
+    for f in files:
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            _die(f"eval_fixture_invalid: {f.name}: {e.__class__.__name__}")
+        label = data.get("label")
+        if label not in valid_labels:
+            _die(f"eval_fixture_invalid: {f.name}: label must be one of {', '.join(valid_labels)}")
+        outcome, reason = _consensus(data.get("verdicts", []), args.min_lenses)
+        ok = (outcome == label)
+        correct += ok
+        should_block = (label != "PASS")        # binary safety view: did NOT auto-pass
+        did_block = (outcome != "PASS")
+        if should_block and did_block:
+            tp += 1
+        elif should_block and not did_block:
+            fn += 1                              # the dangerous miss: a bad build auto-passed
+        elif not should_block and did_block:
+            fp += 1                              # a false alarm: a good build blocked
+        else:
+            tn += 1
+        rows.append((f.name, label, outcome, ok, reason))
+    n = len(files)
+    accuracy = correct / n
+    precision = tp / (tp + fp) if (tp + fp) else 1.0
+    recall = tp / (tp + fn) if (tp + fn) else 1.0
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "fixtures": n, "accuracy": accuracy, "precision": precision, "recall": recall,
+            "tp": tp, "fp": fp, "tn": tn, "fn": fn,
+            "rows": [{"fixture": r[0], "label": r[1], "outcome": r[2], "match": r[3]}
+                     for r in rows],
+        }, separators=(",", ":")))
+    else:
+        for name, label, outcome, ok, _reason in rows:
+            mark = "ok" if ok else "MISMATCH"
+            print(f"  {mark:>8}  {name:<28} label={label:<11} consensus={outcome}")
+        print(f"eval: {correct}/{n} exact ({accuracy:.0%}) · catch precision={precision:.0%} "
+              f"recall={recall:.0%} · missed-bad(fn)={fn}")
 
 
 def cmd_lock(args: argparse.Namespace) -> None:
@@ -2884,6 +3098,43 @@ def build_parser() -> argparse.ArgumentParser:
 
     ppj = sub.add_parser("project", help="print .add/PROJECT.md (the read-first foundation)")
     ppj.set_defaults(func=cmd_project)
+
+    # --- independent verification (Generator–Verifier auto-gate) -------------
+    pvd = sub.add_parser("verdict",
+                         help="record an independent verifier's structured verdict "
+                              "(append-only ledger; validated before write)")
+    pvd.add_argument("slug", nargs="?", default=None)
+    pvd.add_argument("--lens", default=None,
+                     help="which independent verifier (e.g. wiring, concurrency-security, "
+                          "contract-conformance)")
+    pvd.add_argument("--verdict", choices=VERDICT_VALUES, default=None, help="this lens's call")
+    pvd.add_argument("--evidence", default=None,
+                     help="what the verifier observed (required — no shallow verify)")
+    pvd.add_argument("--refutation", default=None,
+                     help="the strongest counter-argument it tried and the result")
+    pvd.add_argument("--security", action="store_true",
+                     help="mark this a security finding (forces HARD-STOP, never auto-passed)")
+    pvd.add_argument("--file", default=None,
+                     help="read a verdict object or JSON array from a file ('-' = stdin)")
+    pvd.set_defaults(func=cmd_verdict)
+
+    pcs = sub.add_parser("consensus",
+                         help="read-only: compute the auto-gate decision "
+                              "(PASS · HARD-STOP · ESCALATE) from recorded verdicts")
+    pcs.add_argument("slug", nargs="?", default=None)
+    pcs.add_argument("--min-lenses", type=int, default=MIN_CONSENSUS_LENSES, dest="min_lenses",
+                     help="distinct lenses required for an auto-PASS (self-consistency)")
+    pcs.add_argument("--json", action="store_true", help="machine-readable JSON output")
+    pcs.set_defaults(func=cmd_consensus)
+
+    pev = sub.add_parser("eval",
+                         help="read-only: score the consensus decision logic against "
+                              "labeled verdict fixtures (recall = no seeded-bad build slips through)")
+    pev.add_argument("--fixtures", default=None,
+                     help="dir of *.json fixtures ({verdicts, label}); default .add/eval/")
+    pev.add_argument("--min-lenses", type=int, default=MIN_CONSENSUS_LENSES, dest="min_lenses")
+    pev.add_argument("--json", action="store_true", help="machine-readable JSON output")
+    pev.set_defaults(func=cmd_eval)
 
     return p
 

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -37,6 +37,18 @@ GRADUATION_CUE = "MVP covered → propose graduation"
 PHASES = ("specify", "scenarios", "contract", "tests", "build", "verify", "observe", "done")
 GATES = ("none", "PASS", "RISK-ACCEPTED", "HARD-STOP")
 
+# --- independent verification (Generator–Verifier separation) ----------------
+# In-context self-critique is unreliable: a model favours its own output
+# (self-enhancement bias) and repeats its own errors, so an in-context
+# "skeptic" approves it uncritically. The auto-gate decision is therefore computed by the
+# engine from STRUCTURED verdicts produced by fresh, context-isolated verifier
+# subagents (one per lens) — see skill/add/verify-critic.md. The engine validates
+# shape and computes the deterministic decision; it never judges the code itself.
+VERDICT_VALUES = ("pass", "fail", "risk")
+VERIFY_LENSES = ("wiring", "concurrency-security", "contract-conformance")
+MIN_CONSENSUS_LENSES = 3            # distinct lenses required for an auto-PASS (self-consistency)
+VERDICT_LEDGER = "verdicts.jsonl"  # append-only, per-task; verdicts are durable, labelled data
+
 
 def _phase_index(name: str) -> int:
     """Ordinal of a phase in PHASES; used to enforce forward-skip rules."""
@@ -650,6 +662,208 @@ def cmd_reopen(args: argparse.Namespace) -> None:
     _sync_task_marker(root, slug, target)
     save_state(root, state)
     print(f"task '{slug}' reopened: done -> {target} (reason recorded); gate reset to none")
+
+
+# --- independent verification: schema · consensus · ledger · eval ------------
+
+def _validate_verdict(obj: object) -> list[str]:
+    """Return a list of shape errors for one verifier verdict ([] == valid).
+
+    A verdict is DATA, not free-form prose: a lens (which independent verifier),
+    a call (pass|fail|risk), and non-empty evidence (no shallow 'looks good'). This
+    is the structured-output guard — it is what stops a vague auto-PASS."""
+    if not isinstance(obj, dict):
+        return ["verdict must be a JSON object"]
+    errs: list[str] = []
+    lens = obj.get("lens")
+    if not isinstance(lens, str) or not lens.strip():
+        errs.append("lens: required non-empty string (which independent verifier)")
+    if obj.get("verdict") not in VERDICT_VALUES:
+        errs.append(f"verdict: must be one of {', '.join(VERDICT_VALUES)}")
+    ev = obj.get("evidence")
+    if not isinstance(ev, str) or not ev.strip():
+        errs.append("evidence: required non-empty string (no shallow verify)")
+    if "security" in obj and not isinstance(obj["security"], bool):
+        errs.append("security: must be a boolean")
+    if "refutation" in obj and not isinstance(obj["refutation"], str):
+        errs.append("refutation: must be a string")
+    return errs
+
+
+def _consensus(verdicts: list[dict],
+               min_lenses: int = MIN_CONSENSUS_LENSES) -> tuple[str, str]:
+    """The deterministic auto-gate decision over recorded verdicts → (outcome, reason).
+
+    outcome ∈ {PASS, HARD-STOP, ESCALATE}. The rule, in priority order:
+      1. ANY security finding (fail|risk) → HARD-STOP — security is never auto-passed.
+      2. ANY refutation (a `fail`)        → HARD-STOP — return to Build.
+      3. ANY residue (a `risk`)           → ESCALATE  — human-led gate (principle 2).
+      4. all `pass` but < min distinct lenses → ESCALATE — independence too thin.
+      5. all `pass` across ≥ min distinct lenses → PASS — self-consistent agreement.
+    The engine computes this from data; the resolver still records the gate."""
+    if not verdicts:
+        return "ESCALATE", "no independent verdicts recorded — an auto-PASS needs evidence"
+    for vd in verdicts:
+        if vd.get("security") and vd.get("verdict") in ("fail", "risk"):
+            return "HARD-STOP", (f"security finding from lens '{vd.get('lens')}' — "
+                                 "never auto-passed")
+    fails = [vd for vd in verdicts if vd.get("verdict") == "fail"]
+    if fails:
+        return "HARD-STOP", f"lens '{fails[0].get('lens')}' refuted the build — return to Build"
+    risks = [vd for vd in verdicts if vd.get("verdict") == "risk"]
+    if risks:
+        return "ESCALATE", f"lens '{risks[0].get('lens')}' flagged residue — human-led gate"
+    distinct = {str(vd.get("lens", "")).strip()
+                for vd in verdicts if str(vd.get("lens", "")).strip()}
+    if len(distinct) < min_lenses:
+        return "ESCALATE", (f"insufficient independent coverage: {len(distinct)}/{min_lenses} "
+                            "distinct lenses passed")
+    return "PASS", f"{len(distinct)} independent lenses agree, none refuted"
+
+
+def _verdict_ledger_path(root: Path, slug: str) -> Path:
+    return root / "tasks" / slug / VERDICT_LEDGER
+
+
+def _load_verdicts(root: Path, slug: str) -> list[dict]:
+    """Read the append-only verdict ledger, failing closed on a corrupt line."""
+    p = _verdict_ledger_path(root, slug)
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    try:
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    except (OSError, json.JSONDecodeError) as e:
+        _die(f"verdict_ledger_invalid: {p} is unreadable or corrupt ({e.__class__.__name__})")
+    return out
+
+
+def cmd_verdict(args: argparse.Namespace) -> None:
+    """Append one (or, via --file, many) structured verifier verdict(s) to the task ledger.
+
+    The agent records a fresh, context-isolated verifier's call here; the engine
+    validates SHAPE before writing (fail closed — a malformed verdict is never stored)."""
+    root = _require_root()
+    state = load_state(root)
+    slug = _resolve_task(state, args.slug)
+    if args.file:
+        try:
+            raw = sys.stdin.read() if args.file == "-" else Path(args.file).read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as e:
+            _die(f"verdict_input_invalid: {e.__class__.__name__}: {e}")
+        records = data if isinstance(data, list) else [data]
+    else:
+        if args.lens is None or args.verdict is None or args.evidence is None:
+            _die("verdict_incomplete: supply --lens, --verdict and --evidence (or --file)")
+        rec: dict = {"lens": args.lens, "verdict": args.verdict, "evidence": args.evidence}
+        if args.refutation is not None:
+            rec["refutation"] = args.refutation
+        if args.security:
+            rec["security"] = True
+        records = [rec]
+    # validate EVERY record before writing ANY (no partial ledger)
+    for i, rec in enumerate(records):
+        errs = _validate_verdict(rec)
+        if errs:
+            _die(f"verdict_invalid (record {i}): " + "; ".join(errs))
+    now = _now()
+    p = _verdict_ledger_path(root, slug)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a", encoding="utf-8") as fh:        # append-only ledger
+        for rec in records:
+            rec = dict(rec)
+            rec.setdefault("at", now)
+            fh.write(json.dumps(rec, separators=(",", ":")) + "\n")
+    print(f"recorded {len(records)} verdict(s) for '{slug}' -> tasks/{slug}/{VERDICT_LEDGER}")
+
+
+def cmd_consensus(args: argparse.Namespace) -> None:
+    """Read-only: compute the auto-gate decision from the recorded independent verdicts.
+
+    The run consults this before `gate`: PASS → `gate PASS`; HARD-STOP → `gate HARD-STOP`
+    (return to Build); ESCALATE → human-led gate (no auto-PASS)."""
+    root = _require_root()
+    state = load_state(root)
+    slug = _resolve_task(state, args.slug)
+    verdicts = _load_verdicts(root, slug)
+    outcome, reason = _consensus(verdicts, args.min_lenses)
+    lenses = sorted({str(v.get("lens", "")).strip()
+                     for v in verdicts if str(v.get("lens", "")).strip()})
+    if getattr(args, "json", False):
+        print(json.dumps({"slug": slug, "outcome": outcome, "reason": reason,
+                          "verdicts": len(verdicts), "lenses": lenses},
+                         separators=(",", ":")))
+    else:
+        print(f"consensus for '{slug}': {outcome} — {reason}")
+        print(f"  {len(verdicts)} verdict(s) across {len(lenses)} lens(es): "
+              f"{', '.join(lenses) or '(none)'}")
+
+
+def cmd_eval(args: argparse.Namespace) -> None:
+    """Read-only: score the consensus decision logic against labeled verdict fixtures.
+
+    Each fixture is `{ "verdicts": [...], "label": "PASS|HARD-STOP|ESCALATE" }` — the
+    decision the gate SHOULD make for a known build (e.g. a seeded-bad build → HARD-STOP).
+    Reports exact accuracy plus a binary 'should-block' confusion: `recall` is the safety
+    metric — every seeded-bad build must be caught (fn = 0). This is red/green TDD applied
+    to the AI gate's own judgment, not just to the code."""
+    root = find_root()
+    explicit = args.fixtures is not None
+    fixtures_dir = Path(args.fixtures) if explicit else (root / "eval" if root else None)
+    files = sorted(fixtures_dir.glob("*.json")) if (fixtures_dir and fixtures_dir.exists()) else []
+    if not files:
+        # An explicit --fixtures that resolves to nothing is a user error (fail closed).
+        # The bare default (no fixtures laid down yet) is a clean no-op, not a failure.
+        if explicit:
+            _die(f"eval_no_fixtures: no *.json fixtures at {fixtures_dir} — check --fixtures")
+        print("eval: no fixtures (default .add/eval/ is empty) — nothing to score")
+        return
+    valid_labels = ("PASS", "HARD-STOP", "ESCALATE")
+    tp = fp = tn = fn = correct = 0
+    rows: list[tuple] = []
+    for f in files:
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            _die(f"eval_fixture_invalid: {f.name}: {e.__class__.__name__}")
+        label = data.get("label")
+        if label not in valid_labels:
+            _die(f"eval_fixture_invalid: {f.name}: label must be one of {', '.join(valid_labels)}")
+        outcome, reason = _consensus(data.get("verdicts", []), args.min_lenses)
+        ok = (outcome == label)
+        correct += ok
+        should_block = (label != "PASS")        # binary safety view: did NOT auto-pass
+        did_block = (outcome != "PASS")
+        if should_block and did_block:
+            tp += 1
+        elif should_block and not did_block:
+            fn += 1                              # the dangerous miss: a bad build auto-passed
+        elif not should_block and did_block:
+            fp += 1                              # a false alarm: a good build blocked
+        else:
+            tn += 1
+        rows.append((f.name, label, outcome, ok, reason))
+    n = len(files)
+    accuracy = correct / n
+    precision = tp / (tp + fp) if (tp + fp) else 1.0
+    recall = tp / (tp + fn) if (tp + fn) else 1.0
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "fixtures": n, "accuracy": accuracy, "precision": precision, "recall": recall,
+            "tp": tp, "fp": fp, "tn": tn, "fn": fn,
+            "rows": [{"fixture": r[0], "label": r[1], "outcome": r[2], "match": r[3]}
+                     for r in rows],
+        }, separators=(",", ":")))
+    else:
+        for name, label, outcome, ok, _reason in rows:
+            mark = "ok" if ok else "MISMATCH"
+            print(f"  {mark:>8}  {name:<28} label={label:<11} consensus={outcome}")
+        print(f"eval: {correct}/{n} exact ({accuracy:.0%}) · catch precision={precision:.0%} "
+              f"recall={recall:.0%} · missed-bad(fn)={fn}")
 
 
 def cmd_lock(args: argparse.Namespace) -> None:
@@ -2884,6 +3098,43 @@ def build_parser() -> argparse.ArgumentParser:
 
     ppj = sub.add_parser("project", help="print .add/PROJECT.md (the read-first foundation)")
     ppj.set_defaults(func=cmd_project)
+
+    # --- independent verification (Generator–Verifier auto-gate) -------------
+    pvd = sub.add_parser("verdict",
+                         help="record an independent verifier's structured verdict "
+                              "(append-only ledger; validated before write)")
+    pvd.add_argument("slug", nargs="?", default=None)
+    pvd.add_argument("--lens", default=None,
+                     help="which independent verifier (e.g. wiring, concurrency-security, "
+                          "contract-conformance)")
+    pvd.add_argument("--verdict", choices=VERDICT_VALUES, default=None, help="this lens's call")
+    pvd.add_argument("--evidence", default=None,
+                     help="what the verifier observed (required — no shallow verify)")
+    pvd.add_argument("--refutation", default=None,
+                     help="the strongest counter-argument it tried and the result")
+    pvd.add_argument("--security", action="store_true",
+                     help="mark this a security finding (forces HARD-STOP, never auto-passed)")
+    pvd.add_argument("--file", default=None,
+                     help="read a verdict object or JSON array from a file ('-' = stdin)")
+    pvd.set_defaults(func=cmd_verdict)
+
+    pcs = sub.add_parser("consensus",
+                         help="read-only: compute the auto-gate decision "
+                              "(PASS · HARD-STOP · ESCALATE) from recorded verdicts")
+    pcs.add_argument("slug", nargs="?", default=None)
+    pcs.add_argument("--min-lenses", type=int, default=MIN_CONSENSUS_LENSES, dest="min_lenses",
+                     help="distinct lenses required for an auto-PASS (self-consistency)")
+    pcs.add_argument("--json", action="store_true", help="machine-readable JSON output")
+    pcs.set_defaults(func=cmd_consensus)
+
+    pev = sub.add_parser("eval",
+                         help="read-only: score the consensus decision logic against "
+                              "labeled verdict fixtures (recall = no seeded-bad build slips through)")
+    pev.add_argument("--fixtures", default=None,
+                     help="dir of *.json fixtures ({verdicts, label}); default .add/eval/")
+    pev.add_argument("--min-lenses", type=int, default=MIN_CONSENSUS_LENSES, dest="min_lenses")
+    pev.add_argument("--json", action="store_true", help="machine-readable JSON output")
+    pev.set_defaults(func=cmd_eval)
 
     return p
 

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -10,4 +10,4 @@ it can never detect drift. The literal was recorded at the commit that first
 introduced it and is updated only by a deliberate, human-approved task.
 """
 
-ENGINE_MD5 = "cc890d6c773700d87501714be495b462"  # re-aimed @ unflagged-freeze guard (flag-first freeze: advance refuse + audit verified-marker)
+ENGINE_MD5 = "39367becb7525b3af4137e6f9006051f"  # re-aimed @ independent-verifier auto-gate (verdict · consensus · eval commands)

--- a/add-method/tooling/test_independent_verify.py
+++ b/add-method/tooling/test_independent_verify.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Behavioral proof of the independent-verifier auto-gate (Generator–Verifier split).
+
+The problem this guards against: under `autonomy: auto`, the old "adversarial verify"
+ran in the SAME context that wrote the code. In-context self-critique is unreliable —
+a model favours its own output (self-enhancement bias) and repeats its own errors,
+so the skeptic approves it uncritically. The fix makes the skeptic STRUCTURALLY independent:
+the auto-gate decision is computed by the engine from recorded, structured verdicts
+produced by fresh context-isolated verifier subagents (one per lens).
+
+Three seams, each proven behaviorally:
+  (A) Verdict SCHEMA — a verdict is well-formed data, not free-form prose; the engine
+      validates shape (no shallow "looks good" passes).
+  (B) CONSENSUS — the deterministic auto-gate decision over the recorded verdicts:
+      any refutation or security finding blocks; residue escalates; an auto-PASS needs
+      agreement across >= N independent lenses (self-consistency).
+  (C) EVAL — the data-engineering harness: score the consensus logic against labeled
+      fixtures so the gate's own judgment is measurable (recall = no seeded-bad build
+      slips through).
+
+Run: python3 -m unittest test_independent_verify -v
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import add
+
+SKILL = Path(__file__).resolve().parent.parent / "skill" / "add"
+
+
+def _run(argv):
+    """Invoke add.main, capturing (exit_code, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    code = 0
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            add.main(argv)
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
+    return code, out.getvalue(), err.getvalue()
+
+
+# --- (A) verdict schema --------------------------------------------------------
+class VerdictSchemaTest(unittest.TestCase):
+    def test_well_formed_verdict_validates(self):
+        errs = add._validate_verdict({
+            "lens": "wiring", "verdict": "pass",
+            "evidence": "every new symbol is referenced; no dead code",
+            "refutation": "tried to find an unreachable export — none",
+            "security": False,
+        })
+        self.assertEqual(errs, [])
+
+    def test_missing_evidence_is_rejected(self):
+        # the whole point: no shallow "looks good" — evidence is mandatory.
+        errs = add._validate_verdict({"lens": "wiring", "verdict": "pass", "evidence": "  "})
+        self.assertTrue(any("evidence" in e for e in errs), errs)
+
+    def test_unknown_verdict_value_is_rejected(self):
+        errs = add._validate_verdict({"lens": "wiring", "verdict": "lgtm", "evidence": "x"})
+        self.assertTrue(any("verdict" in e for e in errs), errs)
+
+    def test_empty_lens_is_rejected(self):
+        errs = add._validate_verdict({"lens": "", "verdict": "pass", "evidence": "x"})
+        self.assertTrue(any("lens" in e for e in errs), errs)
+
+    def test_security_must_be_boolean(self):
+        errs = add._validate_verdict(
+            {"lens": "concurrency-security", "verdict": "pass", "evidence": "x", "security": "yes"})
+        self.assertTrue(any("security" in e for e in errs), errs)
+
+
+# --- (B) consensus decision ----------------------------------------------------
+class ConsensusTest(unittest.TestCase):
+    def _v(self, lens, verdict, security=False):
+        return {"lens": lens, "verdict": verdict, "evidence": "e", "security": security}
+
+    def test_three_independent_passes_auto_pass(self):
+        outcome, _ = add._consensus([
+            self._v("wiring", "pass"),
+            self._v("concurrency-security", "pass"),
+            self._v("contract-conformance", "pass"),
+        ])
+        self.assertEqual(outcome, "PASS")
+
+    def test_any_refutation_hard_stops(self):
+        outcome, reason = add._consensus([
+            self._v("wiring", "pass"),
+            self._v("contract-conformance", "fail"),
+            self._v("concurrency-security", "pass"),
+        ])
+        self.assertEqual(outcome, "HARD-STOP")
+        self.assertIn("contract-conformance", reason)
+
+    def test_security_finding_is_always_hard_stop(self):
+        # even a 'risk' (not 'fail') is a HARD-STOP when flagged security.
+        outcome, reason = add._consensus([
+            self._v("wiring", "pass"),
+            self._v("concurrency-security", "risk", security=True),
+            self._v("contract-conformance", "pass"),
+        ])
+        self.assertEqual(outcome, "HARD-STOP")
+        self.assertIn("security", reason.lower())
+
+    def test_non_security_risk_escalates_to_human(self):
+        outcome, _ = add._consensus([
+            self._v("wiring", "pass"),
+            self._v("concurrency-security", "risk"),
+            self._v("contract-conformance", "pass"),
+        ])
+        self.assertEqual(outcome, "ESCALATE")
+
+    def test_thin_coverage_cannot_auto_pass(self):
+        # two passing lenses is not enough independence for an auto-PASS.
+        outcome, _ = add._consensus([
+            self._v("wiring", "pass"),
+            self._v("contract-conformance", "pass"),
+        ])
+        self.assertEqual(outcome, "ESCALATE")
+
+    def test_duplicate_lens_does_not_count_twice(self):
+        outcome, _ = add._consensus([
+            self._v("wiring", "pass"),
+            self._v("wiring", "pass"),
+            self._v("wiring", "pass"),
+        ])
+        self.assertEqual(outcome, "ESCALATE")
+
+    def test_no_verdicts_never_auto_passes(self):
+        outcome, _ = add._consensus([])
+        self.assertNotEqual(outcome, "PASS")
+
+
+# --- command surface (verdict ledger + consensus) ------------------------------
+class VerdictCommandTest(unittest.TestCase):
+    def setUp(self):
+        self._cwd = Path.cwd()
+        self.tmp = tempfile.mkdtemp(prefix="add-iv-")
+        os.chdir(self.tmp)
+        _run(["init", "--name", "demo"])
+        self.root = add.find_root()
+        _run(["new-task", "t"])
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+
+    def test_verdict_is_appended_to_ledger_and_consensus_reads_it(self):
+        for lens in ("wiring", "concurrency-security", "contract-conformance"):
+            code, _, err = _run(["verdict", "t", "--lens", lens, "--verdict", "pass",
+                                 "--evidence", f"{lens}: checked"])
+            self.assertEqual(code, 0, err)
+        ledger = self.root / "tasks" / "t" / "verdicts.jsonl"
+        self.assertTrue(ledger.exists(), "verdict ledger must be written")
+        lines = [json.loads(l) for l in ledger.read_text().splitlines() if l.strip()]
+        self.assertEqual(len(lines), 3)
+
+        code, out, _ = _run(["consensus", "t", "--json"])
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertEqual(data["outcome"], "PASS")
+        self.assertEqual(data["verdicts"], 3)
+
+    def test_invalid_verdict_is_refused_fail_closed(self):
+        code, _, err = _run(["verdict", "t", "--lens", "wiring", "--verdict", "pass"])  # no evidence
+        self.assertNotEqual(code, 0)
+        self.assertIn("verdict", (err or "").lower())
+        ledger = self.root / "tasks" / "t" / "verdicts.jsonl"
+        self.assertFalse(ledger.exists(), "a refused verdict must not be written")
+
+    def test_security_verdict_drives_hard_stop_consensus(self):
+        _run(["verdict", "t", "--lens", "wiring", "--verdict", "pass", "--evidence", "ok"])
+        _run(["verdict", "t", "--lens", "contract-conformance", "--verdict", "pass", "--evidence", "ok"])
+        _run(["verdict", "t", "--lens", "concurrency-security", "--verdict", "fail",
+              "--evidence", "hardcoded secret", "--security"])
+        code, out, _ = _run(["consensus", "t", "--json"])
+        self.assertEqual(json.loads(out)["outcome"], "HARD-STOP")
+
+
+# --- (C) eval harness ----------------------------------------------------------
+class EvalTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="add-iv-eval-")
+        self.fx = Path(self.tmp) / "eval"
+        self.fx.mkdir()
+
+    def _fixture(self, name, verdicts, label):
+        (self.fx / name).write_text(json.dumps({"verdicts": verdicts, "label": label}))
+
+    def test_eval_scores_consensus_against_labels(self):
+        good = [{"lens": l, "verdict": "pass", "evidence": "e"}
+                for l in ("wiring", "concurrency-security", "contract-conformance")]
+        bad = [{"lens": "wiring", "verdict": "pass", "evidence": "e"},
+               {"lens": "concurrency-security", "verdict": "fail", "evidence": "race"},
+               {"lens": "contract-conformance", "verdict": "pass", "evidence": "e"}]
+        self._fixture("good.json", good, "PASS")
+        self._fixture("seeded-bad.json", bad, "HARD-STOP")
+
+        code, out, err = _run(["eval", "--fixtures", str(self.fx), "--json"])
+        self.assertEqual(code, 0, err)
+        data = json.loads(out)
+        self.assertEqual(data["fixtures"], 2)
+        self.assertEqual(data["accuracy"], 1.0)
+        # the safety metric: every seeded-bad build is caught (no false-negatives).
+        self.assertEqual(data["fn"], 0)
+        self.assertEqual(data["recall"], 1.0)
+
+
+# --- skill wiring (the prompt surface that drives the subagents) ---------------
+class SkillWiringTest(unittest.TestCase):
+    def test_verify_critic_prompt_exists_and_demands_isolation(self):
+        f = SKILL / "verify-critic.md"
+        self.assertTrue(f.exists(), "skill/add/verify-critic.md must exist")
+        text = f.read_text(encoding="utf-8").lower()
+        for token in ("isolat", "fresh", "context", "refute", "consensus"):
+            self.assertIn(token, text, f"verify-critic.md must mention {token!r}")
+
+    def test_verify_phase_routes_to_independent_verification(self):
+        text = (SKILL / "phases" / "6-verify.md").read_text(encoding="utf-8").lower()
+        self.assertIn("verify-critic", text)
+        self.assertIn("consensus", text)
+
+    def test_run_autogate_requires_structural_independence(self):
+        text = (SKILL / "run.md").read_text(encoding="utf-8").lower()
+        self.assertIn("consensus", text)
+        self.assertIn("context-isolated", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/add-method/tooling/test_min_pillar.py
+++ b/add-method/tooling/test_min_pillar.py
@@ -68,6 +68,10 @@ LIFECYCLE = [
     ["advance", "t"], ["advance", "t"],        # specify -> ... -> verify
     ["audit"],                                 # read-only seam audit (no recorded seams yet ->
                                                # clean exit 0; reads TASK.md/state, never docs/)
+    ["verdict", "t", "--lens", "wiring", "--verdict", "pass", "--evidence", "census"],
+                                               # append to tasks/<slug>/verdicts.jsonl + state, never docs/
+    ["consensus", "t"],                        # read-only: decision over recorded verdicts
+    ["eval"],                                  # read-only: default .add/eval absent -> clean no-op
     ["gate", "PASS", "t"],
     ["reopen", "t", "--to", "verify", "--reason", "census"],  # done -> verify (recorded, gate reset)
     ["gate", "PASS", "t"],                                    # re-complete so milestone-done stays valid

--- a/add-method/tooling/test_wording_lint.py
+++ b/add-method/tooling/test_wording_lint.py
@@ -166,14 +166,15 @@ class TestLiveSurfaceGreen(unittest.TestCase):
         self.assertEqual([f for f in live if f.code == "banned_idiom_present"], [])
 
     def test_surface_files_cover_the_contract(self) -> None:
-        """The surface is skill/add (20 files: +loop.md @ v20, +graduate.md @ v22) + docs/appendix-b-prompts.md, per §3."""
+        """The surface is skill/add (21 files: +loop.md @ v20, +graduate.md @ v22, +verify-critic.md) + docs/appendix-b-prompts.md, per §3."""
         files = wl.surface_files()
         names = {p.name for p in files}
         self.assertIn("SKILL.md", names)
         self.assertIn("loop.md", names)
         self.assertIn("graduate.md", names)
+        self.assertIn("verify-critic.md", names)
         self.assertIn("appendix-b-prompts.md", names)
-        self.assertEqual(len(files), 21, f"expected 20 skill files + appendix-b, got {len(files)}")
+        self.assertEqual(len(files), 22, f"expected 21 skill files + appendix-b, got {len(files)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Under `autonomy: auto`, the run's "adversarial verify" and "completeness-critic" execute in the **same agent and same context** that wrote the code (`run.md`). In-context self-critique is unreliable — a model favours its own output (self-enhancement bias) and repeats its own errors, so the in-context skeptic approves it uncritically (Zheng et al. 2023, LLM-as-judge; Huang et al. 2023, "LLMs Cannot Self-Correct Reasoning Yet"). This quietly reintroduces "one agent finds it plausible" — the exact thing ADD sets out to eliminate.

## What

Apply the **Generator–Verifier (Generator–Critic) pattern** for real, with the engine enforcing structure + the deterministic decision and the prompts driving the independent verification:

- **Context-isolated verifier** (`skill/add/verify-critic.md`): the run spawns fresh subagents per lens (`wiring` · `concurrency-security` · `contract-conformance`) that see only §3 contract, §4 tests, the diff and CONVENTIONS — never the build transcript — and must refute.
- **Structured verdict** (`_validate_verdict`): a verdict is data (`lens`/`verdict`/`evidence`), validated before write — no shallow "looks good" auto-PASS.
- **Self-consistency consensus** (`_consensus`): any security finding or refutation → `HARD-STOP`; residue → `ESCALATE`; auto-`PASS` only with agreement across ≥3 distinct lenses.
- **Eval harness** (`add.py eval`): scores the decision logic against labeled fixtures so the gate's own judgment is measurable — `recall` = no seeded-bad build slips through. TDD's red/green applied to the AI's judgment, not just the code.

New CLI: `add.py verdict` (append-only per-task ledger, fail-closed) · `add.py consensus` (read-only PASS/HARD-STOP/ESCALATE) · `add.py eval`. Wired into `run.md`'s auto-gate and `phases/6-verify.md`. The engine stays LLM-free; `cmd_gate` is untouched (non-breaking).

## Tests

Built test-first (`tooling/test_independent_verify.py`, 19 cases). Full suite **721 green** on CI Python (3.10/3.12); all repo invariants honored — three byte-identical `add.py` copies + re-pinned `ENGINE_MD5`, skill-tree parity across canonical/_bundled/.claude, regenerated bundle, subcommand-coverage census, wording rubric.