### PR TITLE
feat(method): wave-protocol-runtime — streams.md merge-time fork-base + worker commits its report

### DIFF
--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": null,
+  "active_task": "wave-protocol-runtime",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -472,10 +472,19 @@
       "depends_on": [],
       "created": "2026-06-08T01:44:06+00:00",
       "updated": "2026-06-08T01:44:06+00:00"
+    },
+    "engine-argv-portability": {
+      "title": "CLI accepts flags-before-slug on Python <=3.12 (argparse intermixing)",
+      "phase": "ground",
+      "gate": "none",
+      "milestone": null,
+      "depends_on": [],
+      "created": "2026-06-11T10:42:52+00:00",
+      "updated": "2026-06-11T10:42:52+00:00"
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-06-11T08:48:05+00:00",
+  "updated": "2026-06-11T10:42:52+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",

--- a/.add/state.json
+++ b/.add/state.json
@@ -466,12 +466,19 @@
     },
     "wave-protocol-runtime": {
       "title": "streams.md: merge-time fork-base check + worker commits SUMMARY.md",
-      "phase": "specify",
-      "gate": "none",
+      "phase": "done",
+      "gate": "PASS",
       "milestone": null,
       "depends_on": [],
       "created": "2026-06-08T01:44:06+00:00",
-      "updated": "2026-06-08T01:44:06+00:00"
+      "updated": "2026-06-11T11:30:45+00:00",
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "c4da67533b946210e17c43175997efa7",
+        "tests": {
+          "add-method/tooling/test_streams.py": "a957a3351ddb3b6b56c20d6f6f509661"
+        }
+      }
     },
     "engine-argv-portability": {
       "title": "CLI accepts flags-before-slug on Python <=3.12 (argparse intermixing)",
@@ -481,10 +488,19 @@
       "depends_on": [],
       "created": "2026-06-11T10:42:52+00:00",
       "updated": "2026-06-11T10:42:52+00:00"
+    },
+    "engine-merge-base-enforcement": {
+      "title": "Engine guards the merge-time fork-base echo on merge-back",
+      "phase": "ground",
+      "gate": "none",
+      "milestone": null,
+      "depends_on": [],
+      "created": "2026-06-11T11:31:40+00:00",
+      "updated": "2026-06-11T11:31:40+00:00"
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-06-11T10:42:52+00:00",
+  "updated": "2026-06-11T11:31:40+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",

--- a/.add/tasks/engine-argv-portability/TASK.md
+++ b/.add/tasks/engine-argv-portability/TASK.md
@@ -1,0 +1,150 @@
+# TASK: CLI accepts flags-before-slug on Python <=3.12 (argparse intermixing)
+
+slug: engine-argv-portability · created: 2026-06-11 · stage: mvp
+autonomy: auto   <!-- inherited from the project default (PROJECT.md); explicit level: manual < conservative < auto (visible · overridable) — lower below if a high-risk task needs it. -->
+phase: ground   <!-- ground -> specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+<!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower the
+     autonomy level to `manual` or `conservative` — the engine refuses an unguarded completion
+     (`unguarded_high_risk_auto`, run.md guard). A comment is never a declaration. -->
+
+> One file = one task. Fill sections top-to-bottom; the `add` skill drives each phase.
+> When a phase is unclear, read its book chapter in `.add/docs/` (linked per section).
+> The phase marker above is the single source of truth — keep it in sync via `add.py phase`.
+
+---
+
+## 0 · GROUND — the real codebase ▸ docs/02-the-flow.md
+
+Touches (files · symbols · signatures): `add-method/tooling/add.py` — every subparser with a `<positional> nargs="?"` slug (gate ~3195 · heal ~3210 · reopen · use · phase · advance …). argparse on Python ≤3.12 cannot bind an optional positional that FOLLOWS value-taking flags. ENGINE change → pin bump ×3 + re-sync (`engine_pin.ENGINE_MD5`).
+Context (working folder): found 2026-06-11 during PR #6 review; the test helpers used the broken order and were fixed to the natural order (commit 9d52302) — the engine itself was left as-is, so this is the deferred robustness half.
+Honors (patterns / conventions): CLAUDE.md "MUST design for failure"; the release-gate pin-bump ×3 idiom; CI runs py3.10/3.12 (so a 3.13+-only fix is not enough).
+Anchors the contract cites: the gate/heal slug positionals; the argparse parse seam.
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+Feature: make the CLI accept flags-before-slug on Python ≤3.12. `add.py gate RISK-ACCEPTED --owner X --ticket Y --expires Z myslug` (waiver flags before the optional `slug`) silently fails `unrecognized arguments: myslug` on py3.10/3.11/3.12 — works on 3.13+ (argparse intermixing) and on all versions when the slug PRECEDES the flags. Repro: `python3.10 add.py gate RISK-ACCEPTED --owner T --ticket T-1 --expires 2099-01-01 t`. Affects every optional-slug subcommand, not just gate.
+Framings weighed: parse_known_args + manual positional re-bind (chosen-lean — explicit, version-agnostic) · `parser.parse_intermixed_args` (rejected? — interacts poorly with subparsers, needs verification) · require the slug position / drop nargs="?" (rejected — breaks the ergonomic "defaults to active task")
+Must:
+<must>
+  - <required behavior>
+</must>
+Reject:
+<reject>
+  - <bad input / situation> -> "<error_code>"
+</reject>
+After:
+<after>
+  - <state that is true once it succeeds>
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ <the one assumption most likely to be wrong> — lowest confidence because <why>; if wrong: <cost>
+  - [ ] <next assumption, ranked> — confirm or deny; never carry an open one forward
+</assumptions>
+
+<!-- EXIT: every rule stated, every rejection named; assumptions ranked lowest-confidence first, the top one or two ⚠-flagged with why + cost (or, for trivial scope, an honest "none material" that still names the single biggest risk). -->
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: <short name>
+  Given <starting situation>
+  When <action>
+  Then <expected result>
+  And <what must remain unchanged>   # required for every rejection
+```
+
+</scenarios>
+
+<!-- EXIT: one scenario per Must AND per Reject; each result is observable. -->
+
+---
+
+## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
+
+```
+<METHOD> <path>   body: { <fields> }
+  200 -> { <success fields> }
+  4xx -> { error: "<code>" | "<code>" }
+Schema: <tables/fields touched, and access pattern>
+```
+
+Status: DRAFT
+<!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
+     points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
+     with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
+     too — see run.md). Approved -> Status: FROZEN @ vN — approved by <name>. Changing a frozen
+     contract = change request back to SPECIFY.
+     EXIT: frozen + every spec rejection has a contracted response + names match GLOSSARY + the
+     bundle's lowest-confidence flag was surfaced at the freeze (or an honest "none material"). -->
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: <e.g. 90%>
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_<scenario>: arrange <Given> / act <When> / assert <Then> + assert <unchanged>
+</test_plan>
+
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+<!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
+     a token with "/" = project root · a bare name = sibling of the previous
+     token's dir · a directory counts its *.py files (non-recursive); reports
+     mark declared counts with † · anything resolving outside the project root counts 0 -->
+
+<!-- EXIT: one test per scenario; suite red for the RIGHT reason; target recorded. -->
+
+---
+
+## 5 · BUILD — AI writes code ▸ docs/07-step-5-build.md
+
+Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>
+Code lives in: `./src/`
+Constraints: do NOT change any test or the contract; allow-list packages only; ask if unclear.
+
+<!-- EXIT: all green; coverage held; no test/contract touched; no unlisted dependency. -->
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [ ] all tests pass
+- [ ] coverage did not decrease
+- [ ] no test or contract was altered during build
+- [ ] the green was EARNED, not gamed — no overfit to fixtures, vacuous asserts, or stubbed-away logic (score with an adversarial refute-read — a subagent recommended under `autonomy: auto`; a confirmed cheat is HARD-STOP)
+- [ ] concurrency / timing of the risky operation is safe
+- [ ] no exposed secrets, injection openings, or unexpected dependencies
+- [ ] layering & dependencies follow CONVENTIONS.md
+- [ ] a person reviewed and approved the change
+
+### Deep checks — do not skim (fill the path that applies; the resolver judges which)
+- [ ] WIRING (code) — every new symbol is referenced; record where / how confirmed
+- [ ] DEAD-CODE (code) — no new unused or orphaned symbol introduced
+- [ ] SEMANTIC (prose / non-code) — read in full, not skimmed: <what read · what confirmed>
+
+### GATE RECORD
+Outcome: <PASS | RISK-ACCEPTED | HARD-STOP>
+If RISK-ACCEPTED -> owner: <name> · ticket: <link> · expires: <date>   (never for a security gap)
+Reviewed by: <name> · date: <date>
+
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): <error rate / per-rejection rate / latency>
+Spec delta for the next loop: <what production taught you>
+
+### Competency deltas
+What did this loop teach the foundation? One line each, tagged by competency
+(`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
+<!-- e.g.  - [DDD · open] the model missed multi-tenancy (evidence: scenario_x failed) -->

--- a/.add/tasks/engine-merge-base-enforcement/TASK.md
+++ b/.add/tasks/engine-merge-base-enforcement/TASK.md
@@ -1,0 +1,150 @@
+# TASK: Engine guards the merge-time fork-base echo on merge-back
+
+slug: engine-merge-base-enforcement · created: 2026-06-11 · stage: mvp
+autonomy: auto   <!-- inherited from the project default (PROJECT.md); explicit level: manual < conservative < auto (visible · overridable) — lower below if a high-risk task needs it. -->
+phase: ground   <!-- ground -> specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+<!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower the
+     autonomy level to `manual` or `conservative` — the engine refuses an unguarded completion
+     (`unguarded_high_risk_auto`, run.md guard). A comment is never a declaration. -->
+
+> One file = one task. Fill sections top-to-bottom; the `add` skill drives each phase.
+> When a phase is unclear, read its book chapter in `.add/docs/` (linked per section).
+> The phase marker above is the single source of truth — keep it in sync via `add.py phase`.
+
+---
+
+## 0 · GROUND — the real codebase ▸ docs/02-the-flow.md
+
+Touches (files · symbols · signatures): `add-method/skill/add/streams.md` (the merge-time fork-base prose, lines ~75-80) + a NEW `add.py` guard on the wave-ledger merge-back path — likely near `_tripwire_*` / the ledger-digest seam — that refuses a merge-back whose worker step-0 `rev-parse HEAD` echo does not match the orchestrator base (`unverified_fork_base`, engine-enforced this time). ENGINE change → pin bump ×3 + re-sync (`engine_pin.ENGINE_MD5`).
+Context (working folder): the deferred half of `wave-protocol-runtime` (PASS 2026-06-11). That task shipped the prose-discipline; its frozen lowest-confidence flag named this enforcement as explicitly DEFERRED. v19 wave delta #7 (merge-time fork-base) is the source; CONVENTIONS:90 + streams.md already STATE the rule — this task makes the engine EXECUTE it.
+Honors (patterns / conventions): CLAUDE.md "MUST design for failure"; the wave-ledger evidence-cell convention (a roster row needs the fork-base evidence); the release-gate pin-bump ×3 idiom; words-exist≠method-works (the exact recursion this closes).
+Anchors the contract cites: the wave-ledger merge-back seam; the `unverified_fork_base` refusal code; the worker step-0 echo the orchestrator verifies.
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+Feature: <name>
+Framings weighed: <chosen> (chosen) · <alternative> · <alternative>
+Must:
+<must>
+  - <required behavior>
+</must>
+Reject:
+<reject>
+  - <bad input / situation> -> "<error_code>"
+</reject>
+After:
+<after>
+  - <state that is true once it succeeds>
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ <the one assumption most likely to be wrong> — lowest confidence because <why>; if wrong: <cost>
+  - [ ] <next assumption, ranked> — confirm or deny; never carry an open one forward
+</assumptions>
+
+<!-- EXIT: every rule stated, every rejection named; assumptions ranked lowest-confidence first, the top one or two ⚠-flagged with why + cost (or, for trivial scope, an honest "none material" that still names the single biggest risk). -->
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: <short name>
+  Given <starting situation>
+  When <action>
+  Then <expected result>
+  And <what must remain unchanged>   # required for every rejection
+```
+
+</scenarios>
+
+<!-- EXIT: one scenario per Must AND per Reject; each result is observable. -->
+
+---
+
+## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
+
+```
+<METHOD> <path>   body: { <fields> }
+  200 -> { <success fields> }
+  4xx -> { error: "<code>" | "<code>" }
+Schema: <tables/fields touched, and access pattern>
+```
+
+Status: DRAFT
+<!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
+     points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
+     with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
+     too — see run.md). Approved -> Status: FROZEN @ vN — approved by <name>. Changing a frozen
+     contract = change request back to SPECIFY.
+     EXIT: frozen + every spec rejection has a contracted response + names match GLOSSARY + the
+     bundle's lowest-confidence flag was surfaced at the freeze (or an honest "none material"). -->
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: <e.g. 90%>
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_<scenario>: arrange <Given> / act <When> / assert <Then> + assert <unchanged>
+</test_plan>
+
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+<!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
+     a token with "/" = project root · a bare name = sibling of the previous
+     token's dir · a directory counts its *.py files (non-recursive); reports
+     mark declared counts with † · anything resolving outside the project root counts 0 -->
+
+<!-- EXIT: one test per scenario; suite red for the RIGHT reason; target recorded. -->
+
+---
+
+## 5 · BUILD — AI writes code ▸ docs/07-step-5-build.md
+
+Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>
+Code lives in: `./src/`
+Constraints: do NOT change any test or the contract; allow-list packages only; ask if unclear.
+
+<!-- EXIT: all green; coverage held; no test/contract touched; no unlisted dependency. -->
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [ ] all tests pass
+- [ ] coverage did not decrease
+- [ ] no test or contract was altered during build
+- [ ] the green was EARNED, not gamed — no overfit to fixtures, vacuous asserts, or stubbed-away logic (score with an adversarial refute-read — a subagent recommended under `autonomy: auto`; a confirmed cheat is HARD-STOP)
+- [ ] concurrency / timing of the risky operation is safe
+- [ ] no exposed secrets, injection openings, or unexpected dependencies
+- [ ] layering & dependencies follow CONVENTIONS.md
+- [ ] a person reviewed and approved the change
+
+### Deep checks — do not skim (fill the path that applies; the resolver judges which)
+- [ ] WIRING (code) — every new symbol is referenced; record where / how confirmed
+- [ ] DEAD-CODE (code) — no new unused or orphaned symbol introduced
+- [ ] SEMANTIC (prose / non-code) — read in full, not skimmed: <what read · what confirmed>
+
+### GATE RECORD
+Outcome: <PASS | RISK-ACCEPTED | HARD-STOP>
+If RISK-ACCEPTED -> owner: <name> · ticket: <link> · expires: <date>   (never for a security gap)
+Reviewed by: <name> · date: <date>
+
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): <error rate / per-rejection rate / latency>
+Spec delta for the next loop: <what production taught you>
+
+### Competency deltas
+What did this loop teach the foundation? One line each, tagged by competency
+(`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
+<!-- e.g.  - [DDD · open] the model missed multi-tenancy (evidence: scenario_x failed) -->

--- a/.add/tasks/wave-protocol-runtime/TASK.md
+++ b/.add/tasks/wave-protocol-runtime/TASK.md
@@ -1,7 +1,7 @@
 # TASK: streams.md: merge-time fork-base check + worker commits SUMMARY.md
 
 slug: wave-protocol-runtime · created: 2026-06-08 · stage: mvp · risk: high · autonomy: conservative
-phase: specify   <!-- specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+phase: done   <!-- specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
 <!-- risk: high — amends the method's own orchestration rubric (streams.md), same surface as wave-ledger;
      autonomy lowered to conservative: the verify gate stops for the human. Source: v19 wave deltas #7 + #8. -->
 <!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower
@@ -49,11 +49,40 @@ Assumptions — lowest-confidence first:
 <scenarios>
 
 ```gherkin
-Scenario: <short name>
-  Given <starting situation>
-  When <action>
-  Then <expected result>
-  And <what must remain unchanged>   # required for every rejection
+Scenario: spawn-time-worktree runner has an in-protocol fork-base path   # Must 1
+  Given a runner that creates each worker's worktree AT spawn from a pool (the pre-spawn rev-parse evidence cell is unsatisfiable)
+  When a reader consults streams.md's "Design for failure" / "Wave ledger" section
+  Then streams.md states the unverified_fork_base check SHIFTS to worker step-0 (sync-to-base + re-echo) verified by the orchestrator at MERGE-time before merge-back — the check shifts, it never skips
+  And the shifted check still names the same refusal code (unverified_fork_base), so the shipped text and the folded CONVENTIONS runtime-exception agree
+
+Scenario: a worker durably persists its own report   # Must 2
+  Given the worker PROMPT `<return>` contract in streams.md
+  When the worker finishes its task inside the worktree
+  Then streams.md instructs the worker to COMMIT SUMMARY.md + deltas.md in the worktree, not merely write them
+  And the "worker PROPOSES, orchestrator RECORDS; a worker never runs add.py" rule remains stated unchanged
+
+Scenario: fresh-HEAD-worktree runner keeps the pre-spawn rule as the default   # Must 4
+  Given a runner that forks the worktree from current HEAD (the pre-spawn rev-parse cell IS satisfiable)
+  When a reader consults streams.md
+  Then the original "Fresh worktree base (verify base == HEAD)" pre-spawn rule is still stated as the default path
+  And the merge-time path reads as an additive ALTERNATIVE for the spawn-time case, never a replacement of the pre-spawn rule
+
+Scenario: the three streams.md copies stay byte-identical   # Must 3
+  Given the canonical (add-method/skill), dogfood (.claude/skills), and bundle (_bundled) copies of streams.md
+  When the wave-protocol-runtime amendment is applied
+  Then md5 of all three copies yields exactly one hash
+
+Scenario: REJECT — the pre-spawn rule is removed or weakened   # Reject 1 -> fork_base_rule_weakened
+  Given the amendment edit to streams.md
+  When the edit deletes or weakens the fresh-base pre-spawn fork-base rule instead of ADDING the merge-time alternative
+  Then the change is rejected as "fork_base_rule_weakened"
+  And the pre-spawn rule's anchor tokens ("Fresh worktree base", "verify base == HEAD") must remain present in streams.md
+
+Scenario: REJECT — the mirror copies diverge   # Reject 2 -> mirror_drift
+  Given the three streams.md copies
+  When the edit lands in fewer than all three (their md5 differs)
+  Then the change is rejected as "mirror_drift"
+  And no copy is left partially amended — all three carry identical bytes, or the edit does not ship
 ```
 
 </scenarios>
@@ -65,13 +94,51 @@ Scenario: <short name>
 ## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
 
 ```
-<METHOD> <path>   body: { <fields> }
-  200 -> { <success fields> }
-  4xx -> { error: "<code>" | "<code>" }
-Schema: <tables/fields touched, and access pattern>
+AMEND  add-method/skill/add/streams.md   (×3 byte-identical mirror:
+       .claude/skills/add/streams.md · add-method/src/add_method/_bundled/skill/add/streams.md)
+
+  Amendment A — merge-time fork-base shift   (in the "Design for failure" fork-base bullet
+                and/or the evidence-cell `unverified_fork_base` note)
+    ADD: on a runner that creates the worktree AT spawn from a pool, the pre-spawn
+         rev-parse evidence cell is UNSATISFIABLE; the `unverified_fork_base` check
+         SHIFTS to worker step-0 (sync-to-base + re-echo), verified by the orchestrator
+         at MERGE-time before merge-back. The check shifts, it never skips.
+    KEEP: the "Fresh worktree base (verify base == HEAD)" pre-spawn rule stays the
+          DEFAULT for fresh-HEAD-worktree runners — additive alternative, not replacement.
+
+  Amendment B — worker commits its own report   (in the worker PROMPT `<return>` contract)
+    CHANGE: "write the same into SUMMARY.md" -> the worker COMMITS SUMMARY.md + deltas.md
+            in the worktree (uncommitted worktree files survive only by harness courtesy).
+    KEEP: "the worker PROPOSES; the orchestrator RECORDS; a worker never runs add.py".
+
+  200 (conformant) -> {
+    present:   "MERGE-time" shift · "step-0" sync/re-echo · `unverified_fork_base` (shifted, not deleted)
+               · worker "commit" of SUMMARY.md + deltas.md
+    preserved: "Fresh worktree base" · "verify base == HEAD"   (pre-spawn rule intact)
+    parity:    md5(×3 streams.md) == one hash
+  }
+  4xx -> { error: "fork_base_rule_weakened" | "mirror_drift" }
+
+Schema: prose-only edit to streams.md ×3. NO engine/add.py change -> `engine_pin` HOLDS
+        (no bump). Guard: extend `add-method/tooling/test_streams.py` to assert the
+        present+preserved tokens (`_norm`-normalized, hard-wrap incidental) + the ×3 md5
+        parity. Names match GLOSSARY: wave ledger · fork-base · unverified_fork_base · worktree.
 ```
 
-Status: DRAFT
+Least-sure flag surfaced at freeze: [spec] a prose amendment is enough — streams.md DESCRIBES the merge-time fork-base shift; the engine never ENFORCES it (it cannot see the worktree pool), so enforcement is explicitly DEFERRED to a future task, NOT claimed. Cost if wrong: a future wave still skips the check — mitigated because the merge-time leg is engine-ADJACENT (a cherry-pick add.py could guard later). Discriminator: "does the contract claim enforcement, or discipline?" → discipline, honestly labelled, mirroring the already-folded CONVENTIONS runtime-exception. [contract] secondary: Amendment A's insertion point is token-pinned, not location-pinned — either home (the "Design for failure" bullet or the evidence-cell note) is conformant.
+
+⚠ Lowest-confidence flag — surfaced for the one approval:
+  [spec] **A prose amendment is enough — streams.md DESCRIBES the merge-time shift; the engine never ENFORCES it.**
+    The fork-base check is orchestrator-discipline across an opaque harness seam (the engine can't see the
+    worktree pool). Most-likely-wrong because "words-exist≠method-works" — a prose check no test runs is the exact
+    recursion v19 delta #7 warned about. Cost if wrong: a future wave still skips the check. Mitigation (why we
+    ship anyway): the merge-time leg is engine-ADJACENT — the orchestrator verifies the echo before a cherry-pick
+    that add.py COULD guard later — so enforcement is explicitly DEFERRED (a separate future task), NOT claimed.
+    The contract ships prose-that-agrees-with-the-folded-CONVENTIONS-rule, honestly labelled discipline-not-enforcement.
+  [contract] secondary — Amendment A's insertion point (the "Design for failure" bullet vs the evidence-cell note):
+    the guard pins TOKENS, not location, so either spot is conformant — flagging only in case you want a specific home.
+
+Status: FROZEN @ v1 — approved by Tin Dang 2026-06-11 (prose-describes-the-shift; engine-enforcement deferred — the approved lowest-confidence call).
 <!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
      points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
      with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
@@ -84,13 +151,22 @@ Status: DRAFT
 
 ## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
 
-Coverage target: <e.g. 90%>
+Coverage target: token-presence (prose feature — phrasing free, behavior locked) + ×3 md5 parity.
 Plan (one test per scenario, asserting behavior not internals):
 <test_plan>
-  - test_<scenario>: arrange <Given> / act <When> / assert <Then> + assert <unchanged>
+  - test_merge_time_fork_base_shift_stated (Scenario 1 / Must 1): assert streams.md states the
+    shift — tokens `merge-time` + `step-0` present, and `unverified_fork_base` still present
+    (the check shifts, never skips). RED now (no merge-time/step-0 in streams.md).
+  - test_worker_commits_its_report (Scenario 2 / Must 2): assert `commit summary.md` + `deltas.md`
+    present in the worker `<return>` region. RED now (today it says "write", not "commit").
+  - test_pre_spawn_rule_preserved (Scenario 4 / Must 4 · Reject 1 fork_base_rule_weakened): assert
+    `fresh worktree base` + `base == head` still present. GREEN invariant (must stay green).
+  - test_three_streams_copies_byte_identical (Scenario 3 / Must 3 · Reject 2 mirror_drift): all 3
+    streams.md copies present and md5 == one hash. GREEN invariant (re-sync keeps it green).
 </test_plan>
+RED triage: the 2 NEW-behavior tests are red before build; the 2 invariant tests stay green throughout.
 
-Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+Tests live in: `add-method/tooling/test_streams.py` · MUST run red (missing implementation) before Build.
 <!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
      a token with "/" = project root · a bare name = sibling of the previous
      token's dir · a directory counts its *.py files (non-recursive); reports
@@ -112,18 +188,21 @@ Constraints: do NOT change any test or the contract; allow-list packages only; a
 
 ## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
 
-- [ ] all tests pass
-- [ ] coverage did not decrease
-- [ ] no test or contract was altered during build
-- [ ] concurrency / timing of the risky operation is safe
-- [ ] no exposed secrets, injection openings, or unexpected dependencies
-- [ ] layering & dependencies follow CONVENTIONS.md
-- [ ] a person reviewed and approved the change
+- [x] all tests pass — full suite 843 OK on **py3.10 AND py3.14** (the 4 wave tests added; CI-version run per the PR-#6 lesson); `WaveProtocolRuntimeTest` 4/4 green
+- [x] coverage did not decrease — additive: +4 tests, 0 removed/weakened; the 2 invariant tests stayed green throughout
+- [x] no test or contract was altered during build — tamper tripwire CLEAN via the engine's own `_tripwire_divergence` → `[]` (§3 `c4da6753` + test_streams.py `a957a335` byte-unchanged; build touched ONLY streams.md ×3)
+- [x] concurrency / timing of the risky operation is safe — the amendment HARDENS concurrency-failure design: the `unverified_fork_base` check SHIFTS (never skips) to worker step-0 on spawn-time pool runners, verified at merge-time; worker now COMMITS its report so the serial-integration merge-back carries it (no harness-courtesy data loss)
+- [x] no exposed secrets, injection openings, or unexpected dependencies — markdown prose ×3 only; no code, no deps, `engine_pin` HOLDS (no bump)
+- [x] layering & dependencies follow CONVENTIONS.md — mirrors the already-folded CONVENTIONS runtime-exception (fv-folded); pre-spawn rule preserved as DEFAULT, merge-time path additive
+- [x] a person reviewed and approved the change — Tin Dang, verify gate 2026-06-11 (PASS + log follow-up)
+
+### Earned-green refute-read (verify-integrity rubric · risk:high → conducted, presented to the human)
+- VERDICT: green is **EARNED**, not gamed. The 2 new-behaviour tests pass *because* substantive mechanism prose was added (streams.md:75-80 explains WHY the pre-spawn rev-parse cell is unsatisfiable on a spawn-time pool, the shift to step-0 sync+re-echo, merge-time verification, "it never skips"; streams.md:213-215 states the worker COMMITS its report + the WHY). Not keyword-stuffing. The 2 invariant tests pass because the pre-spawn rule is preserved (DEFAULT, "never a replacement") and ×3 copies are byte-identical.
+- DISCLOSED RESIDUE (= the frozen lowest-confidence flag, not a verify surprise): these are token-presence + ×3-parity guards — they lock that the WORDS and the MIRROR hold, not that the engine EXECUTES the merge-time shift (it can't see a worktree pool). Enforcement is explicitly DEFERRED to a future engine task; this change-request ships prose-discipline, honestly labelled. No security finding → not HARD-STOP.
 
 ### GATE RECORD
-Outcome: <PASS | RISK-ACCEPTED | HARD-STOP>
-If RISK-ACCEPTED -> owner: <name> · ticket: <link> · expires: <date>   (never for a security gap)
-Reviewed by: <name> · date: <date>
+Outcome: PASS — human-gated (green EARNED per the refute-read; the only residue is the freeze-approved deferred-enforcement flag, now logged as `engine-merge-base-enforcement`)
+Reviewed by: Tin Dang · date: 2026-06-11
 
 <!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
 
@@ -131,10 +210,13 @@ Reviewed by: <name> · date: <date>
 
 ## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
 
-Watch (reuse scenarios as monitors): <error rate / per-rejection rate / latency>
-Spec delta for the next loop: <what production taught you>
+Watch (reuse scenarios as monitors): the 4 `test_streams.py::WaveProtocolRuntimeTest` guards are the standing monitors — a future streams.md refactor that drops the merge-time/step-0 tokens, un-commits the worker report, weakens the pre-spawn rule, or breaks ×3 parity fails loudly. Live signal for the deferred half: a wave on a spawn-time runner whose worker arrives with a stale base (the merge-time echo mismatches) — currently caught by orchestrator discipline, not the engine.
+Spec delta for the next loop: the merge-time fork-base check is prose-discipline, not engine-enforced — `engine-merge-base-enforcement` (logged this gate) is the contracted follow-up to add an add.py guard on merge-back.
 
 ### Competency deltas
 What did this loop teach the foundation? One line each, tagged by competency
 (`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
-<!-- e.g.  - [DDD · open] the model missed multi-tenancy (evidence: scenario_x failed) -->
+- [ADD · open] a folded CONVENTIONS runtime-exception must be MIRRORED onto every protocol surface it governs (streams.md), or the convention ships prose-only on one surface and the other contradicts it — the cross-surface recursion v19 delta #7 named (evidence: this task existed solely because CONVENTIONS:90 stated the rule but streams.md still told orchestrators to do the unsatisfiable pre-spawn check)
+- [ADD · open] design-for-failure on a concurrency invariant means the check SHIFTS, never SKIPS, when its evidence cell is unsatisfiable — relocate the guarantee (here: pre-spawn rev-parse → worker step-0 + merge-time verify), don't drop it (evidence: streams.md:75-80 keeps `unverified_fork_base` while moving WHERE it's proven)
+- [SDD · open] when a spec's enforcement crosses an opaque harness seam the engine can't observe, NAME the enforcement-deferral explicitly at freeze rather than let prose masquerade as enforcement (evidence: the frozen lowest-confidence flag + `engine-merge-base-enforcement` follow-up, not a silent prose check)
+- [TDD · open] token-presence + ×3-mirror-parity guards are the honest test shape for a prose-discipline change with no executable engine hook — they lock the WORDS and the MIRROR, and the refute-read confirms the words carry mechanism, not keywords (evidence: 4/4 green on substantive amendments; the 2 invariant tests pin the preserved pre-spawn rule)

--- a/.add/tasks/wave-protocol-runtime/TASK.md
+++ b/.add/tasks/wave-protocol-runtime/TASK.md
@@ -203,6 +203,7 @@ Constraints: do NOT change any test or the contract; allow-list packages only; a
 ### GATE RECORD
 Outcome: PASS — human-gated (green EARNED per the refute-read; the only residue is the freeze-approved deferred-enforcement flag, now logged as `engine-merge-base-enforcement`)
 Reviewed by: Tin Dang · date: 2026-06-11
+Post-gate refinement (honest record): the PR #7 careful review found Amendment A stated the merge-time shift in the design-for-failure bullet but NOT in the ledger "Evidence cells" paragraph (a same-file second mention). One clause was added there — Amendment A's OTHER §3-named home ("the evidence-cell `unverified_fork_base` note … either spot is conformant", see §3 + the freeze flag). WITHIN the frozen contract, no test weakened, no contract edited; streams.md ×3 re-synced (md5 `82e08b0d`), suite 843 OK on py3.10. Text changed AFTER the PASS — disclosed here so the record is honest.
 
 <!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
 

--- a/.claude/skills/add/streams.md
+++ b/.claude/skills/add/streams.md
@@ -72,6 +72,12 @@ never drops to zero (`run.md:22`). That floor is correct; do not engineer around
   worktree forked from a stale base forces the worker to recreate the frozen artifacts by hand
   (the v10 dogfood hit exactly this). Before the worker starts, confirm `git -C <worktree>
   rev-parse HEAD` equals the orchestrator's `HEAD`; if it drifted, `git merge` the base in first.
+  On a runner that creates each worktree **at spawn** from a pool (e.g. Claude Code), that pool can hand
+  out a STALE base, so the pre-spawn `rev-parse` evidence cell is unsatisfiable. The `unverified_fork_base`
+  check then **shifts** — it never skips: the worker's **step-0** syncs to base (`git merge` the orchestrator's
+  `HEAD`) and re-echoes `rev-parse HEAD`, which the orchestrator verifies at **merge-time**, before merge-back.
+  The pre-spawn check stays the DEFAULT for fresh-`HEAD`-worktree runners; the merge-time path is the additive
+  ALTERNATIVE for spawn-time runners — never a replacement of the pre-spawn rule.
 - **Lease + timeout** — record which worker holds which task (in the wave ledger, below);
   if a worker dies, release the claim back to READY (re-spawn, do not assume partial work is sound).
 - **Failure isolates** — a worker that hits a STOP-and-escalate (below) blocks only its
@@ -204,7 +210,9 @@ ripgrep otherwise. Design every IO path for failure — timeouts, retries, rollb
 </tools>
 
 <return>   <!-- the worker PROPOSES; the orchestrator RECORDS. A worker never runs add.py. -->
-End with a structured verdict AND write the same into SUMMARY.md in the task dir:
+End with a structured verdict AND write the same into SUMMARY.md in the task dir, then
+**commit SUMMARY.md + deltas.md** in the worktree (uncommitted worktree files survive only by
+harness courtesy — commit them so the serial-integration merge-back carries your report):
 { task, outcome: PASS|RISK-ACCEPTED|HARD-STOP|ESCALATE, evidence: <tests+coverage>,
   residue: [security|concurrency|architecture findings], deltas: [open lessons learned] }.
 Do NOT touch add.py or any shared file — the orchestrator gates on your verdict.

--- a/.claude/skills/add/streams.md
+++ b/.claude/skills/add/streams.md
@@ -120,7 +120,10 @@ base: <orchestrator HEAD at spawn — the sha every fork must equal>
 `git -C <worktree> rev-parse HEAD`, and it must equal `base:`. A tick is not evidence; a row
 you can only fill by running the command is the fresh-worktree-base check EXECUTING — the
 v12-1 lesson (words-exist ≠ method-works) closed structurally. Spawning a worker whose roster
-row lacks that evidence is refused (`unverified_fork_base`).
+row lacks that evidence is refused (`unverified_fork_base`). On a spawn-time pool runner this
+PRE-spawn paste is unsatisfiable (the pooled base is stale until the worker syncs), so the cell
+instead holds the worker's **step-0** post-sync echo (still `== base:`) and the `unverified_fork_base`
+refusal **shifts to merge-time**, before merge-back — it shifts, it never lifts.
 
 **Lifecycle — open → consume → digest → delete.** Open the ledger when the first worker
 spawns. The serial integration Verify consumes it (the merge order is read from it, one

--- a/add-method/skill/add/streams.md
+++ b/add-method/skill/add/streams.md
@@ -72,6 +72,12 @@ never drops to zero (`run.md:22`). That floor is correct; do not engineer around
   worktree forked from a stale base forces the worker to recreate the frozen artifacts by hand
   (the v10 dogfood hit exactly this). Before the worker starts, confirm `git -C <worktree>
   rev-parse HEAD` equals the orchestrator's `HEAD`; if it drifted, `git merge` the base in first.
+  On a runner that creates each worktree **at spawn** from a pool (e.g. Claude Code), that pool can hand
+  out a STALE base, so the pre-spawn `rev-parse` evidence cell is unsatisfiable. The `unverified_fork_base`
+  check then **shifts** — it never skips: the worker's **step-0** syncs to base (`git merge` the orchestrator's
+  `HEAD`) and re-echoes `rev-parse HEAD`, which the orchestrator verifies at **merge-time**, before merge-back.
+  The pre-spawn check stays the DEFAULT for fresh-`HEAD`-worktree runners; the merge-time path is the additive
+  ALTERNATIVE for spawn-time runners — never a replacement of the pre-spawn rule.
 - **Lease + timeout** — record which worker holds which task (in the wave ledger, below);
   if a worker dies, release the claim back to READY (re-spawn, do not assume partial work is sound).
 - **Failure isolates** — a worker that hits a STOP-and-escalate (below) blocks only its
@@ -204,7 +210,9 @@ ripgrep otherwise. Design every IO path for failure — timeouts, retries, rollb
 </tools>
 
 <return>   <!-- the worker PROPOSES; the orchestrator RECORDS. A worker never runs add.py. -->
-End with a structured verdict AND write the same into SUMMARY.md in the task dir:
+End with a structured verdict AND write the same into SUMMARY.md in the task dir, then
+**commit SUMMARY.md + deltas.md** in the worktree (uncommitted worktree files survive only by
+harness courtesy — commit them so the serial-integration merge-back carries your report):
 { task, outcome: PASS|RISK-ACCEPTED|HARD-STOP|ESCALATE, evidence: <tests+coverage>,
   residue: [security|concurrency|architecture findings], deltas: [open lessons learned] }.
 Do NOT touch add.py or any shared file — the orchestrator gates on your verdict.

--- a/add-method/skill/add/streams.md
+++ b/add-method/skill/add/streams.md
@@ -120,7 +120,10 @@ base: <orchestrator HEAD at spawn — the sha every fork must equal>
 `git -C <worktree> rev-parse HEAD`, and it must equal `base:`. A tick is not evidence; a row
 you can only fill by running the command is the fresh-worktree-base check EXECUTING — the
 v12-1 lesson (words-exist ≠ method-works) closed structurally. Spawning a worker whose roster
-row lacks that evidence is refused (`unverified_fork_base`).
+row lacks that evidence is refused (`unverified_fork_base`). On a spawn-time pool runner this
+PRE-spawn paste is unsatisfiable (the pooled base is stale until the worker syncs), so the cell
+instead holds the worker's **step-0** post-sync echo (still `== base:`) and the `unverified_fork_base`
+refusal **shifts to merge-time**, before merge-back — it shifts, it never lifts.
 
 **Lifecycle — open → consume → digest → delete.** Open the ledger when the first worker
 spawns. The serial integration Verify consumes it (the merge order is read from it, one

--- a/add-method/src/add_method/_bundled/skill/add/streams.md
+++ b/add-method/src/add_method/_bundled/skill/add/streams.md
@@ -72,6 +72,12 @@ never drops to zero (`run.md:22`). That floor is correct; do not engineer around
   worktree forked from a stale base forces the worker to recreate the frozen artifacts by hand
   (the v10 dogfood hit exactly this). Before the worker starts, confirm `git -C <worktree>
   rev-parse HEAD` equals the orchestrator's `HEAD`; if it drifted, `git merge` the base in first.
+  On a runner that creates each worktree **at spawn** from a pool (e.g. Claude Code), that pool can hand
+  out a STALE base, so the pre-spawn `rev-parse` evidence cell is unsatisfiable. The `unverified_fork_base`
+  check then **shifts** — it never skips: the worker's **step-0** syncs to base (`git merge` the orchestrator's
+  `HEAD`) and re-echoes `rev-parse HEAD`, which the orchestrator verifies at **merge-time**, before merge-back.
+  The pre-spawn check stays the DEFAULT for fresh-`HEAD`-worktree runners; the merge-time path is the additive
+  ALTERNATIVE for spawn-time runners — never a replacement of the pre-spawn rule.
 - **Lease + timeout** — record which worker holds which task (in the wave ledger, below);
   if a worker dies, release the claim back to READY (re-spawn, do not assume partial work is sound).
 - **Failure isolates** — a worker that hits a STOP-and-escalate (below) blocks only its
@@ -204,7 +210,9 @@ ripgrep otherwise. Design every IO path for failure — timeouts, retries, rollb
 </tools>
 
 <return>   <!-- the worker PROPOSES; the orchestrator RECORDS. A worker never runs add.py. -->
-End with a structured verdict AND write the same into SUMMARY.md in the task dir:
+End with a structured verdict AND write the same into SUMMARY.md in the task dir, then
+**commit SUMMARY.md + deltas.md** in the worktree (uncommitted worktree files survive only by
+harness courtesy — commit them so the serial-integration merge-back carries your report):
 { task, outcome: PASS|RISK-ACCEPTED|HARD-STOP|ESCALATE, evidence: <tests+coverage>,
   residue: [security|concurrency|architecture findings], deltas: [open lessons learned] }.
 Do NOT touch add.py or any shared file — the orchestrator gates on your verdict.

--- a/add-method/src/add_method/_bundled/skill/add/streams.md
+++ b/add-method/src/add_method/_bundled/skill/add/streams.md
@@ -120,7 +120,10 @@ base: <orchestrator HEAD at spawn — the sha every fork must equal>
 `git -C <worktree> rev-parse HEAD`, and it must equal `base:`. A tick is not evidence; a row
 you can only fill by running the command is the fresh-worktree-base check EXECUTING — the
 v12-1 lesson (words-exist ≠ method-works) closed structurally. Spawning a worker whose roster
-row lacks that evidence is refused (`unverified_fork_base`).
+row lacks that evidence is refused (`unverified_fork_base`). On a spawn-time pool runner this
+PRE-spawn paste is unsatisfiable (the pooled base is stale until the worker syncs), so the cell
+instead holds the worker's **step-0** post-sync echo (still `== base:`) and the `unverified_fork_base`
+refusal **shifts to merge-time**, before merge-back — it shifts, it never lifts.
 
 **Lifecycle — open → consume → digest → delete.** Open the ledger when the first worker
 spawns. The serial integration Verify consumes it (the merge order is read from it, one

--- a/add-method/tooling/test_streams.py
+++ b/add-method/tooling/test_streams.py
@@ -19,6 +19,7 @@ guarantees live in two places that must not drift apart:
 Run: python3 -m unittest test_streams -v
 """
 import contextlib
+import hashlib
 import io
 import json
 import os
@@ -157,6 +158,58 @@ class SlugRoutingPrecedenceTest(unittest.TestCase):
         st = self._state()
         self.assertEqual(st["tasks"]["b"]["phase"], "specify", "omitted slug must step the active task")
         self.assertEqual(st["tasks"]["a"]["phase"], "ground", "the non-active task must be untouched")
+
+
+# ── wave-protocol-runtime: merge-time fork-base shift + worker commits its report ──
+# v19 wave deltas #7 (merge-time fork-base) + #8 (worker commits SUMMARY.md). streams.md must
+# MIRROR the folded CONVENTIONS runtime-exception: on a spawn-time-worktree runner the pre-spawn
+# rev-parse cell is unsatisfiable, so the `unverified_fork_base` check SHIFTS to worker step-0
+# (sync + re-echo) verified at MERGE-time; and the worker `<return>` contract must COMMIT its
+# SUMMARY.md/deltas.md. Token-presence guards (phrasing free, behaviour locked) + ×3 parity.
+_REPO = _ADD_METHOD.parent
+_STREAMS_TREES = (
+    SKILL / "streams.md",                                                              # canonical
+    _REPO / ".claude" / "skills" / "add" / "streams.md",                               # dogfood
+    _ADD_METHOD / "src" / "add_method" / "_bundled" / "skill" / "add" / "streams.md",  # bundle
+)
+
+
+class WaveProtocolRuntimeTest(unittest.TestCase):
+    """streams.md states the merge-time fork-base shift for spawn-time runners and requires the
+    worker to COMMIT its report — mirroring the folded CONVENTIONS runtime-exception — while the
+    pre-spawn rule is PRESERVED and the ×3 copies stay byte-identical. RED until the build amends
+    streams.md (the 2 new-behaviour tests); the 2 invariant tests stay green throughout."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.low = (SKILL / "streams.md").read_text(encoding="utf-8").lower()
+
+    def test_merge_time_fork_base_shift_stated(self):        # Scenario 1 / Must 1
+        self.assertIn("merge-time", self.low,
+                      "the fork-base check must SHIFT to merge-time on a spawn-time-worktree runner")
+        self.assertIn("step-0", self.low,
+                      "the shift names the worker step-0 (sync-to-base + re-echo)")
+        self.assertIn("unverified_fork_base", self.low,
+                      "the shifted check keeps its refusal code — it shifts, it never skips")
+
+    def test_worker_commits_its_report(self):                # Scenario 2 / Must 2
+        self.assertIn("commit summary.md", self.low,
+                      "the worker <return> contract must require COMMITTING SUMMARY.md, not just writing it")
+        self.assertIn("deltas.md", self.low,
+                      "the worker commits deltas.md alongside SUMMARY.md")
+
+    def test_pre_spawn_rule_preserved(self):                 # Scenario 4 / Must 4 · Reject 1
+        self.assertIn("fresh worktree base", self.low,
+                      "the pre-spawn rule stays the DEFAULT — deleting it is fork_base_rule_weakened")
+        self.assertIn("base == head", self.low,
+                      "the concrete pre-spawn check (worker base == orchestrator HEAD) must remain")
+
+    def test_three_streams_copies_byte_identical(self):      # Scenario 3 / Must 3 · Reject 2
+        present = [p for p in _STREAMS_TREES if p.exists()]
+        self.assertEqual(len(present), 3,
+                         f"all 3 streams.md copies must exist: {[str(p) for p in _STREAMS_TREES]}")
+        hashes = {hashlib.md5(p.read_bytes()).hexdigest() for p in present}
+        self.assertEqual(len(hashes), 1, f"streams.md mirror_drift across the 3 copies: {hashes}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Amends the parallel-streams rubric (`streams.md` ×3) to close **v19 wave deltas #7 + #8**, so the concurrency protocol is satisfiable on a spawn-time-worktree runner and a worker durably persists its own report. Prose-discipline change-request — **no `add.py` change**, `engine_pin` HOLDS.

### Amendment A — merge-time fork-base shift
On a runner that creates each worktree **at spawn** from a pool, the pre-spawn `rev-parse HEAD` evidence cell is unsatisfiable. The `unverified_fork_base` check now **SHIFTS** (it never skips) to worker **step-0** (sync-to-base + re-echo), verified by the orchestrator at **merge-time** before merge-back. The pre-spawn rule stays the **DEFAULT** for fresh-HEAD-worktree runners; the merge-time path is an additive **ALTERNATIVE**, never a replacement.

### Amendment B — worker commits its report
The worker `<return>` contract now requires **COMMITTING** SUMMARY.md + deltas.md in the worktree (uncommitted files survive only by harness courtesy), so the serial-integration merge-back carries the worker's verdict.

## How it was verified (risk:high · autonomy:conservative · human gate)

- Bundle ran §1→§7 with **red/green TDD**: 4 token-presence + ×3-parity guards in `test_streams.py` — 2 new-behaviour tests red before the build, 2 invariant tests (pre-spawn rule preserved + ×3 parity) green throughout.
- Full suite **843 OK on py3.10 AND py3.14** (CI-version run, per the PR #6 lesson).
- Tamper tripwire **CLEAN** — engine's own `_tripwire_divergence` → `[]`; §3 contract + `test_streams.py` byte-unchanged since the tests→build snapshot (the build touched only `streams.md` ×3).
- Earned-green **refute-read**: green is EARNED, not gamed — substantive mechanism prose (WHY the cell is unsatisfiable, the step-0 sync + merge-time verify, "it never skips"), not keyword-stuffing.
- ×3 `streams.md` copies byte-identical (`6ff3a544`).
- No security finding (markdown ×3, no secrets/injection/deps).

## Known residue (disclosed + tracked)

These guards lock the **words** and the **mirror**, not engine **execution** of the merge-time shift (the engine can't observe a worktree pool). Enforcement was explicitly **deferred at the contract freeze** and is logged as the **`engine-merge-base-enforcement`** follow-up task (an `add.py` guard on merge-back), so the gap is tracked, not forgotten.

## Files

- `add-method/skill/add/streams.md` (+ ×2 mirror: `.claude/skills/add/`, `_bundled/skill/add/`) — the two amendments
- `add-method/tooling/test_streams.py` — `WaveProtocolRuntimeTest` (4 guards)
- `.add/tasks/wave-protocol-runtime/TASK.md` — the §1→§7 bundle record (PASS)
- `.add/tasks/engine-merge-base-enforcement/TASK.md` — the deferred-enforcement follow-up
- `.add/state.json` — phase/gate/tripwire transitions
