### PR TITLE
chore(release): 1.3.0 — render-ready UDD foundation + scope gate + driver marker + update command

### DIFF
--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [1.3.0] — 2026-06-13
+
+The render-ready-foundation release: a UI project now gets a lintable design
+foundation the AI drafts from, a build's declared scope is enforced as a gate,
+every command names who drives the next step, and the new update command
+refreshes an installed project in place. All additive; no breaking changes
+(SemVer MINOR).
+
+### Added
+- **Render-ready UDD foundation** — a `DESIGN.md` prose front-door plus a JSON
+  foundation (3-layer design tokens · a component catalog · flat prototype
+  content trees) the AI drafts UI from, wired into 0-setup. `add.py check` now
+  lints the named set under `.add/design/`, going red with a named code on any
+  layer, catalog, tree, or cross-file token-resolution violation — and staying
+  silent when a project has no design set, so non-UI projects are unaffected.
+  A `udd-tokens.md` + `udd-catalog.md` pair documents the compact-DTCG dialect
+  and the json-render render recipe.
+- **The scope gate** — a task's `§5 Scope (may touch)` declaration is frozen
+  into a snapshot at tests→build and enforced at the gate: an out-of-scope touch
+  heals the task back to BUILD for an honest redo (counting against a per-task
+  cap), while erased gate evidence fails closed. Scope creep can no longer ride a
+  green suite into a merge.
+- **Engine next-step footer + the driver marker** — every completing command now
+  prints exactly one engine-sourced `next:` line, and names who owns it:
+  `[you drive]` when the AI proceeds, `[human gate]` at a decision point. The
+  driver marker resolves from one place (autonomy × phase), so the next step and
+  its owner are never ambiguous across a session.
+- **The `update` command** — `npx @pilotspace/add update` (and the
+  `pilotspace-add update` command on PyPI) re-materializes the managed layer
+  (skill · tooling · docs) to the installed package version without a re-install.
+  It never touches your work — `state.json`, `PROJECT.md`, milestones, tasks, and
+  archive are preserved (state is backed up first regardless) — is idempotent via
+  a `.add-version` stamp, and offers `--check` to report version drift without
+  writing.
+
+### Changed
+- The foundation self-improved across these milestones: closing
+  `udd-design-foundation` folded its OBSERVE backlog into the versioned
+  CONVENTIONS/PROJECT foundation (foundation-version 29), sharpening the
+  contract-completeness, adversarial-refute, and engine-pin conventions.
+
 ## [1.2.0] — 2026-06-10
 
 The decision-arc release: the method now narrates the build as one continuous

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ADD (AI-Driven Development) — a minimal, state-tracked Claude Code skill that drives every feature through Specify → Scenarios → Contract → Tests → Build → Verify → Observe. Ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.2.0"
+version = "1.3.0"
 description = "ADD (AI-Driven Development) — install the ADD skill, tooling, and AIDD book into any project"
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/add-method/tooling/test_getting_started_spine.py
+++ b/add-method/tooling/test_getting_started_spine.py
@@ -5,7 +5,7 @@ The doc is the artifact under test: the spine (everything before the
 escape-hatch heading) asks the reader to type ONLY the install command; the
 by-hand seven-phase walk lives in a self-contained escape-hatch appendix.
 These tests pin the v15 restructure; the shipped guards (test_quickstart,
-test_v8_docs, test_onboarding_align, test_release_1_2_0) pin what must
+test_v8_docs, test_onboarding_align, test_release_1_3_0) pin what must
 survive it — together they are the union the rewrite designs to.
 Run: python3 -m unittest test_getting_started_spine -v
 """

--- a/add-method/tooling/test_release_1_3_0.py
+++ b/add-method/tooling/test_release_1_3_0.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.2.0 release readiness (task release-1-2-0).
+"""Red/green tests for the 1.3.0 release readiness (task release-1-3-0).
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.2.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.3.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_2_0 -v
+    python3 -m unittest test_release_1_3_0 -v
 """
 import hashlib
 import json
@@ -21,17 +21,17 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.2.0"
-PRIOR_VERSIONS = ("1.1.0", "1.0.0")     # the changelog must keep its lineage
+VERSION = "1.3.0"
+PRIOR_VERSIONS = ("1.2.0", "1.1.0", "1.0.0")     # the changelog must keep its lineage
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline capabilities the release notes must name (v18→v23 + flag-first)
-FEATURE_ANCHORS = ("decision arc", "graduate", "WAVE.md", "verify-deepen",
-                   "unflagged_freeze")
+# the headline capabilities the release notes must name (the post-1.2.0 milestones
+# + the update command merged for 1.3.0)
+FEATURE_ANCHORS = ("UDD foundation", "scope gate", "driver marker", "update command")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_2_0_entry(self):
+    def test_changelog_has_1_3_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -40,7 +40,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.2.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.3.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -64,7 +64,7 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    def test_versions_agree_at_1_2_0(self):
+    def test_versions_agree_at_1_3_0(self):
         pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
         py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
                        (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)

--- a/add-method/tooling/test_shared_engine_pin.py
+++ b/add-method/tooling/test_shared_engine_pin.py
@@ -28,7 +28,7 @@ ENGINE_PATHS = (
 IMPORTERS = (
     "test_getting_started_spine.py",
     "test_installer_handoff.py",
-    "test_release_1_2_0.py",
+    "test_release_1_3_0.py",
     "test_review_checklist.py",
     "test_skill_onramp.py",
 )

--- a/add-method/tooling/test_ubiquitous_language.py
+++ b/add-method/tooling/test_ubiquitous_language.py
@@ -33,7 +33,7 @@ TERMS = [
     dict(slug="one-approval-front", ban=r"\b(one[- ]approval|approval|the|whole|task's) front\b",
          old_keep="one-approval front", idiom="one-approval front", keep="specification bundle", token=None),
     # (?!-audit): `seam-audit` is a Group C machine token — CI job/workflow name,
-    # pinned by test_audit_ci + test_release_1_2_0 (contract machine-layer rule).
+    # pinned by test_audit_ci + test_release_1_3_0 (contract machine-layer rule).
     dict(slug="seam", ban=r"\bseams?\b(?!-audit)",
          old_keep="seam", idiom="seam", keep="decision point", token=None),
     dict(slug="fold", ban=r"\bfold(s|ed|ing)?\b",


### PR DESCRIPTION
## Release 1.3.0 — render-ready UDD foundation + scope gate + driver marker + update command

Bumps the 3 version sources in lockstep (`package.json` · `pyproject.toml` · `add_method.__version__`) **1.2.0 → 1.3.0**, migrates the forward-pinned release-readiness test, and documents the release. **The engine is untouched.**

### What ships in 1.3.0 (all additive — SemVer MINOR)
Everything merged since `v1.2.0`:
- **Render-ready UDD foundation** (`udd-design-foundation`, PR #11) — a `DESIGN.md` prose front-door + a JSON foundation (token layers · component catalog · prototype content trees); `add.py check` lints the named set under `.add/design/` with named reds on layer/catalog/tree/cross-file violations, silent when absent.
- **The scope gate** (`build-scope-lock`) — a task's `§5 Scope (may touch)` is frozen at tests→build and enforced at the gate; out-of-scope touches heal back to BUILD.
- **Engine next-step footer + driver marker** (`next-step-seams`) — one engine-sourced `next:` line per completing command, naming the driver (`[you drive]` / `[human gate]`).
- **The `update` command** (PR #5) — `npx @pilotspace/add update` / `pilotspace-add update` re-materializes the managed layer without a re-install, preserving project state.

### Release machinery
- `CHANGELOG.md` — new `## [1.3.0]` entry; the 1.2.0/1.1.0/1.0.0 lineage is preserved.
- `test_release_1_2_0.py → test_release_1_3_0.py` — `VERSION` / `PRIOR_VERSIONS` / `FEATURE_ANCHORS` re-aimed; the **engine-untouched** invariant is kept.
- `test_shared_engine_pin.py` — its `IMPORTERS` list re-pointed to the renamed release test.

### Evidence
- `test_release_1_3_0` **8/8**; full tooling suite **1006 OK** on python **3.14 + 3.10**.
- Engine unchanged: `add.py` ×3 still `== engine_pin.ENGINE_MD5`.
- The 3 version sources agree at `1.3.0` (the `publish.yml` guard passes).

### Publish
The **git tag `v1.3.0` is the human-gated publish trigger** — it is intentionally **not** pushed here. After merge, tag `v1.3.0` to release to npm + PyPI via `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
