### PR TITLE
docs(method): reflect 1.3.0 in the package README + GETTING-STARTED

### DIFF
--- a/add-method/GETTING-STARTED.md
+++ b/add-method/GETTING-STARTED.md
@@ -343,6 +343,10 @@ You just ran the method; now read *why* it's shaped this way:
 - Each step in depth — `.add/docs/03-step-1-specify.md` through `.add/docs/09-the-loop.md`
 - Operating it on a team — `.add/docs/11-governance.md`, `.add/docs/12-roles.md`
 - A fully worked example — `.add/docs/appendix-d-worked-example.md`
+- Building UI? The render-ready UDD foundation — `.add/DESIGN.md` is the prose
+  front-door to a lintable design system (`.add/design/` tokens · catalog ·
+  prototypes) the AI drafts from; `add.py check` lints it (delete `DESIGN.md` if
+  your project has no UI)
 
 The rule to remember: **build the right thing (direction), prove it's right
 (verification), and let the AI do the building in between.**

--- a/add-method/README.md
+++ b/add-method/README.md
@@ -46,6 +46,12 @@ pilotspace-add init
 No flags needed — the project name is inferred from your folder and the stage
 defaults to `prototype` (pass `--name "My App" --stage mvp` to choose up front).
 
+**Already installed?** Refresh to the latest without a re-install —
+`npx @pilotspace/add@latest update` (or `pipx run pilotspace-add update`)
+re-materializes the skill, tooling, and book while leaving your project work
+(`.add/state.json`, `PROJECT.md`, milestones, tasks) untouched; add `--check` to
+see whether a project is behind the installed package.
+
 **New here?** Follow the [10-minute Quickstart](./GETTING-STARTED.md) — it walks
 your first feature end to end.
 
@@ -56,6 +62,13 @@ This installs:
 | `.claude/skills/add/` | the `add` skill Claude loads (thin router + per-phase guides) |
 | `.add/tooling/add.py` | scaffolder + state tracker (Python, stdlib only) |
 | `.add/docs/` | the AIDD book — the method rationale |
+| `.add/DESIGN.md` | (UI projects) the prose front-door to the **render-ready UDD foundation** — delete it if your project has no UI |
+
+On a UI project, UDD gives the AI a frozen design ground to draft from: `DESIGN.md`
+plus a lintable JSON foundation under `.add/design/` (design tokens · component
+catalog · prototype trees). `add.py check` lints that foundation, going red with a
+named code on any layer, catalog, tree, or cross-file violation — and staying
+silent when a project has no design set.
 
 Project state (`.add/state.json`) and the living-documentation files (`CONVENTIONS.md`,
 `GLOSSARY.md`, `MODEL_REGISTRY.md`, `dependencies.allowlist`) are *not* created


### PR DESCRIPTION
## What

Brings the npm/PyPI **package** docs current with 1.3.0 (they predated the feature work; the package CHANGELOG already has the entry).

- **README → Install**: the new `update` verb (`npx @pilotspace/add@latest update` / pip form) — refresh the managed layer without a re-install, preserving project state; `--check` reports drift.
- **README → "This installs"**: a `.add/DESIGN.md` row + a short note on the **render-ready UDD foundation** (`DESIGN.md` + a lintable JSON foundation under `.add/design/` that `add.py check` lints, silent when absent).
- **GETTING-STARTED → "Where to read more"**: a UDD-foundation pointer for UI projects.

## Scope
Package docs only (per the chosen scope) — the book/repo-root track is left untouched.

## Evidence
Docs-only; engine untouched. Wording-lint clean (avoided the banned "the front" idiom). Full tooling suite **1006 OK on python 3.14 + 3.10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)