### PR TITLE
docs: document the `update` verb — refresh ADD in place without re-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ both distribution channels: `@pilotspace/add` (npm) and `pilotspace-add` (PyPI).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- **`update` — refresh a project without re-installing.** Both launchers gained an
+  `update` verb that re-materializes the managed layer (the `add` skill,
+  `.add/tooling`, `.add/docs`) to the installed package version. It clean-replaces
+  each tree (so a file removed upstream leaves no orphan — the prior `init --force`
+  merge behaviour) and never touches user work: `state.json`, `PROJECT.md`,
+  milestones, tasks, and archive are preserved, with state backed up first. It is
+  idempotent, records a `.add/.add-version` stamp, and `update --check` reports
+  drift read-only. One-shot: `npx @pilotspace/add@latest update` ·
+  `pipx run pilotspace-add update`. Carries an empty forward-only state-migration
+  registry so the next schema change ships as an in-place update.
 
 ## [1.1.0] — 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ npx @pilotspace/add init
 pip install pilotspace-add && pilotspace-add init
 ```
 
+Already installed? Update in place with `npx @pilotspace/add@latest update` (npm)
+or `pipx run pilotspace-add update` (pip) — it refreshes the skill, tooling, and
+book and leaves your project state untouched (`update --check` reports drift).
+
 ### 2 · Spawn your first feature — talk to the agent
 
 In Claude Code, run **`/add`** and say what you want to build:

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [Unreleased]
+
+### Added
+- **`update` — refresh a project without re-installing.** The launchers
+  (`@pilotspace/add` on npm, `pilotspace-add` on PyPI) gained an `update` verb
+  that re-materializes the managed layer (the `add` skill, `.add/tooling`,
+  `.add/docs`) to the installed package version. It **clean-replaces** each tree,
+  so a file removed upstream no longer lingers as an orphan (the prior
+  `init --force` merge behaviour), and it never touches your work — `state.json`,
+  `PROJECT.md`, milestones, tasks, and archive are preserved (state is backed up
+  to `pre-update-state.bak.json` first regardless). It is idempotent (the same
+  version twice is a no-op), records a `.add/.add-version` stamp, and
+  `update --check` reports version drift read-only. One-shot per ecosystem:
+  `npx @pilotspace/add@latest update` · `pipx run pilotspace-add update`.
+- **State-migration framework** — `update` carries a forward-only, idempotent
+  migration registry (empty today) so the next state-schema change ships as an
+  in-place update, never a re-install.
+
 ## [1.2.0] — 2026-06-10
 
 The decision-arc release: the method now narrates the build as one continuous

--- a/add-method/GETTING-STARTED.md
+++ b/add-method/GETTING-STARTED.md
@@ -63,6 +63,28 @@ handoff — from here on it's conversation, not terminal commands.
 > Why stages exist: the steps never change, only how *deeply* you run them.
 > See `.add/docs/10-setup-and-stages.md`.
 
+### Updating to a newer ADD — no re-install
+
+When a new ADD version ships, refresh a project in two steps: bump the package
+(your package manager), then re-materialize it into the project with `update`:
+
+```bash
+# npm — one shot (npx fetches latest, then re-materializes into this project):
+npx @pilotspace/add@latest update
+
+# pip — one shot via pipx (the npx analog: fetch latest + run):
+pipx run pilotspace-add update
+
+# …or plain pip, in two steps:
+pip install -U pilotspace-add && pilotspace-add update
+```
+
+`update` clean-replaces the managed layer (`skill` · `.add/tooling` · `.add/docs`)
+and **never touches your work** — `state.json`, `PROJECT.md`, milestones, tasks and
+archive are left exactly as they were (it backs `state.json` up first regardless). It
+is idempotent (same version twice is a no-op) and writes a `.add/.add-version` stamp.
+Run `… update --check` to see whether a project is behind the installed package.
+
 ---
 
 ## 2 · Your first feature — talk to the agent

--- a/add-method/README.md
+++ b/add-method/README.md
@@ -46,6 +46,17 @@ pilotspace-add init
 No flags needed — the project name is inferred from your folder and the stage
 defaults to `prototype` (pass `--name "My App" --stage mvp` to choose up front).
 
+**Already installed? Update in place — no re-install:**
+
+```bash
+npx @pilotspace/add@latest update      # npm (one shot)
+pipx run pilotspace-add update         # pip (one shot)
+```
+
+`update` refreshes the skill, tooling, and book to the latest version and leaves
+your project state (`state.json`, `PROJECT.md`, milestones, tasks) untouched;
+`update --check` reports whether a project is behind.
+
 **New here?** Follow the [10-minute Quickstart](./GETTING-STARTED.md) — it walks
 your first feature end to end.
 


### PR DESCRIPTION
## What

Documents how to **update an installed ADD project in place** — across CHANGELOG, README (root + shipped), and GETTING-STARTED:

- `npx @pilotspace/add@latest update` (npm, one shot)
- `pipx run pilotspace-add update` (pip, the `npx` analog)
- `… update --check` to see if a project is behind

The docs explain that `update` clean-replaces the managed layer (skill · `.add/tooling` · `.add/docs`) — so a file removed upstream leaves no orphan — and **never touches user work** (`state.json`, `PROJECT.md`, milestones, tasks, archive), backing up state first.

## Scope & dependency

This is the **documentation half**. The `update` verb's implementation (both launchers `bin/cli.js` + `_installer.py`/`_cli.py`, the `.add-version` stamp, the migration framework, and `test_update.py`) lives in the companion branch **`feat/add-update`**. 

**Please merge this with — or after — the feature branch**, so the docs never describe a command absent from `main`. Happy to fold the two into a single PR instead if you prefer; this split was requested to keep the docs reviewable on their own.

## Notes

- **No version bump** — the entries sit under `## [Unreleased]` (the release tests pin `1.2.0`); whoever cuts the next release rolls them into the version number.
- `pipx run` caches for a few days by default, so its "always latest" is slightly softer than `npx`'s — fine for an update command, called out so it's deliberate.