### PR TITLE
feat: publish ADD to a Claude Code marketplace (add@add-method)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "add-method",
+  "description": "ADD (AI-Driven Development) — the methodology skill, installable straight into Claude Code.",
+  "owner": {
+    "name": "pilotspace",
+    "email": "tindang.ht97@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "add",
+      "source": "./add-method",
+      "description": "Drives every feature through Specify → Scenarios → Contract → Tests → Build → Verify → Observe, with red/green TDD built in. On first run it materializes the engine and the AIDD book into your project — self-contained and portable, exactly like an npm or pip install, no extra tooling needed.",
+      "keywords": [
+        "ai-driven-development",
+        "aidd",
+        "tdd",
+        "spec-driven",
+        "methodology"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -25,6 +25,23 @@ you are so context never rots across sessions.
 
 ## Always start here (orient — do not skip)
 
+The engine lives at `.add/tooling/add.py` and the book at `.add/docs/`. Make sure the
+engine is in this project before anything else:
+
+- If `.add/tooling/add.py` exists, go straight to `status` below.
+- If it does NOT exist, ADD was installed as a Claude Code plugin — the engine and the
+  book ride in the plugin, not the project. Materialize them into the project once, before
+  any other step:
+
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill
+  ```
+
+  That drops `.add/tooling/` (the engine) and `.add/docs/` (the book) here, so the engine,
+  the book, and the agent-agnostic guideline block in `CLAUDE.md` all work for every agent
+  and for a human at the shell — exactly like an npm or pip install. The skill itself stays
+  in the plugin, so nothing is duplicated.
+
 Run the tool to find the resume point instead of re-reading the repo:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ or
 pip install pilotspace-add && pilotspace-add init
 ```
 
+or, on **Claude Code**, install the skill straight from the marketplace — no npm or pip needed:
+
+```text
+/plugin marketplace add pilotspace/ADD
+/plugin install add@add-method
+```
+
+Open `/add` and say what you want to build. On first run the skill materializes the engine
+and the AIDD book into your project (`.add/tooling/` + `.add/docs/`) straight from the plugin,
+then scaffolds `.add/`. The result is self-contained and portable — identical to an npm or pip
+install, so every agent and a human at the shell can run `python3 .add/tooling/add.py`.
+
 ### 2 · Spawn your first feature — talk to the agent
 
 In Claude Code, run **`/add`** and say what you want to build:

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "add",
+  "displayName": "ADD — AI-Driven Development",
+  "version": "1.6.0",
+  "description": "ADD (AI-Driven Development) — a minimal, state-tracked Claude Code skill that drives every feature through Specify → Scenarios → Contract → Tests → Build → Verify → Observe. Ships the AIDD book as its trust layer.",
+  "author": {
+    "name": "Tin Dang",
+    "email": "tindang.ht97@gmail.com"
+  },
+  "homepage": "https://github.com/pilotspace/ADD#readme",
+  "repository": "https://github.com/pilotspace/ADD",
+  "license": "MIT",
+  "keywords": [
+    "ai-driven-development",
+    "add",
+    "aidd",
+    "claude-code",
+    "skill",
+    "tdd",
+    "spec-driven",
+    "agent",
+    "methodology"
+  ],
+  "skills": "./skill/"
+}

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [Unreleased]
+
+### Added
+- **Claude Code plugin distribution** — ADD is now installable straight from a
+  marketplace, with no npm or pip step: `/plugin marketplace add pilotspace/ADD`
+  then `/plugin install add@add-method`. A repo-root `.claude-plugin/marketplace.json`
+  lists the `add` plugin (`add-method/.claude-plugin/plugin.json`), which bundles the
+  skill, the engine, and the AIDD book. On first run the skill materializes the engine
+  and book INTO the project (`node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill`)
+  so `.add/tooling/add.py`, `.add/docs/`, and the agent-agnostic guideline block all
+  work for every agent and a human at the shell — a self-contained, portable result
+  identical to an npm/pip install. The skill stays in the plugin (no duplicate).
+- **`cli.js init --no-skill`** — drops the engine + book only, leaving skill delivery to
+  the plugin. Used by the plugin bootstrap above; npm/pip installs are unchanged.
+- **Plugin boundaries disclosure** (README "What this plugin does, writes, and runs") —
+  states plainly that the plugin is user-initiated, runs only its bundled engine, writes
+  only under the project's `.add/`, and makes a single advisory, opt-out (`ADD_NO_UPDATE_CHECK`)
+  update check — so a marketplace safety review can confirm the boundaries at a glance.
+  Guarded by `tooling/test_plugin_manifest.py` (manifests valid, version tracks
+  `package.json`, the bootstrap line can't be dropped, and `--no-skill` lands the engine
+  and book but no duplicate skill).
+
 ## [1.6.0] — 2026-06-16
 
 The releasing release: shipping a versioned cut is now a first-class **5th ADD

--- a/add-method/README.md
+++ b/add-method/README.md
@@ -30,7 +30,7 @@ across sessions (context rot). ADD fixes both:
 
 ## Install
 
-Pick your ecosystem — both install the same skill, tooling, and book:
+Pick your ecosystem — all three install the same skill, tooling, and book:
 
 ```bash
 # Node / npm
@@ -42,6 +42,17 @@ npx @pilotspace/add init
 pip install pilotspace-add
 pilotspace-add init
 ```
+
+```text
+# Claude Code plugin — no npm or pip needed
+/plugin marketplace add pilotspace/ADD
+/plugin install add@add-method
+```
+
+The plugin carries the engine and the book. On first `/add`, the skill materializes them
+into the project (`node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill`) and scaffolds
+`.add/` — a self-contained, portable result identical to the npm/pip flow. The skill stays
+in the plugin, so nothing is duplicated.
 
 No flags needed — the project name is inferred from your folder and the stage
 defaults to `prototype` (pass `--name "My App" --stage mvp` to choose up front).
@@ -74,6 +85,28 @@ Project state (`.add/state.json`) and the living-documentation files (`CONVENTIO
 `GLOSSARY.md`, `MODEL_REGISTRY.md`, `dependencies.allowlist`, `SOUL.md` — the AI's
 human-owned voice) are *not* created here — the installer drops files only;
 initialisation is the agent's first move when you run `/add`.
+
+## What this plugin does, writes, and runs (boundaries)
+
+ADD is a development methodology, so by design it works *inside your project* — here is
+exactly what that means, so there are no surprises:
+
+- **Runs only when you ask.** Nothing executes on install. The skill acts when you run
+  `/add` (or another agent follows the guideline block). It is user-initiated, every time.
+- **What it runs:** the bundled engine and bootstrapper only — `node bin/cli.js` and
+  `python3 .add/tooling/add.py`. No downloaded or remote code is executed; everything it
+  runs ships in the package.
+- **What it writes:** files under your project's `.add/` (state, milestones, tasks, the
+  book) and the managed guideline block in `CLAUDE.md` / `AGENTS.md`. On a plugin install
+  it also materializes the engine + book into `.add/` on first run. It writes nowhere
+  outside the project working directory; it never touches files above the project root.
+- **Network:** one optional, advisory update check. On `status` / `guide` the engine may
+  make a single HTTPS GET to `https://registry.npmjs.org/@pilotspace/add/latest` to see if
+  a newer version exists — at most once per 24h (cached in `.update-cache.json`), 1.5s
+  timeout, fail-open (offline ⇒ silent no-op). It only writes a one-line note to **stderr**
+  and never changes a command's output or exit code. Disable it entirely with
+  `ADD_NO_UPDATE_CHECK=1`. No other network access, no telemetry, no analytics.
+- **No secrets, no credentials, no privileged access.** Pure local file orchestration.
 
 ## Use it
 

--- a/add-method/bin/cli.js
+++ b/add-method/bin/cli.js
@@ -32,11 +32,15 @@ function parseArgs(argv) {
   // stage/name stay null unless EXPLICITLY passed — the engine's own `init`
   // defaults the stage and infers the name from the folder, so the manual-init
   // hint only echoes flags the user actually chose (shortest true command).
-  const args = { _: [], force: false, check: false, stage: null, name: null };
+  const args = { _: [], force: false, check: false, noSkill: false, stage: null, name: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--force") args.force = true;
     else if (a === "--check") args.check = true;
+    // --no-skill: drop the engine + book ONLY, not the skill. The Claude Code plugin
+    // already provides the `add` skill, so a plugin bootstrap uses this to materialize
+    // .add/tooling/ + .add/docs/ into the project without a duplicate .claude/skills/add.
+    else if (a === "--no-skill") args.noSkill = true;
     else if (a === "--stage" || a === "--name") {
       const v = argv[++i];
       // fail loudly on a trailing/abutting flag — never silently drop a value
@@ -72,13 +76,15 @@ function cmdInit(args) {
   if (!fs.existsSync(target)) fail("target directory does not exist: " + target);
   log("Installing ADD into " + target);
 
-  // 1. skill -> .claude/skills/add
-  copyDir(
-    path.join(PKG_ROOT, "skill", "add"),
-    path.join(target, ".claude", "skills", "add"),
-    { skipIfExists: !args.force, cleanReplace: args.force }
-  );
-  log("  ✓ skill      -> .claude/skills/add/");
+  // 1. skill -> .claude/skills/add  (skipped under --no-skill: the plugin provides it)
+  if (!args.noSkill) {
+    copyDir(
+      path.join(PKG_ROOT, "skill", "add"),
+      path.join(target, ".claude", "skills", "add"),
+      { skipIfExists: !args.force, cleanReplace: args.force }
+    );
+    log("  ✓ skill      -> .claude/skills/add/");
+  }
 
   // 2. tooling -> .add/tooling  (exclude tests from the installed copy)
   const toolingDest = path.join(target, ".add", "tooling");
@@ -101,7 +107,8 @@ function cmdInit(args) {
   // NO step 4: the installer DROPS FILES ONLY. Initialisation is deferred to the AI
   // (via `/add`) or a CLI user — a pre-run plain `add.py init` would grandfather-lock
   // the v12 lock-down gate before `/add` runs (see file header). So no Python is run here.
-  log("\nDone. The `add` skill + tooling are installed (no project state yet — that's intentional).");
+  log("\nDone. " + (args.noSkill ? "The engine + book are" : "The `add` skill + tooling are") +
+      " installed (no project state yet — that's intentional).");
   log("Next:  open your AI Agent CLI (like Claude Code, Codex, etc.), then run `/add`, and say what you want to build — the agent");
   log("       sets up the foundation, sizes it into a milestone, and drives the build with you;");
   log("       you sign off once, at the lock-down.");
@@ -197,8 +204,9 @@ function main() {
       break;
     case "help":
     case "--help":
-      log("usage: npx @pilotspace/add <init|update> [targetDir] [--force] [--check]");
+      log("usage: npx @pilotspace/add <init|update> [targetDir] [--force] [--check] [--no-skill]");
       log("  init    install the ADD skill + tooling + book into a project");
+      log("          (--no-skill drops the engine + book only — used by the Claude Code plugin)");
       log("  update  re-materialize skill/tooling/docs to this package version (preserves your state)");
       break;
     default:

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -25,6 +25,23 @@ you are so context never rots across sessions.
 
 ## Always start here (orient — do not skip)
 
+The engine lives at `.add/tooling/add.py` and the book at `.add/docs/`. Make sure the
+engine is in this project before anything else:
+
+- If `.add/tooling/add.py` exists, go straight to `status` below.
+- If it does NOT exist, ADD was installed as a Claude Code plugin — the engine and the
+  book ride in the plugin, not the project. Materialize them into the project once, before
+  any other step:
+
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill
+  ```
+
+  That drops `.add/tooling/` (the engine) and `.add/docs/` (the book) here, so the engine,
+  the book, and the agent-agnostic guideline block in `CLAUDE.md` all work for every agent
+  and for a human at the shell — exactly like an npm or pip install. The skill itself stays
+  in the plugin, so nothing is duplicated.
+
 Run the tool to find the resume point instead of re-reading the repo:
 
 ```bash

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -25,6 +25,23 @@ you are so context never rots across sessions.
 
 ## Always start here (orient — do not skip)
 
+The engine lives at `.add/tooling/add.py` and the book at `.add/docs/`. Make sure the
+engine is in this project before anything else:
+
+- If `.add/tooling/add.py` exists, go straight to `status` below.
+- If it does NOT exist, ADD was installed as a Claude Code plugin — the engine and the
+  book ride in the plugin, not the project. Materialize them into the project once, before
+  any other step:
+
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill
+  ```
+
+  That drops `.add/tooling/` (the engine) and `.add/docs/` (the book) here, so the engine,
+  the book, and the agent-agnostic guideline block in `CLAUDE.md` all work for every agent
+  and for a human at the shell — exactly like an npm or pip install. The skill itself stays
+  in the plugin, so nothing is duplicated.
+
 Run the tool to find the resume point instead of re-reading the repo:
 
 ```bash

--- a/add-method/tooling/test_plugin_manifest.py
+++ b/add-method/tooling/test_plugin_manifest.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Plugin-manifest guard: the Claude Code marketplace + plugin manifests must stay
+valid, in sync with the npm package, and honour the contract the `add` skill's
+engine/book resolution rule promises.
+
+ADD ships two ways now:
+  - npm/pip  -> the CLI drops .add/tooling/add.py + .add/docs/ into the project.
+  - plugin   -> `/plugin install add@add-method`. Nothing is dropped; the skill
+                reaches the engine and the book at ${CLAUDE_PLUGIN_ROOT}/... .
+
+For the plugin path to work, three things must hold and never drift:
+  1. .claude-plugin/marketplace.json (repo root) lists the `add` plugin and points
+     at ./add-method, where a plugin.json actually lives.
+  2. add-method/.claude-plugin/plugin.json is well-formed, names skills ./skill/,
+     and carries the SAME version as package.json (one source of truth).
+  3. The files the SKILL.md resolution rule promises under ${CLAUDE_PLUGIN_ROOT}
+     — tooling/add.py, tooling/templates/, docs/, skill/add/SKILL.md — exist, and
+     the rule itself is present in the skill (so it cannot be silently removed).
+
+Run: python3 -m unittest test_plugin_manifest -v
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+_TOOLING = Path(__file__).resolve().parent
+_ADD_METHOD = _TOOLING.parent              # add-method/  (== the plugin root)
+_REPO_ROOT = _ADD_METHOD.parent            # repo root    (== the marketplace root)
+
+_MARKETPLACE = _REPO_ROOT / ".claude-plugin" / "marketplace.json"
+_PLUGIN = _ADD_METHOD / ".claude-plugin" / "plugin.json"
+_PACKAGE_JSON = _ADD_METHOD / "package.json"
+
+
+def _load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+class MarketplaceManifest(unittest.TestCase):
+    def test_exists_and_is_valid_json(self) -> None:
+        self.assertTrue(_MARKETPLACE.is_file(), f"missing {_MARKETPLACE}")
+        data = _load(_MARKETPLACE)
+        self.assertIsInstance(data, dict)
+
+    def test_required_fields(self) -> None:
+        data = _load(_MARKETPLACE)
+        self.assertTrue(data.get("name"), "marketplace needs a name")
+        self.assertNotIn(" ", data["name"], "marketplace name is the @<name> handle — no spaces")
+        self.assertIsInstance(data.get("owner"), dict)
+        self.assertTrue(data["owner"].get("name"), "owner needs a name")
+        self.assertIsInstance(data.get("plugins"), list)
+        self.assertTrue(data["plugins"], "marketplace lists no plugins")
+
+    def test_add_plugin_source_resolves_to_a_plugin_dir(self) -> None:
+        data = _load(_MARKETPLACE)
+        entry = next((p for p in data["plugins"] if p.get("name") == "add"), None)
+        self.assertIsNotNone(entry, "marketplace must list the `add` plugin")
+        src = entry["source"]
+        self.assertIsInstance(src, str, "source is the same-repo relative path form")
+        self.assertTrue(src.startswith("./"), "relative source must start with ./")
+        plugin_dir = (_REPO_ROOT / src).resolve()
+        self.assertEqual(plugin_dir, _ADD_METHOD, "the add plugin lives in ./add-method")
+        self.assertTrue((plugin_dir / ".claude-plugin" / "plugin.json").is_file(),
+                        "source dir must contain .claude-plugin/plugin.json")
+
+
+class PluginManifest(unittest.TestCase):
+    def test_exists_and_is_valid_json(self) -> None:
+        self.assertTrue(_PLUGIN.is_file(), f"missing {_PLUGIN}")
+        self.assertIsInstance(_load(_PLUGIN), dict)
+
+    def test_name_and_skills_path(self) -> None:
+        data = _load(_PLUGIN)
+        self.assertEqual(data.get("name"), "add", "plugin name drives /add:<skill>")
+        self.assertEqual(data.get("skills"), "./skill/", "skills dir holds add/SKILL.md")
+        skill_md = (_ADD_METHOD / "skill" / "add" / "SKILL.md")
+        self.assertTrue(skill_md.is_file(), "skills path must resolve to add/SKILL.md")
+
+    def test_version_tracks_the_npm_package(self) -> None:
+        # one source of truth — a bumped package.json must bump the plugin too.
+        self.assertEqual(_load(_PLUGIN).get("version"),
+                         _load(_PACKAGE_JSON).get("version"),
+                         "plugin.json version must match package.json version")
+
+
+class PluginRootContract(unittest.TestCase):
+    """A plugin install must be able to materialize the engine + book into the project."""
+
+    def test_bootstrapper_and_payload_present(self) -> None:
+        # the skill bootstraps via `node ${CLAUDE_PLUGIN_ROOT}/bin/cli.js init --no-skill`,
+        # which copies these into the project — so all three must ride in the plugin.
+        self.assertTrue((_ADD_METHOD / "bin" / "cli.js").is_file(),
+                        "${CLAUDE_PLUGIN_ROOT}/bin/cli.js (the bootstrapper) must exist")
+        self.assertTrue((_ADD_METHOD / "tooling" / "add.py").is_file(),
+                        "the engine the bootstrap drops must exist")
+        self.assertTrue((_ADD_METHOD / "tooling" / "templates").is_dir(),
+                        "the engine needs its co-located templates/ dir")
+
+    def test_book_present(self) -> None:
+        docs = _ADD_METHOD / "docs"
+        self.assertTrue(docs.is_dir(), "the book the bootstrap drops must exist")
+        self.assertTrue(list(docs.glob("0*-*.md")), "the book must ship its chapters")
+
+    def test_skill_carries_the_bootstrap(self) -> None:
+        # the bootstrap line is the ONLY thing that makes a plugin install reach the
+        # engine — it must never be dropped from the skill.
+        text = (_ADD_METHOD / "skill" / "add" / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("${CLAUDE_PLUGIN_ROOT}/bin/cli.js", text)
+        self.assertIn("--no-skill", text)
+
+
+class BootstrapDropsEngineAndBookOnly(unittest.TestCase):
+    """`cli.js init --no-skill` is what a plugin runs on first use: it must drop the
+    engine + book into the project but NOT a duplicate skill (the plugin owns the skill)."""
+
+    def test_no_skill_drops_engine_and_book_but_not_skill(self) -> None:
+        import shutil
+        import subprocess
+        import tempfile
+
+        if shutil.which("node") is None:
+            self.skipTest("node is not available")
+        cli = _ADD_METHOD / "bin" / "cli.js"
+        with tempfile.TemporaryDirectory() as d:
+            proc = subprocess.run(["node", str(cli), "init", "--no-skill", d],
+                                  capture_output=True, text=True)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            target = Path(d)
+            self.assertTrue((target / ".add" / "tooling" / "add.py").is_file(),
+                            "engine must land in .add/tooling/")
+            self.assertTrue((target / ".add" / "docs").is_dir(),
+                            "book must land in .add/docs/")
+            self.assertFalse((target / ".claude" / "skills" / "add").exists(),
+                             "--no-skill must NOT drop a duplicate skill (plugin owns it)")
+            # runtime-only: no test files leak into the project copy
+            self.assertEqual(list((target / ".add" / "tooling").glob("test_*.py")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Makes ADD installable as a **Claude Code plugin** from a marketplace, alongside npm and pip:

```text
/plugin marketplace add pilotspace/ADD
/plugin install add@add-method
```

## How

- **`.claude-plugin/marketplace.json`** (repo root) lists the `add` plugin, source `./add-method`.
- **`add-method/.claude-plugin/plugin.json`** is the manifest (`name: add`, `skills: ./skill/`, version tracks `package.json`). `add-method/` already is the publishable package, so it doubles as the plugin root.
- **First-run bootstrap — materialize the engine + book into the project.** ADD is agent-agnostic by design: `add.py init` writes a guideline block into the project's `CLAUDE.md`/`AGENTS.md` that hardcodes `python3 .add/tooling/add.py` and "the book is in `.add/docs/`". Those are **project files**, so they can't reference `${CLAUDE_PLUGIN_ROOT}`. A plugin that served the engine from its cache would break every other agent (Gemini, Codex), break a human at the shell, and make the project non-portable.

  So on first run, when `.add/tooling/add.py` is absent, the skill runs:

  ```bash
  node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill
  ```

  This drops `.add/tooling/` (engine) and `.add/docs/` (book) into the project — a **self-contained, portable result identical to an npm/pip install**. The new `cli.js --no-skill` flag omits the skill (the plugin already provides it), so there is no duplicate `.claude/skills/add`.

## Why this shape (addressing the obvious alternative)

An earlier cut tried to serve the engine/book from `${CLAUDE_PLUGIN_ROOT}` and drop nothing. That is wrong for ADD: the engine + book are project-local artifacts the guideline contract depends on. Materializing them keeps "the artifacts survive" intact and makes a plugin install behave exactly like npm/pip for every agent and for `git`.

## Verification

- `claude plugin validate ./add-method` and `claude plugin validate .` pass (`--strict` too).
- **End-to-end from the installed plugin cache:** bootstrap drops the engine + book, `add.py init` writes state, the `CLAUDE.md` guideline block points at the local `.add/tooling/add.py`, and that engine runs with the plugin uninstalled. `--no-skill` lands the engine + book but no duplicate skill, tests stripped.
- New guard `tooling/test_plugin_manifest.py` (10 tests): manifests valid + in sync, version tracks `package.json`, the bootstrap line can't be dropped, and `cli.js --no-skill` is behaviorally tested.
- Full suite: 1165 tests; the only non-passing are the two pre-existing environmental cases (`test_packaging` wheel build, `test_ship_clean` npm-pack guard), both reproduced unchanged on `main`.

## Docs

Both READMEs gain a third install option; `CHANGELOG.md` gets an `[Unreleased] → Added` entry.
