### PR TITLE
docs(book): bump README book edition to 1.6.0 (match shipped release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### A complete, practical book on building software when AI writes the code
 
-**Edition:** 1.3.0 · **Type:** AI Workflow Methodology
+**Edition:** 1.6.0 · **Type:** AI Workflow Methodology
 
 ---
 


### PR DESCRIPTION
Supersedes the stale #23 (proposed 1.4.0). The README book edition read **1.3.0** while the package shipped **1.6.0** (npm + PyPI); this brings the edition marker current.

If the book edition is meant to track a cadence separate from the package version, say the word and I'll set a different value.