### PR TITLE
chore(release): cut 1.7.0 — the installer & onboarding release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ one source of truth, updated on every version tag:
 
 **→ [`add-method/CHANGELOG.md`](./add-method/CHANGELOG.md)**
 
-Latest: **1.4.0** (2026-06-15) — guided self-tuning setup, the `add.py waves`
-DAG scheduler, a human-owned self-improving `SOUL.md` voice, the `autonomy
-show|set` verb, and an agent-agnostic update nudge. One version tag publishes
-both channels: `@pilotspace/add` (npm) and `pilotspace-add` (PyPI).
+Latest: **1.7.0** (2026-06-18) — a guided, agent-aware, self-healing ADD
+installer (an interactive `@clack/prompts` onramp with a plain-text fallback)
+installable per-project or to a shared global home (`--global` / `--global-data`),
+plus recorded delta resolution, guided-choice prompts at every human gate, a
+milestone-close ship review, and Claude Code plugin distribution. One version
+tag publishes both channels: `@pilotspace/add` (npm) and `pilotspace-add` (PyPI).
 
 <!-- This file is deliberately a pointer, matching GETTING-STARTED.md. It
      replaced a stale full copy that had drifted: root stalled at v1.1.0 while

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,11 @@ Append-only release ledger (newest-first) — date · version · milestones · w
 A milestone is "released" iff it appears in a row here (membership is the attribution source).
 The engine records a row via `add.py release <version>`; the human owns the tag/publish.
 
+## 1.7.0 — 2026-06-18
+milestones: delta-resolution, udd-design-loop, decision-suggestions, ship-review, installer-experience
+waivers: none
+evidence: ADD 1.7.0 — installer-experience (guided/agent-aware/self-healing/global onramp via @clack/prompts + --global/--global-data) + delta-resolution + decision-suggestions + ship-review + udd-design-loop attribution; suite 1266 green; tag v1.7.0 triggers npm/PyPI publish
+
 ## 1.6.0 — 2026-06-16
 milestones: release-altitude
 waivers: none

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "ADD (AI-Driven Development) — a minimal, state-tracked Claude Code skill that drives every feature through Specify → Scenarios → Contract → Tests → Build → Verify → Observe. Ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,27 +4,60 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
-## [Unreleased]
+## [1.7.0] — 2026-06-18
+
+The installer & onboarding release: standing up — or repairing — ADD is now one
+guided installer that adapts to the terminal and the agent, and the method's own
+build loop gained recorded delta resolution, guided choices at every human gate,
+and a milestone-close ship review. All additive; no breaking changes (SemVer MINOR).
 
 ### Added
+- **Guided, agent-aware, self-healing installer (`installer-experience`)** — `npx
+  @pilotspace/add` (and `pilotspace-add`) now runs an interactive `@clack/prompts`
+  onramp in a real terminal and degrades to a byte-identical plain-text flow in
+  CI / non-TTY (the pip twin matches, on the stdlib). It **detects the active agent**
+  (Claude Code · Claude app/cowork · Codex · OpenCode · generic) and writes that
+  agent's integration file (`CLAUDE.md` / `AGENTS.md`) as a marker-delimited pointer,
+  then prints that agent's exact next step. `init` **and** `update` now **heal/reconcile**
+  a partial `.add/` — restoring missing managed assets and refreshing stale ones
+  **without touching** `state.json` / `PROJECT.md` / milestones / tasks.
+- **Global install (`--global`)** — install the engine + book + skill once into a
+  shared ADD home (`ADD_HOME` → `XDG_DATA_HOME/add` → `~/.add`) and reuse it across
+  projects; `update --global` refreshes the home and propagates to every registered
+  project. The home mirrors the bundled layer; the registry is a flat, atomically
+  written `registry.json`, and a corrupt registry fails loud (read-before-write,
+  zero-mutation abort).
+- **Global data (`--global-data`)** — opt-in (implies `--global`): a one-way snapshot
+  of a project's **user-data** under `<home>/data/<key>` keyed by project path, so the
+  shared home remembers each opting project. The per-project, git-tracked default is
+  byte-unchanged; without the flag, data stays local.
 - **Claude Code plugin distribution** — ADD is now installable straight from a
   marketplace, with no npm or pip step: `/plugin marketplace add pilotspace/ADD`
   then `/plugin install add@add-method`. A repo-root `.claude-plugin/marketplace.json`
-  lists the `add` plugin (`add-method/.claude-plugin/plugin.json`), which bundles the
-  skill, the engine, and the AIDD book. On first run the skill materializes the engine
-  and book INTO the project (`node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill`)
-  so `.add/tooling/add.py`, `.add/docs/`, and the agent-agnostic guideline block all
-  work for every agent and a human at the shell — a self-contained, portable result
-  identical to an npm/pip install. The skill stays in the plugin (no duplicate).
-- **`cli.js init --no-skill`** — drops the engine + book only, leaving skill delivery to
-  the plugin. Used by the plugin bootstrap above; npm/pip installs are unchanged.
-- **Plugin boundaries disclosure** (README "What this plugin does, writes, and runs") —
-  states plainly that the plugin is user-initiated, runs only its bundled engine, writes
-  only under the project's `.add/`, and makes a single advisory, opt-out (`ADD_NO_UPDATE_CHECK`)
-  update check — so a marketplace safety review can confirm the boundaries at a glance.
-  Guarded by `tooling/test_plugin_manifest.py` (manifests valid, version tracks
-  `package.json`, the bootstrap line can't be dropped, and `--no-skill` lands the engine
-  and book but no duplicate skill).
+  lists the `add` plugin, which bundles the skill, the engine, and the AIDD book; on
+  first run the skill materializes the engine and book INTO the project
+  (`cli.js init --no-skill`) so every agent and a human at the shell get a
+  self-contained result identical to an npm/pip install. The skill stays in the plugin
+  (no duplicate); boundaries are disclosed in the README and guarded by
+  `tooling/test_plugin_manifest.py`.
+- **Recorded delta resolution (`delta-resolution`)** — both delta types now resolve
+  explicitly: SPEC deltas get a `seed` / `drop` lifecycle and competency deltas
+  consolidate into the foundation via **`add.py fold`** (transcription-only, human-
+  authorized). `add.py check` stays green only when deltas are well-formed.
+- **Guided-choice prompts (`decision-suggestions`)** — every human gate (intake ·
+  bundle approval · verify · milestone close · release) renders a recommended pick
+  plus 1–3 described alternatives. Presentation-only — the engine is untouched.
+- **Milestone-close ship review (`ship-review`)** — closing a milestone now records a
+  cross-task ship review (ship-by-domain · per-task evidence · goal-met map) that the
+  existing engine gate reads, plus AI-defined release-step hints that feed `release.md`.
+
+### Notes
+- The `udd-design-loop` work (the `design.md` UDD loop + the wireframe/HTML-mock
+  recipe, described narratively under [1.5.0]) is attributed to this cut in the
+  `RELEASES.md` ledger — its first explicit ledger accounting.
+- **The engine records; the human ships.** `add.py release` recorded the `RELEASES.md`
+  row and this changelog lineage; it never bumps a version source, tags, or publishes.
+  The human-gated `git tag v1.7.0` triggers the npm / PyPI publish.
 
 ## [1.6.0] — 2026-06-16
 

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "ADD (AI-Driven Development) — a minimal, state-tracked Claude Code skill that drives every feature through Specify → Scenarios → Contract → Tests → Build → Verify → Observe. Ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.6.0"
+version = "1.7.0"
 description = "ADD (AI-Driven Development) — install the ADD skill, tooling, and AIDD book into any project"
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.6.0"
+__version__ = "1.7.0"

--- a/add-method/tooling/test_release_1_7_0.py
+++ b/add-method/tooling/test_release_1_7_0.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.6.0 release readiness (the RELEASE scope level).
+"""Red/green tests for the 1.7.0 release readiness (the installer & onboarding release).
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.6.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.7.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_6_0 -v
+    python3 -m unittest test_release_1_7_0 -v
 """
 import hashlib
 import json
@@ -21,18 +21,18 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.6.0"
-PRIOR_VERSIONS = ("1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
+VERSION = "1.7.0"
+PRIOR_VERSIONS = ("1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline capabilities the release notes must name (the release-altitude
-# milestone: the release.md guide, the release-report gather, the RELEASES.md
-# ledger, and the book chapter 16)
-FEATURE_ANCHORS = ("release.md", "release-report", "RELEASES.md", "16-releasing.md")
+# the headline capabilities the release notes must name (the installer-experience
+# milestone: the interactive clack onramp, the global install + global-data flags,
+# the delta-resolution fold verb, and Claude Code plugin distribution)
+FEATURE_ANCHORS = ("@clack/prompts", "--global-data", "add.py fold", "Claude Code plugin")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_6_0_entry(self):
+    def test_changelog_has_1_7_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -41,7 +41,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.6.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.7.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -65,7 +65,7 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    def test_versions_agree_at_1_6_0(self):
+    def test_versions_agree_at_1_7_0(self):
         pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
         py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
                        (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)

--- a/add-method/tooling/test_shared_engine_pin.py
+++ b/add-method/tooling/test_shared_engine_pin.py
@@ -28,7 +28,7 @@ ENGINE_PATHS = (
 IMPORTERS = (
     "test_getting_started_spine.py",
     "test_installer_handoff.py",
-    "test_release_1_6_0.py",
+    "test_release_1_7_0.py",
     "test_review_checklist.py",
     "test_skill_onramp.py",
 )


### PR DESCRIPTION
## Release 1.7.0 — the installer & onboarding release

Cuts **ADD 1.7.0**, bundling **5 closed-and-unreleased milestones**. Dogfoods the RELEASE
scope level on the method itself: `add.py release 1.7.0` recorded the `RELEASES.md` row +
attribution; the human owns the tag. **No engine change** (`add.py` md5 unchanged).

### Bundled milestones (RELEASES.md row)
| Milestone | What ships |
|-----------|-----------|
| **installer-experience** (headline) | guided/agent-aware/self-healing installer — interactive `@clack/prompts` onramp + byte-identical plain-text fallback; agent detection → integration file + next step; `init`/`update` heal a partial `.add/`; `--global` shared home; `--global-data` per-project snapshot |
| **delta-resolution** | SPEC `seed`/`drop` lifecycle + `add.py fold` for competency deltas |
| **decision-suggestions** | recommended pick + described alternatives at every human gate (presentation-only) |
| **ship-review** | milestone-close cross-task ship review the engine gate reads + AI-defined release steps |
| **udd-design-loop** | first explicit ledger attribution (features described narratively under [1.5.0]) |

Plus the **Claude Code plugin distribution** work that was sitting under `[Unreleased]`.

### Version bump (SemVer MINOR — all additive)
Four version sources bumped in lockstep `1.6.0 → 1.7.0`:
`package.json` · `pyproject.toml` · `src/add_method/__init__.py` · `.claude-plugin/plugin.json`
(the plugin manifest is the 4th source, added by #30, guarded by `test_plugin_manifest`).

### Changes in this PR
- `add-method/CHANGELOG.md` — rich `[1.7.0]` entry authored from the consolidated deltas + each milestone goal; folds the prior `[Unreleased]` plugin block into it.
- `RELEASES.md` — the engine-recorded 1.7.0 ledger row (5 milestones, 0 waivers); preamble reconciled to stay atop the newest-first rows.
- root `CHANGELOG.md` — restored to a clean pointer (dropped the engine's terse auto-block) + refreshed the stale "Latest: 1.4.0" snapshot.
- `test_release_1_6_0.py → test_release_1_7_0.py` — forward-pin migrated (VERSION 1.7.0, 1.6.0 prepended to PRIOR_VERSIONS, FEATURE_ANCHORS retargeted) + the five-importers aggregator repointed.

### Readiness floor (engine-enforced at the cut)
- ✅ **0 open security HARD-STOP** (the un-forceable stop)
- ✅ **0 RISK-ACCEPTED waivers** riding into the cut
- ✅ full add-method tooling suite **1266/1266 green**; `add.py audit` clean (63 tasks)
- ✅ versions agree at 1.7.0 across all four sources (`publish.yml` guard satisfied)

### Ship (human-gated — after merge)
The engine recorded the cut; **the human runs the tag**, which `publish.yml` re-verifies and ships:
```
git tag v1.7.0 && git push origin v1.7.0
```
That triggers the npm (`@pilotspace/add`) + PyPI (`pilotspace-add`) publish. The tag is the
only outward act — it is never pushed autonomously.

🤖 Built + cut with ADD (AI-Driven Development).
