### PR TITLE
ci(publish): install npm deps in the publish guard so the clack test runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,19 @@ jobs:
         with:
           python-version: '3.12'
 
+      # The npm installer twin carries a runtime dep (@clack/prompts) on the
+      # interactive path; the suite spawns `node cli.js` with the force-interactive
+      # seam, so @clack/prompts must be importable for the clack-cancel branch to be
+      # exercised — without it the run degrades to the plain-text fallback (exit 0
+      # != 130) and the gate fails closed. Mirrors the same step in ci.yml.
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Install npm deps (clack interactive path)
+        working-directory: add-method
+        run: npm ci
+
       - name: Run tooling test suite (red/green gate)
         working-directory: add-method
         run: python3 -m unittest discover -s tooling -p 'test_*.py'


### PR DESCRIPTION
The `v1.7.0` tag push fired `publish.yml`, whose `guard` job re-runs the full tooling suite before the npm/PyPI publish jobs. The guard had **no node toolchain**, so `@clack/prompts` was not importable and `test_user_cancelled_writes_nothing_npm` degraded to the plain-text fallback (exit 0 ≠ 130) — the gate **failed closed and both publish jobs were skipped**. Nothing published (the readiness floor did its job).

Same gap fixed in `ci.yml` (71819c0) but not propagated to the publish guard. Adds `actions/setup-node@v5` (node 20) + deterministic `npm ci` before the test-suite step, mirroring `ci.yml`. The npm publish job already provisions node; only the guard was missing it.

After merge, re-pointing the `v1.7.0` tag here re-runs `publish.yml` with the fix present at the tagged commit, so the guard passes and the publish proceeds.