### PR TITLE
feat(skill): flex report blocks — DECIDED block, NEXT-as-list, FLAGS rename

### DIFF
--- a/.add/CONVENTIONS.md
+++ b/.add/CONVENTIONS.md
@@ -485,7 +485,7 @@ Architecture:
   drifts from its canonical glossary TERM the same way — §3's "Least-sure flag surfaced at freeze" vs the
   glossary's "lowest-confidence flag" shipped bridged-not-migrated; introduce a working label only with a
   bridge ("formerly …") or migrate it in the same breath, never a silent rename. [unflagged-freeze — folded foundation-version 23]
-- (ADD) **A gate report's ⚠ FLAGS must reconcile with `add.py report --decide`'s open-item count before stamping —
+- (ADD) **A gate report's FLAGS must reconcile with `add.py report --decide`'s open-item count before stamping —
   fix the data (the TASK.md markers), never the sentence.** Prose calling an item "resolved" while the digest still
   counts it open is the un-transparent gate the decision arc exists to kill. Now SHIPPED as report-template.md's
   reconcile rule. [report-arc — folded foundation-version 22]

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -112,7 +112,7 @@ See `run.md`.
 
 Whenever you present a decision point to the human in chat (intake · bundle approval · gate ·
 milestone close), follow `report-template.md` — open with the ARC (goal · done · plan,
-engine-sourced), then SUMMARY → DECISION → ⚠ FLAGS → EVIDENCE → NEXT, show-before-ask, never
+engine-sourced), then SUMMARY → DECISION → FLAGS → DECIDED → EVIDENCE → NEXT, show-before-ask, never
 pre-stamp a decision point — and the question is a summary, never the artifact.
 
 In **observe**, also emit **lessons learned** — learnings tagged by which of the five

--- a/.claude/skills/add/report-template.md
+++ b/.claude/skills/add/report-template.md
@@ -8,12 +8,12 @@ replacement for the digest.
 Use it every time you report at or near a decision point: an intake proposal, a
 bundle approval, a verify gate, a task completion, a milestone close.
 
-## The decision arc — rendered first, above the five blocks
+## The decision arc — rendered first, above the report blocks
 
 Every report at a human gate opens with the **ARC** — three labelled lines that
 place the decision in the work's whole arc, so the human confirms with sight of
 where this is going, not just the step in front of them. Render it first, then a
-separator, then the unchanged five blocks below:
+separator, then the report blocks below:
 
 ```
 ARC  goal: <the milestone / project goal this decision serves>
@@ -48,14 +48,19 @@ and `add.py` output disagree, the engine wins — fix the arc, not the engine.
 - **intake** — `goal:` the sized request · `done:` classified new-major,
   rationale stated · `plan:` create the milestone → first contract → goal.
 
-## The five blocks, in order
+## The report blocks, in order
+
+The blocks below are the CORE set, rendered in order at every decision-point
+report. Render every one (write "none" rather than dropping a block); add MORE
+blocks when a specific report needs them (see "Beyond the core blocks" below).
 
 ```
 SUMMARY   one line: intent + target + where we are + what we done
-DECISION  what you need from the human (or "none — FYI")
-⚠ FLAGS   lowest-confidence first, why + cost-if-wrong
+DECISION  what you need from the human (or "none — FYI") — exactly one
+FLAGS     lowest-confidence first: why + cost-if-wrong
+DECIDED   highest-confidence first: the autonomous calls you made + why each was safe
 EVIDENCE  small table: tests · gates · parity · check — engine-sourced
-NEXT      the single next action + what it unlocks
+NEXT      the recommended next actions, ranked (top ▶ highlighted, bolded) + what each unlocks
 ```
 
 1. **SUMMARY** — one line carrying intent + target + position, e.g.
@@ -67,15 +72,34 @@ NEXT      the single next action + what it unlocks
    description (see "guided choice" below). Exactly one decision per report, or an
    explicit "none — FYI". If a decision exists, ask it after everything below has
    been shown (show-before-ask).
-3. **⚠ FLAGS** — lowest-confidence first, each with *why* confidence is lowest and the
+3. **FLAGS** — lowest-confidence first, each with *why* confidence is lowest and the
    *cost if wrong*. Where TASK.md markers exist (`⚠` / `- [~]` / `- [ ]`),
    quote them verbatim and keep their document order — extraction ≠ judgment.
-4. **EVIDENCE** — engine-sourced facts pasted from `add.py` output, never
+4. **DECIDED** — the counterpart to FLAGS: the high-confidence calls you settled
+   autonomously WITHOUT a gate, highest-confidence first, each with *why* it was
+   safe (the change-type or evidence that earned the autonomy). FLAGS surfaces the
+   lowest-confidence calls so the human can challenge them; DECIDED surfaces the
+   highest-confidence ones so the human can see what you closed without asking. "none" when you made no
+   autonomous calls. NEVER list a security / residue / lowered-autonomy call here —
+   those always escalate in DECISION (see the Hard rules), never auto-decided.
+5. **EVIDENCE** — engine-sourced facts pasted from `add.py` output, never
    re-typed from memory. If your prose and the engine disagree, the engine
    wins: fix the engine or the data, not the sentence.
-5. **NEXT** — one action and what it unlocks. Mirror the rollup's DECIDE NEXT
-   line when it is right; overrule it only with a stated reason (e.g. planned
+6. **NEXT** — the recommended next actions as a ranked list, the top one marked
+   `▶` and each with what it unlocks. NEXT is **informational, not a second gate**:
+   it shows the menu of what's next and never adds a decision — the one decision
+   stays the DECISION block. Mirror the rollup's DECIDE NEXT line for the top
+   action when it is right; overrule it only with a stated reason (e.g. planned
    tasks the state file cannot see yet).
+
+### Beyond the core blocks — add more when the decision needs it
+
+The six blocks above are the CORE set. When a specific report needs more than they
+carry — a `RISK` ledger, a `DIFF`, a `SCOPE` map, a `COST` estimate — add an extra
+block in the same shape (SCREAMING-CASE label · one-line intent · engine-sourced
+where it can be), placed AFTER EVIDENCE and BEFORE NEXT so NEXT always closes the
+report. Add a block only when it carries what the core six don't; never pad to look
+thorough — and never drop a core block; render "none" instead.
 
 ### The DECISION block as a guided choice
 
@@ -120,7 +144,7 @@ intent + what "yes" means + the flag count — pointing at the report above.
   **recommended pick** (`▶ … (recommended)`, exactly one) + its 1–3 described alternatives, every
   option carrying a one-line description; never a bare next step. `confidence.md` informs the pick;
   the human overrides freely. Not at `[you drive]` autonomous steps.
-- **Reconcile the count.** Before the ask, your ⚠ FLAGS must reconcile with
+- **Reconcile the count.** Before the ask, your FLAGS must reconcile with
   `add.py report --decide`'s open-item count. If your prose calls an item
   resolved while the digest still counts it open, the engine wins — fix the data
   (the TASK.md markers the digest reads), not the sentence. A report whose flag
@@ -133,10 +157,14 @@ intent + what "yes" means + the flag count — pointing at the report above.
 - **Honest scope.** "Done" means the request, not the last task: report
   "task 2/3", never "done" while approved scope remains.
 - **The question is a summary, never the artifact.** Every approval ask carries
-  two layers: a compact SUMMARY · DECISION · ⚠ FLAGS block sits in chat
+  two layers: a compact SUMMARY · DECISION · FLAGS block sits in chat
   immediately before the ask (positional), and the question text itself is a
   summary of two lines at most — intent + what "yes" means + the flag count —
   pointing at the report above (compositional). The full bundle, diff, or
   artifact lives only in the chat report; a question that re-carries it buries
   the decision.
+- **NEXT is not a second gate.** NEXT lists recommended next actions (ranked, top
+  `▶`); the single decision stays the DECISION block — NEXT never carries an approval ask.
+- **DECIDED never holds a gate-class call.** A security / residue / lowered-autonomy
+  call is escalated in DECISION, never reported as already auto-decided in DECIDED.
 </constraints>

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -112,7 +112,7 @@ See `run.md`.
 
 Whenever you present a decision point to the human in chat (intake · bundle approval · gate ·
 milestone close), follow `report-template.md` — open with the ARC (goal · done · plan,
-engine-sourced), then SUMMARY → DECISION → ⚠ FLAGS → EVIDENCE → NEXT, show-before-ask, never
+engine-sourced), then SUMMARY → DECISION → FLAGS → DECIDED → EVIDENCE → NEXT, show-before-ask, never
 pre-stamp a decision point — and the question is a summary, never the artifact.
 
 In **observe**, also emit **lessons learned** — learnings tagged by which of the five

--- a/add-method/skill/add/report-template.md
+++ b/add-method/skill/add/report-template.md
@@ -8,12 +8,12 @@ replacement for the digest.
 Use it every time you report at or near a decision point: an intake proposal, a
 bundle approval, a verify gate, a task completion, a milestone close.
 
-## The decision arc — rendered first, above the five blocks
+## The decision arc — rendered first, above the report blocks
 
 Every report at a human gate opens with the **ARC** — three labelled lines that
 place the decision in the work's whole arc, so the human confirms with sight of
 where this is going, not just the step in front of them. Render it first, then a
-separator, then the unchanged five blocks below:
+separator, then the report blocks below:
 
 ```
 ARC  goal: <the milestone / project goal this decision serves>
@@ -48,14 +48,19 @@ and `add.py` output disagree, the engine wins — fix the arc, not the engine.
 - **intake** — `goal:` the sized request · `done:` classified new-major,
   rationale stated · `plan:` create the milestone → first contract → goal.
 
-## The five blocks, in order
+## The report blocks, in order
+
+The blocks below are the CORE set, rendered in order at every decision-point
+report. Render every one (write "none" rather than dropping a block); add MORE
+blocks when a specific report needs them (see "Beyond the core blocks" below).
 
 ```
 SUMMARY   one line: intent + target + where we are + what we done
-DECISION  what you need from the human (or "none — FYI")
-⚠ FLAGS   lowest-confidence first, why + cost-if-wrong
+DECISION  what you need from the human (or "none — FYI") — exactly one
+FLAGS     lowest-confidence first: why + cost-if-wrong
+DECIDED   highest-confidence first: the autonomous calls you made + why each was safe
 EVIDENCE  small table: tests · gates · parity · check — engine-sourced
-NEXT      the single next action + what it unlocks
+NEXT      the recommended next actions, ranked (top ▶ highlighted, bolded) + what each unlocks
 ```
 
 1. **SUMMARY** — one line carrying intent + target + position, e.g.
@@ -67,15 +72,34 @@ NEXT      the single next action + what it unlocks
    description (see "guided choice" below). Exactly one decision per report, or an
    explicit "none — FYI". If a decision exists, ask it after everything below has
    been shown (show-before-ask).
-3. **⚠ FLAGS** — lowest-confidence first, each with *why* confidence is lowest and the
+3. **FLAGS** — lowest-confidence first, each with *why* confidence is lowest and the
    *cost if wrong*. Where TASK.md markers exist (`⚠` / `- [~]` / `- [ ]`),
    quote them verbatim and keep their document order — extraction ≠ judgment.
-4. **EVIDENCE** — engine-sourced facts pasted from `add.py` output, never
+4. **DECIDED** — the counterpart to FLAGS: the high-confidence calls you settled
+   autonomously WITHOUT a gate, highest-confidence first, each with *why* it was
+   safe (the change-type or evidence that earned the autonomy). FLAGS surfaces the
+   lowest-confidence calls so the human can challenge them; DECIDED surfaces the
+   highest-confidence ones so the human can see what you closed without asking. "none" when you made no
+   autonomous calls. NEVER list a security / residue / lowered-autonomy call here —
+   those always escalate in DECISION (see the Hard rules), never auto-decided.
+5. **EVIDENCE** — engine-sourced facts pasted from `add.py` output, never
    re-typed from memory. If your prose and the engine disagree, the engine
    wins: fix the engine or the data, not the sentence.
-5. **NEXT** — one action and what it unlocks. Mirror the rollup's DECIDE NEXT
-   line when it is right; overrule it only with a stated reason (e.g. planned
+6. **NEXT** — the recommended next actions as a ranked list, the top one marked
+   `▶` and each with what it unlocks. NEXT is **informational, not a second gate**:
+   it shows the menu of what's next and never adds a decision — the one decision
+   stays the DECISION block. Mirror the rollup's DECIDE NEXT line for the top
+   action when it is right; overrule it only with a stated reason (e.g. planned
    tasks the state file cannot see yet).
+
+### Beyond the core blocks — add more when the decision needs it
+
+The six blocks above are the CORE set. When a specific report needs more than they
+carry — a `RISK` ledger, a `DIFF`, a `SCOPE` map, a `COST` estimate — add an extra
+block in the same shape (SCREAMING-CASE label · one-line intent · engine-sourced
+where it can be), placed AFTER EVIDENCE and BEFORE NEXT so NEXT always closes the
+report. Add a block only when it carries what the core six don't; never pad to look
+thorough — and never drop a core block; render "none" instead.
 
 ### The DECISION block as a guided choice
 
@@ -120,7 +144,7 @@ intent + what "yes" means + the flag count — pointing at the report above.
   **recommended pick** (`▶ … (recommended)`, exactly one) + its 1–3 described alternatives, every
   option carrying a one-line description; never a bare next step. `confidence.md` informs the pick;
   the human overrides freely. Not at `[you drive]` autonomous steps.
-- **Reconcile the count.** Before the ask, your ⚠ FLAGS must reconcile with
+- **Reconcile the count.** Before the ask, your FLAGS must reconcile with
   `add.py report --decide`'s open-item count. If your prose calls an item
   resolved while the digest still counts it open, the engine wins — fix the data
   (the TASK.md markers the digest reads), not the sentence. A report whose flag
@@ -133,10 +157,14 @@ intent + what "yes" means + the flag count — pointing at the report above.
 - **Honest scope.** "Done" means the request, not the last task: report
   "task 2/3", never "done" while approved scope remains.
 - **The question is a summary, never the artifact.** Every approval ask carries
-  two layers: a compact SUMMARY · DECISION · ⚠ FLAGS block sits in chat
+  two layers: a compact SUMMARY · DECISION · FLAGS block sits in chat
   immediately before the ask (positional), and the question text itself is a
   summary of two lines at most — intent + what "yes" means + the flag count —
   pointing at the report above (compositional). The full bundle, diff, or
   artifact lives only in the chat report; a question that re-carries it buries
   the decision.
+- **NEXT is not a second gate.** NEXT lists recommended next actions (ranked, top
+  `▶`); the single decision stays the DECISION block — NEXT never carries an approval ask.
+- **DECIDED never holds a gate-class call.** A security / residue / lowered-autonomy
+  call is escalated in DECISION, never reported as already auto-decided in DECIDED.
 </constraints>

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -112,7 +112,7 @@ See `run.md`.
 
 Whenever you present a decision point to the human in chat (intake · bundle approval · gate ·
 milestone close), follow `report-template.md` — open with the ARC (goal · done · plan,
-engine-sourced), then SUMMARY → DECISION → ⚠ FLAGS → EVIDENCE → NEXT, show-before-ask, never
+engine-sourced), then SUMMARY → DECISION → FLAGS → DECIDED → EVIDENCE → NEXT, show-before-ask, never
 pre-stamp a decision point — and the question is a summary, never the artifact.
 
 In **observe**, also emit **lessons learned** — learnings tagged by which of the five

--- a/add-method/src/add_method/_bundled/skill/add/report-template.md
+++ b/add-method/src/add_method/_bundled/skill/add/report-template.md
@@ -8,12 +8,12 @@ replacement for the digest.
 Use it every time you report at or near a decision point: an intake proposal, a
 bundle approval, a verify gate, a task completion, a milestone close.
 
-## The decision arc — rendered first, above the five blocks
+## The decision arc — rendered first, above the report blocks
 
 Every report at a human gate opens with the **ARC** — three labelled lines that
 place the decision in the work's whole arc, so the human confirms with sight of
 where this is going, not just the step in front of them. Render it first, then a
-separator, then the unchanged five blocks below:
+separator, then the report blocks below:
 
 ```
 ARC  goal: <the milestone / project goal this decision serves>
@@ -48,14 +48,19 @@ and `add.py` output disagree, the engine wins — fix the arc, not the engine.
 - **intake** — `goal:` the sized request · `done:` classified new-major,
   rationale stated · `plan:` create the milestone → first contract → goal.
 
-## The five blocks, in order
+## The report blocks, in order
+
+The blocks below are the CORE set, rendered in order at every decision-point
+report. Render every one (write "none" rather than dropping a block); add MORE
+blocks when a specific report needs them (see "Beyond the core blocks" below).
 
 ```
 SUMMARY   one line: intent + target + where we are + what we done
-DECISION  what you need from the human (or "none — FYI")
-⚠ FLAGS   lowest-confidence first, why + cost-if-wrong
+DECISION  what you need from the human (or "none — FYI") — exactly one
+FLAGS     lowest-confidence first: why + cost-if-wrong
+DECIDED   highest-confidence first: the autonomous calls you made + why each was safe
 EVIDENCE  small table: tests · gates · parity · check — engine-sourced
-NEXT      the single next action + what it unlocks
+NEXT      the recommended next actions, ranked (top ▶ highlighted, bolded) + what each unlocks
 ```
 
 1. **SUMMARY** — one line carrying intent + target + position, e.g.
@@ -67,15 +72,34 @@ NEXT      the single next action + what it unlocks
    description (see "guided choice" below). Exactly one decision per report, or an
    explicit "none — FYI". If a decision exists, ask it after everything below has
    been shown (show-before-ask).
-3. **⚠ FLAGS** — lowest-confidence first, each with *why* confidence is lowest and the
+3. **FLAGS** — lowest-confidence first, each with *why* confidence is lowest and the
    *cost if wrong*. Where TASK.md markers exist (`⚠` / `- [~]` / `- [ ]`),
    quote them verbatim and keep their document order — extraction ≠ judgment.
-4. **EVIDENCE** — engine-sourced facts pasted from `add.py` output, never
+4. **DECIDED** — the counterpart to FLAGS: the high-confidence calls you settled
+   autonomously WITHOUT a gate, highest-confidence first, each with *why* it was
+   safe (the change-type or evidence that earned the autonomy). FLAGS surfaces the
+   lowest-confidence calls so the human can challenge them; DECIDED surfaces the
+   highest-confidence ones so the human can see what you closed without asking. "none" when you made no
+   autonomous calls. NEVER list a security / residue / lowered-autonomy call here —
+   those always escalate in DECISION (see the Hard rules), never auto-decided.
+5. **EVIDENCE** — engine-sourced facts pasted from `add.py` output, never
    re-typed from memory. If your prose and the engine disagree, the engine
    wins: fix the engine or the data, not the sentence.
-5. **NEXT** — one action and what it unlocks. Mirror the rollup's DECIDE NEXT
-   line when it is right; overrule it only with a stated reason (e.g. planned
+6. **NEXT** — the recommended next actions as a ranked list, the top one marked
+   `▶` and each with what it unlocks. NEXT is **informational, not a second gate**:
+   it shows the menu of what's next and never adds a decision — the one decision
+   stays the DECISION block. Mirror the rollup's DECIDE NEXT line for the top
+   action when it is right; overrule it only with a stated reason (e.g. planned
    tasks the state file cannot see yet).
+
+### Beyond the core blocks — add more when the decision needs it
+
+The six blocks above are the CORE set. When a specific report needs more than they
+carry — a `RISK` ledger, a `DIFF`, a `SCOPE` map, a `COST` estimate — add an extra
+block in the same shape (SCREAMING-CASE label · one-line intent · engine-sourced
+where it can be), placed AFTER EVIDENCE and BEFORE NEXT so NEXT always closes the
+report. Add a block only when it carries what the core six don't; never pad to look
+thorough — and never drop a core block; render "none" instead.
 
 ### The DECISION block as a guided choice
 
@@ -120,7 +144,7 @@ intent + what "yes" means + the flag count — pointing at the report above.
   **recommended pick** (`▶ … (recommended)`, exactly one) + its 1–3 described alternatives, every
   option carrying a one-line description; never a bare next step. `confidence.md` informs the pick;
   the human overrides freely. Not at `[you drive]` autonomous steps.
-- **Reconcile the count.** Before the ask, your ⚠ FLAGS must reconcile with
+- **Reconcile the count.** Before the ask, your FLAGS must reconcile with
   `add.py report --decide`'s open-item count. If your prose calls an item
   resolved while the digest still counts it open, the engine wins — fix the data
   (the TASK.md markers the digest reads), not the sentence. A report whose flag
@@ -133,10 +157,14 @@ intent + what "yes" means + the flag count — pointing at the report above.
 - **Honest scope.** "Done" means the request, not the last task: report
   "task 2/3", never "done" while approved scope remains.
 - **The question is a summary, never the artifact.** Every approval ask carries
-  two layers: a compact SUMMARY · DECISION · ⚠ FLAGS block sits in chat
+  two layers: a compact SUMMARY · DECISION · FLAGS block sits in chat
   immediately before the ask (positional), and the question text itself is a
   summary of two lines at most — intent + what "yes" means + the flag count —
   pointing at the report above (compositional). The full bundle, diff, or
   artifact lives only in the chat report; a question that re-carries it buries
   the decision.
+- **NEXT is not a second gate.** NEXT lists recommended next actions (ranked, top
+  `▶`); the single decision stays the DECISION block — NEXT never carries an approval ask.
+- **DECIDED never holds a gate-class call.** A security / residue / lowered-autonomy
+  call is escalated in DECISION, never reported as already auto-decided in DECIDED.
 </constraints>

--- a/add-method/tooling/test_xml_convention.py
+++ b/add-method/tooling/test_xml_convention.py
@@ -264,7 +264,7 @@ ENGINE_FILES = {
     "report-template.md": {
         "tags": {"constraints"},
         "narrative": (
-            "## The five blocks, in order",                            # holds the digest ``` fence
+            "## The report blocks, in order",                          # holds the digest ``` fence
         )},
     "setup-review.md": {
         "tags": {"constraints"},


### PR DESCRIPTION
Enhance the decision-point chat convention (`report-template.md`) so the AI can shape the report to what a decision needs, and surface high-confidence autonomous calls — not only what is least sure.

## Changes
- **Dynamic blocks** — `## The five blocks` → `## The report blocks`; the listed blocks are the CORE set + a "Beyond the core blocks" rule for adding `RISK`/`DIFF`/`SCOPE`/`COST` blocks (after EVIDENCE, before NEXT). Core blocks are never dropped — render "none".
- **New `DECIDED` block** — the counterpart to FLAGS. FLAGS = lowest-confidence calls the human can challenge; DECIDED = the highest-confidence calls the AI settled autonomously, each with *why* it was safe. A security / residue / lowered-autonomy call **never** lands in DECIDED — it always escalates in DECISION (Hard rule, mirroring "security always escalates").
- **`NEXT` → ranked highlighted list** of recommended next actions; informational, **not** a second gate — the single decision stays the DECISION block.
- **`⚠ FLAGS` → `FLAGS`** across the digest, descriptions, Hard rules, and the SKILL.md cue line (order now `SUMMARY → DECISION → FLAGS → DECIDED → EVIDENCE → NEXT`).

## Notes
- Presentation/trust layer only — **no engine change**; the foundation invariant is that this layer iterates without a contract re-freeze.
- Propagated byte-identical across all 3 skill trees (canonical · `_bundled` · dogfood); parity held by `test_tree_parity` + `test_bundle_parity`. `test_xml_convention` narrative heading updated to the renamed section.
- Live dogfood foundation (`CONVENTIONS.md`) reconciled to the FLAGS rename; archived/done-task records left as accurate freeze-time history.

**Suite: 1319 passing** (`add-method/tooling`).