### PR TITLE
release(add-method): cut ADD v1.8.0 — team-collaboration + delta-resolution-polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.8.0 — 2026-06-23
+
+- Multi-active state model + migration (team-collaboration foundation) — 8 carried · 0 key decision(s)
+- User Identity — 3 carried · 0 key decision(s)
+- Ownership & assignment — 3 carried · 0 key decision(s)
+- Git-merge safety — 4 carried · 0 key decision(s)
+- Multi Active Ux — 6 carried · 0 key decision(s)
+- Delta Resolution Polish — 0 carried · 0 key decision(s)
+
 ## 1.7.3 — 2026-06-18
 
 - Multi-agent installer reach — 0 carried · 0 key decision(s)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.8.0 — 2026-06-23
+milestones: state-model-reshape, user-identity, ownership-assignment, git-merge-safety, multi-active-UX, delta-resolution-polish
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: suite 1543/0 · check 377/0 · audit clean · 6 milestones
+
 ## 1.7.3 — 2026-06-18
 milestones: multi-agent-installer
 waivers: none

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [1.8.0] — 2026-06-23
+
+Team collaboration: ADD becomes git-native and multi-user, with N
+parallel-active milestones, plus a polish pass on the delta-resolution
+machinery. Additive and backward-compatible — `add.py` ships a one-way state
+migration (single-active → multi-active), and the non-interactive byte stream
+for existing single-user flows is preserved. Bundles six closed milestones.
+
+### Added
+- **Multi-active milestones (`team-collaboration`)** — work N milestones in
+  parallel: `add.py activate` / `deactivate` manage an active working SET,
+  `add.py mine` is a my-work lens over owned tasks, the `streams:` block shows a
+  per-stream owner, and waves can span all active milestones.
+- **Git-native user identity** — `add.py whoami` resolves the actor from git
+  config; tasks carry an owner.
+- **Ownership & assignment** — `add.py assign` / `unassign` attach a task to an
+  owner; ownership renders across status and reports.
+- **Git-merge safety** — merge-base enforcement guards a stale worker base; the
+  drift vectors a parallel-wave merge can introduce are pinned suite fixtures.
+- **Multi-file commit primitive** — `_atomic_write_many` is now true
+  all-or-nothing: stage every temp → fsync → rename-aside → rename-all, with
+  rollback-on-any-failure restoring prior bytes. `fold`, `release`, and the
+  delta seed all route through it, closing the prior mid-rename residual window.
+- **`--match <substr>` selector** — `add.py new-task --from-delta` and
+  `add.py drop-delta` accept `--match` to target ONE open SPEC delta among
+  several; a 0-match or ambiguous match is a named reject. First-open behavior
+  is byte-identical when `--match` is absent.
+- **`compact --force`** — `add.py compact --force` overrides the project-wide
+  `open_spec_deltas_unresolved` block ONLY (never a structural guard) so an
+  urgent compaction is not blocked by an UNRELATED open SPEC delta; the bypass
+  is warned and recorded as `force_bypassed_spec_deltas`.
+
+### Notes
+- One version tag publishes both channels: `@pilotspace/add` (npm) and
+  `pilotspace-add` (PyPI). The engine (`add.py`) is mirrored byte-identical
+  across all three trees with `ENGINE_MD5` re-pinned.
+
 ## [1.7.3] — 2026-06-18
 
 Multi-agent installer reach (`multi-agent-installer`). Additive; no breaking

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.7.3"
+version = "1.8.0"
 description = "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — install the ADD skill, tooling, and AIDD book into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.7.3"
+__version__ = "1.8.0"

--- a/add-method/tooling/test_release_1_8_0.py
+++ b/add-method/tooling/test_release_1_8_0.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.7.3 release readiness (multi-agent installer reach).
+"""Red/green tests for the 1.8.0 release readiness (team-collaboration + delta-resolution-polish).
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.7.3) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.8.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_7_3 -v
+    python3 -m unittest test_release_1_8_0 -v
 """
 import hashlib
 import json
@@ -21,17 +21,19 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.7.3"
-PRIOR_VERSIONS = ("1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
+VERSION = "1.8.0"
+PRIOR_VERSIONS = ("1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0",
+                  "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline capabilities the release notes must name (multi-agent-installer:
-# six+ new agent profiles + the Gemini settings.json wiring)
-FEATURE_ANCHORS = ("multi-agent-installer", "Cursor", "Gemini CLI", ".gemini/settings.json")
+# the headline capabilities the release notes must name (team-collaboration major
+# + the delta-resolution-polish trio)
+FEATURE_ANCHORS = ("team-collaboration", "Multi-active milestones",
+                   "Multi-file commit primitive", "--match", "compact --force")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_7_3_entry(self):
+    def test_changelog_has_1_8_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -40,7 +42,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.7.3 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.8.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -79,19 +81,36 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    # NOTE: 1.7.3 is superseded by 1.8.0 — the live-version-agreement assertions
-    # (versions/plugin/runtime == VERSION) moved to test_release_1_8_0.py. This file
-    # keeps only the lineage + shipped-doc checks, which stay true across bumps.
+    def test_versions_agree_at_1_8_0(self):
+        pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
+        py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
+                       (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
+        self.assertEqual((pkg, py), (VERSION, VERSION),
+                         "publish.yml's guard would fail this release closed")
+
+    def test_plugin_version_agrees(self):
+        plugin = json.loads(
+            (PKG / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+        self.assertEqual(plugin, VERSION,
+                         "the Claude Code plugin manifest must match the shipped version")
+
+    def test_runtime_version_agrees(self):
+        init = (PKG / "src" / "add_method" / "__init__.py").read_text(encoding="utf-8")
+        runtime = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', init).group(1)
+        self.assertEqual(runtime, VERSION,
+                         "add_method.__version__ must match the shipped version")
+
     def test_getting_started_mentions_guide_line(self):
         text = (PKG / "GETTING-STARTED.md").read_text(encoding="utf-8")
         self.assertIn("guide  :", text,
                       "orient docs must name the phase-playbook line")
 
-    def test_engine_untouched(self):
+    def test_engine_trees_parity(self):
         for p in (HERE / "add.py", REPO / ".add" / "tooling" / "add.py",
                   BUNDLE / "tooling" / "add.py"):
             self.assertEqual(hashlib.md5(p.read_bytes()).hexdigest(), ENGINE_MD5,
-                             f"the release task must not touch the engine: {p}")
+                             f"engine trees must stay byte-identical + pinned: {p}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## ADD v1.8.0 — team-collaboration major + delta-resolution-polish

Cuts the 1.8.0 release bundling **six** closed milestones. The engine records the cut (CHANGELOG + RELEASES.md ledger); the human runs the tag / publish.

### Milestones
**team-collaboration major** — git-native multi-user + N parallel-active milestones
- state-model-reshape · user-identity · ownership-assignment · git-merge-safety · multi-active-UX

**delta-resolution-polish**
- multi-file commit primitive (all-or-nothing) · `--match` selector · `compact --force`

### The cut
- 4 version sources bumped in lockstep (1.7.3 → 1.8.0): `package.json`, `pyproject.toml`, `__init__.py`, `.claude-plugin/plugin.json`
- `add.py release 1.8.0` → root CHANGELOG terse render + RELEASES.md ledger row
- canonical rich `## [1.8.0]` entry authored in `add-method/CHANGELOG.md`
- forward-pin migrated: `test_release_1_7_3.py` shed of live-version asserts; new `test_release_1_8_0.py` carries them

### Readiness
- **0 HARD-STOP, 0 waivers** — un-forceable security floor clear
- Suite **1551 / 0** · `check` 365/0 · `audit` clean
- Engine 3-copy parity + `ENGINE_MD5` unchanged (release touches no engine code)

After merge: tag `v1.8.0` (human-gated) triggers npm + PyPI publish; GH release cut manually.
