### PR TITLE
release(method): ADD 1.9.0 — lean-pass major (4 milestones)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.9.0 — 2026-06-24
+
+- lean-pass M3 · flow simplification — 0 carried · 0 key decision(s)
+- lean-pass M1 · skill effectiveness — 5 carried · 0 key decision(s)
+- Flow enforcement — turn convention fill-seams into engine gates — 2 carried · 0 key decision(s)
+- fast-lane — 3 carried · 0 key decision(s)
+
 ## 1.8.0 — 2026-06-23
 
 - Multi-active state model + migration (team-collaboration foundation) — 8 carried · 0 key decision(s)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.9.0 — 2026-06-24
+milestones: flow-simplification, skill-effectiveness, flow-enforcement, fast-lane
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: suite 1642/0 · check 378/0 · audit clean (74 tasks) · 4 milestones (lean-pass M1 skill-effectiveness + M3 flow-simplification + M4 flow-enforcement + fast-lane)
+
 ## 1.8.0 — 2026-06-23
 milestones: state-model-reshape, user-identity, ownership-assignment, git-merge-safety, multi-active-UX, delta-resolution-polish
 waivers: none

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,32 +4,50 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
-## [Unreleased]
+## [1.9.0] — 2026-06-24
 
-Lean-pass major — make ADD's own surface the most-effective prompt at optimized
-token cost (not token-golf). Bundles the `skill-effectiveness` (M1) and
-`flow-simplification` (M3) milestones. Behavior is unchanged except for one
-opt-in gate; the rest is a leaner skill tree that routes identically.
+Lean-pass major — make ADD's own surface (skill · flow · engine) the most-effective
+prompt at optimized token cost, *not* token-golf. Bundles four closed milestones:
+`skill-effectiveness` (M1), `flow-simplification` (M3), `flow-enforcement` (M4), and
+the `fast-lane` sub-milestone. The skill tree routes identically but loads lighter;
+the method's three fill-seams are now engine-enforced rather than convention; and a
+new opt-in **fast lane** collapses ceremony for small tasks without lowering the trust
+floor. Every new gate is opt-in or grandfathered — existing flows are byte-unchanged.
 
 ### Added
-- **Confirm-parent gate (opt-in, `flow-simplification`)** — `new-milestone
-  <slug> --await-confirm` seeds the milestone *unconfirmed*, so `new-task` is
-  HELD (reject `milestone_unconfirmed`) until you show the filled `MILESTONE.md`,
-  get the human's go, and run the new `add.py milestone-confirm <slug>`. Closes
-  the gap where the AI would detail a task's §0–§5 before the human had agreed
-  the parent milestone. WITHOUT the flag no `confirmed` key is written →
-  grandfathered → no gate, so every existing flow is byte-unchanged. Mirrors
+- **Fast lane (`fast-lane`)** — `add.py new-task <slug> --fast` runs a small task
+  through a minimal `TASK.fast.md` (sections {0,1,3,4,5,6}) that still freezes a
+  contract, proves a red→green, and reads back cold in a later session. The lane is
+  *collapse-never-skip*: a `--fast` task is freeze-gated under ANY milestone (the floor
+  fires on `_optin OR fast`). Human-triggered only — the engine never auto-classifies a
+  task as "small". New `phases/fast-lane.md` guide + a SKILL.md quick-ref document it.
+- **Freeze-before-build gate (`fast-lane`)** — crossing tests→build now refuses
+  `contract_not_frozen` when §3 is still DRAFT and the task is opted-in or fast, closing
+  the gap where a task could reach `gate=PASS` without an approved, frozen contract.
+- **Contract-fill + build-expectations gates (opt-in, `flow-enforcement`)** — under
+  `new-milestone --await-confirm`, the engine HOLDS a task whose §3 CONTRACT or §6
+  Build-expectations block is still a placeholder, so the method's fill-seams are
+  enforced rather than trusted. `await_confirm` is the master switch; without it no key
+  is written → grandfathered → byte-unchanged.
+- **Gate-record write-back (`flow-enforcement`)** — recording a verify gate now stamps
+  the verdict into the §6 GATE RECORD of the TASK.md for ALL tasks (grandfathered
+  backfill), so the file itself carries the outcome the Seam audit reads.
+- **Confirm-parent gate (opt-in, `flow-simplification`)** — `new-milestone <slug>
+  --await-confirm` seeds the milestone *unconfirmed*, so `new-task` is HELD (reject
+  `milestone_unconfirmed`) until you show the filled `MILESTONE.md`, get the human's go,
+  and run the new `add.py milestone-confirm <slug>`. Closes the gap where the AI would
+  detail a task's §0–§5 before the human had agreed the parent milestone. Mirrors
   `init --await-lock` one level down.
 
 ### Changed
-- **Skill tree 25% lighter (`skill-effectiveness`)** — the on-demand skill
-  guides were compacted tree-wide (164,333 → ~123,000 bytes) with zero routing,
-  gate, reject-code, threshold, or rule lost; an independent adversarial review
-  confirmed every operative element preserved. Same flow an agent reads, fewer
-  tokens to load.
-- **One home for the worker-spawn model tiers (`spawn-fold`)** — the tier→model
-  mapping (mid→sonnet / top→opus) now lives only in `streams.md`; `advisor.md`
-  points at it instead of copying. Advisor keeps its own advisory template.
+- **Skill tree 25% lighter (`skill-effectiveness`)** — the on-demand skill guides were
+  compacted tree-wide (164,333 → ~123,000 bytes) with zero routing, gate, reject-code,
+  threshold, or rule lost; an independent adversarial review confirmed every operative
+  element preserved (it flagged 6 dropped nuances → all restored). Same flow an agent
+  reads, fewer tokens to load.
+- **One home for the worker-spawn model tiers (`spawn-fold`)** — the tier→model mapping
+  (mid→sonnet / top→opus) now lives only in `streams.md`; `advisor.md` points at it
+  instead of copying. Advisor keeps its own advisory template.
 
 ## [1.8.0] — 2026-06-23
 

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.8.0"
+version = "1.9.0"
 description = "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — install the ADD skill, tooling, and AIDD book into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.8.0"
+__version__ = "1.9.0"

--- a/add-method/tooling/test_release_1_9_0.py
+++ b/add-method/tooling/test_release_1_9_0.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.8.0 release readiness (team-collaboration + delta-resolution-polish).
+"""Red/green tests for the 1.9.0 release readiness (lean-pass major bundle).
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.8.0) are
+Bundles four closed milestones — skill-effectiveness (M1), flow-simplification (M3),
+flow-enforcement (M4), and the fast-lane sub-milestone.
+
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.9.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_8_0 -v
+    python3 -m unittest test_release_1_9_0 -v
 """
 import hashlib
 import json
@@ -21,19 +24,19 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.8.0"
-PRIOR_VERSIONS = ("1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0",
-                  "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
+VERSION = "1.9.0"
+PRIOR_VERSIONS = ("1.8.0", "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0",
+                  "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline capabilities the release notes must name (team-collaboration major
-# + the delta-resolution-polish trio)
-FEATURE_ANCHORS = ("team-collaboration", "Multi-active milestones",
-                   "Multi-file commit primitive", "--match", "compact --force")
+# the headline capabilities the release notes must name (the lean-pass bundle:
+# fast lane + the three engine-enforced fill-seams + the lighter skill tree)
+FEATURE_ANCHORS = ("fast-lane", "--fast", "Freeze-before-build", "flow-enforcement",
+                   "Gate-record write-back", "Skill tree 25% lighter", "Confirm-parent")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_8_0_entry(self):
+    def test_changelog_has_1_9_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -42,7 +45,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.8.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.9.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -81,10 +84,26 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    # NOTE: the version-equality asserts (package.json / pyproject / plugin / __init__ all == VERSION)
-    # migrated forward to test_release_1_9_0.py at the 1.9.0 bump — the live version sources now read
-    # 1.9.0, so pinning them to 1.8.0 here would fail closed. This file keeps the 1.8.0 *lineage* asserts
-    # (changelog entry + feature anchors survive) and the version-independent shape checks below.
+    def test_versions_agree_at_1_9_0(self):
+        pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
+        py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
+                       (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
+        self.assertEqual((pkg, py), (VERSION, VERSION),
+                         "publish.yml's guard would fail this release closed")
+
+    def test_plugin_version_agrees(self):
+        plugin = json.loads(
+            (PKG / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+        self.assertEqual(plugin, VERSION,
+                         "the Claude Code plugin manifest must match the shipped version")
+
+    def test_runtime_version_agrees(self):
+        init = (PKG / "src" / "add_method" / "__init__.py").read_text(encoding="utf-8")
+        runtime = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', init).group(1)
+        self.assertEqual(runtime, VERSION,
+                         "add_method.__version__ must match the shipped version")
+
     def test_getting_started_mentions_guide_line(self):
         text = (PKG / "GETTING-STARTED.md").read_text(encoding="utf-8")
         self.assertIn("guide  :", text,


### PR DESCRIPTION
## ADD 1.9.0 — the lean-pass major

Cuts a MINOR release bundling the **four** closed lean-pass milestones. The engine
recorded the cut (`add.py release 1.9.0`); **the tag is the human-gated trigger** that
publishes `@pilotspace/add` (npm) + `pilotspace-add` (PyPI) — not done by this PR.

### Milestones bundled
| Milestone | Headline |
|-----------|----------|
| `skill-effectiveness` (M1) | skill tree **25% lighter** (164k→123k B), zero routing/gate/rule lost (adversarial review restored 6 dropped nuances) |
| `flow-simplification` (M3) | confirm-parent gate (opt-in) · spawn-fold (one home for tier map) · phase-review |
| `flow-enforcement` (M4) | contract-fill + build-expectations gates (opt-in, `await_confirm`) · gate-record write-back (all tasks) |
| `fast-lane` | `--fast` minimal `TASK.fast.md` · freeze-before-build gate · `phases/fast-lane.md` + SKILL quick-ref |

Every new gate is **opt-in or grandfathered** — existing flows are byte-unchanged. The
engine itself is unchanged (`ENGINE_MD5` untouched); this is a version + notes cut.

### What's in the diff (9 files)
- **`add-method/CHANGELOG.md`** — hand-authored rich `## [1.9.0]` entry (the shipped changelog).
- **4 version sources → 1.9.0** — `package.json`, `pyproject.toml`, `.claude-plugin/plugin.json`, `src/add_method/__init__.py`.
- **Forward-pin test migrated** — new `test_release_1_9_0.py` carries the version-equality asserts + new anchors; `test_release_1_8_0.py` keeps its lineage/anchor asserts (version-asserts stripped).
- **Engine-recorded** — root `CHANGELOG.md` terse block + `RELEASES.md` append-only row (actor + evidence) attributing the 4 milestones.

### Readiness floor (met)
- suite **1642/0** · check **378/0** · audit **clean** (74 tasks)
- **0** security HARD-STOP · **0** RISK-ACCEPTED waivers riding in (nothing to disclose)

### After merge (human-owned)
`git tag v1.9.0` → `publish.yml` re-runs the suite guard, then publishes both channels. Confirm live-registry serving 1.9.0 as post-tag verify evidence.
