### PR TITLE
feat(docs): ship the AIDD book to GitHub Pages (MkDocs Material)

### DIFF
--- a/.add/milestones/docs-site/MILESTONE.md
+++ b/.add/milestones/docs-site/MILESTONE.md
@@ -1,0 +1,62 @@
+# MILESTONE: Docs site — ship the AIDD book to GitHub Pages
+
+goal: a reader can browse and search the full AIDD book at a public GitHub Pages URL, built with MkDocs Material from the canonical add-method/docs/ and deployed automatically by CI
+rationale: intake `new-major` — a public, hosted documentation website is a new product pillar no active milestone's goal covers. The AIDD book has only ever shipped *inside* the npm/PyPI package (`add-method/docs/`) as the trust layer people read on GitHub; it has never been a standalone browsable web presence. EXTENDS the book/trust-layer work; DEPENDS-ON nothing; OVERLAPS no live or archived milestone (verified against the milestone map — release-altitude ships *versions*, not a docs site).
+stage: mvp · status: active · created: 2026-06-24
+
+> SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
+> exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,
+> written just-in-time. Update this doc whenever a task reveals a milestone gap.
+
+## Scope
+In:  A buildable MkDocs-Material site whose `docs_dir` is the canonical `add-method/docs/` (single source — no content copy, book byte-unchanged), with full nav over all 17 chapters (00→16) + 7 appendices (a–g), the 4 PNG diagrams rendering, client-side search, and dark/light mode; the EXISTING `README.md` serves as the home (MkDocs maps README→index.html — NO new book file, per the human's "keep the home out of the book" decision); and a GitHub Actions workflow that builds `--strict` and deploys to GitHub Pages on push to main, reachable at the project's public Pages URL.
+Out: a custom domain / CNAME (default `*.github.io` for now) · versioned-docs (mike) · i18n/translations · blog/case-study pages (`blog-*`, `case-study-*` live at repo root, not in `add-method/docs/`) · API/reference autogeneration · editing the book's prose · syncing the `.add/docs/` dogfood copy or `_bundled/docs/` mirror into the site (canonical only).
+
+## Shared decisions & glossary deltas   (living — every task must honor these)
+- **Single source of truth:** the site builds from the canonical `add-method/docs/` in place (`docs_dir: add-method/docs`); NO copy into a `site/`/`content/` tree — no new parity surface to keep in sync.
+- **Strict build is the gate:** `mkdocs build --strict` must pass (fails on a broken intra-book link or a nav entry missing a file) — it is the red/green seam for both tasks.
+- **Lean-dependency posture:** the only new runtime dependency is `mkdocs-material` (pinned), declared in one place (a `requirements-docs.txt` or `[docs]` extra); the stdlib engine (`add.py`) is untouched.
+- **Engine records, human ships:** enabling GitHub Pages in repo settings and the first live publish are human-owned (mirrors release.md) — CI builds + deploys, the human flips Pages on.
+
+## Shared / risky contracts (freeze these first)
+- **site config + nav contract** (`mkdocs.yml`: `docs_dir`, `site_name`, theme=material, the ordered `nav` over chapters+appendices, `index.md` as home) -> owning task `site-scaffold` — the riskiest decision; if the source/nav shape is wrong everything downstream reworks.
+- **deploy contract** (the Pages workflow trigger + build command + deploy target) -> owning task `pages-deploy`.
+
+## Tasks (breadth-first decomposition; detail lives in each TASK.md)
+- [ ] site-scaffold   depends-on: none           — `mkdocs.yml` (Material theme, `docs_dir: add-method/docs`, full ordered nav, search, dark/light), an `index.md` home page, diagrams rendering; `mkdocs build --strict` green locally; docs dependency pinned.
+- [ ] pages-deploy    depends-on: site-scaffold   — GitHub Actions workflow building the site `--strict` and deploying to GitHub Pages on push to main (official Pages deploy); update `homepage`/README links to the Pages URL.
+
+## Exit criteria (observable; map each to the task that delivers it)
+- [ ] `mkdocs build --strict` produces a static site with every chapter (00→16) + appendix (a–g) in the nav and all 4 diagrams rendering, no broken-link/nav warnings   (← site-scaffold)   (verify: `mkdocs build --strict` exits 0)
+- [ ] a home/landing page renders at the site root with search and dark/light mode working   (← site-scaffold)   (verify: test asserts `site/index.html` exists + `search` plugin + `palette` toggle in `mkdocs.yml`)
+- [ ] pushing to main triggers a CI workflow that builds `--strict` and deploys the site to GitHub Pages   (← pages-deploy)   (verify: GitHub Actions Pages workflow run is green on a PR/dry-run build)
+- [ ] the published book is reachable at the project's public GitHub Pages URL and `homepage`/README point to it   (← pages-deploy)   (verify: `curl -sI <pages-url>` returns 200 + grep README/package.json for the URL)
+
+## Close — ship review   (AI fills when every task is done — the evidence behind the engine gate, read before the boxes are checked)
+> Whole-milestone, cross-task review the AI fills in. It is the evidence behind the EXISTING engine
+> gate (milestone-done / checking the Exit-criteria boxes) — NOT a new approval. Tool-agnostic.
+
+### Ship by domain   (what changed, per bounded context)
+- tooling : untouched (`add.py` / `state.json` engine unchanged — no engine edit this milestone; state.json only tracks the two tasks).
+- skill   : untouched (`SKILL.md` / `phases/*` unchanged).
+- book    : untouched at the SOURCE — `add-method/docs/` + `_bundled/docs/` byte-identical (parity held). The book is now also RENDERED as a site (new infra, not new content).
+- site/CI (new surface) : `mkdocs.yml` (Material site over canonical `add-method/docs/`, README→home, full nav, search, dark/light) · `requirements-docs.txt` (build-time `mkdocs-material`) · `.gitignore` += `site/` · `.github/workflows/pages.yml` (build `--strict` → deploy to Pages) · link edits in `add-method/package.json`, `add-method/pyproject.toml`, repo-root `README.md` → the Pages URL.
+
+### Cross-task evidence   (one row per task)
+- site-scaffold : gate=PASS · tests=7 green · residue=none (strict build exit 0, 0 warnings; book/bundle/deps byte-unchanged; healed one false scope_violation via the `add-method/..` climb + re-anchor)
+- pages-deploy  : gate=PASS · tests=7 green · residue=DISCLOSED — the LIVE deploy is CI-verified on push + needs the human to enable Settings ▸ Pages ▸ Source = "GitHub Actions" (engine/CI builds, human ships); workflow YAML + local strict build verified
+
+### Goal met?   (map the evidence back to this milestone's Exit criteria — read before the Exit-criteria boxes are checked)
+- [x] criterion 1 (strict build, all chapters+appendices+diagrams, no warnings) — met by site-scaffold (local `mkdocs build --strict` exit 0; 24 pages + 4 PNG + search index)
+- [x] criterion 2 (home/landing + search + dark/light) — met by site-scaffold (README→index.html; rendered HTML carries the search box + palette toggle)
+- [~] criterion 3 (push triggers CI build+deploy) — BUILT + locally verified (workflow YAML shape + the same `mkdocs build --strict`); the live green run is PENDING the human enabling Pages + merge/push (honest ceiling, not faked)
+- [~] criterion 4 (reachable at the public URL + links point to it) — links DONE (homepage/pyproject/README → Pages URL); reachability PENDING the first live deploy
+- goal: a reader can browse + search the full AIDD book at a public Pages URL — PROVEN buildable end-to-end locally; the public URL goes live on the human's enable-Pages + merge. Criteria 3–4 close once the first `docs` workflow run is green.
+
+## Release steps   (AI-DEFINED — fill the ordered steps to ship this milestone; engine records, human gate)
+> The AI writes the release steps for THIS milestone here (hints, not engine commands). MERGE is one
+> small step among them. These feed the release scope (release.md) when the cut is bundled.
+- [ ] open a PR from a `feat/docs-site` branch (the work: mkdocs.yml · requirements-docs.txt · .gitignore · pages.yml · the 3 link edits) — the human reviews + merges
+- [ ] enable GitHub Pages: repo Settings ▸ Pages ▸ Build and deployment ▸ Source = "GitHub Actions" (one-time, human-owned)
+- [ ] merge to main → the `docs` workflow builds `--strict` + deploys → confirm the run is green and the site is live at https://pilotspace.github.io/ADD/ (closes exit criteria 3–4)
+- [ ] (optional, later) bundle this milestone into the next release cut (`release.md`) — docs-site is orthogonal to the package version; no version bump shipped here

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": null,
+  "active_task": "pages-deploy",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -1195,10 +1195,81 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "site-scaffold": {
+      "title": "MkDocs Material site scaffold over the canonical book",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": "docs-site",
+      "depends_on": [],
+      "created": "2026-06-24T06:16:19+00:00",
+      "updated": "2026-06-24T06:44:17+00:00",
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "30b92ed40cb80e0c702f4f27d1b2f85d",
+        "tests": {
+          ".add/tasks/site-scaffold/tests/test_site_scaffold.py": "e55c8bb45b924d0a5c9a5a513a50adc3"
+        }
+      },
+      "scope": {
+        "declared": [
+          "mkdocs.yml",
+          "requirements-docs.txt",
+          ".gitignore",
+          "./"
+        ],
+        "snapshot_md5": "0ab4f2ea9a4980955307e9e29ad933cc"
+      },
+      "heal": {
+        "attempts": 1,
+        "history": [
+          {
+            "at": "2026-06-24T06:42:29+00:00",
+            "reason": "scope_violation: task 'site-scaffold' touched outside its declared \u00a75 Scope \u2014 .gitignore \u00b7 mkdocs.yml \u00b7 requirements-docs.txt (3 total)",
+            "source": "scope"
+          }
+        ]
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
+    },
+    "pages-deploy": {
+      "title": "GitHub Actions workflow: build --strict + deploy the docs site to Pages",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": "docs-site",
+      "depends_on": [],
+      "created": "2026-06-24T06:45:26+00:00",
+      "updated": "2026-06-24T07:02:31+00:00",
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "131e62dd7d5445893cdcc7a12ec079c5",
+        "tests": {
+          ".add/tasks/pages-deploy/tests/test_pages_deploy.py": "0e997e2d80d719975b5536e8ac17451f"
+        }
+      },
+      "scope": {
+        "declared": [
+          ".github/workflows/pages.yml",
+          "add-method/package.json",
+          "add-method/pyproject.toml",
+          "README.md",
+          "./"
+        ],
+        "snapshot_md5": "0ab4f2ea9a4980955307e9e29ad933cc"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-06-23T16:59:02+00:00",
+  "updated": "2026-06-24T07:02:31+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -1380,9 +1451,26 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "docs-site": {
+      "title": "Docs site \u2014 ship the AIDD book to GitHub Pages",
+      "goal": "a reader can browse and search the full AIDD book at a public GitHub Pages URL, built with MkDocs Material from the canonical add-method/docs/ and deployed automatically by CI",
+      "stage": "mvp",
+      "status": "active",
+      "created": "2026-06-24T06:13:01+00:00",
+      "updated": "2026-06-24T06:16:16+00:00",
+      "confirmed": true,
+      "confirmed_at": "2026-06-24T06:16:16+00:00",
+      "confirmed_by": "tindang",
+      "await_confirm": true,
+      "actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
-  "active_milestone": null,
+  "active_milestone": "docs-site",
   "archived": [
     {
       "slug": "v5",
@@ -1837,8 +1925,11 @@
       "archived": "2026-06-23"
     }
   ],
-  "active_milestones": [],
+  "active_milestones": [
+    "docs-site"
+  ],
   "active_tasks": {
-    "flow-simplification": "phase-review"
+    "flow-simplification": "phase-review",
+    "docs-site": "pages-deploy"
   }
 }

--- a/.add/tasks/pages-deploy/TASK.md
+++ b/.add/tasks/pages-deploy/TASK.md
@@ -1,0 +1,297 @@
+# TASK: GitHub Actions workflow: build --strict + deploy the docs site to Pages
+
+slug: pages-deploy · created: 2026-06-24 · stage: mvp
+autonomy: auto   <!-- inherited from the project default (PROJECT.md); explicit level: manual < conservative < auto (visible · overridable) — lower below if a high-risk task needs it, or run `add.py autonomy set`. -->
+phase: done   <!-- ground -> specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+<!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower the
+     autonomy level to `manual` or `conservative` — the engine refuses an unguarded completion
+     (`unguarded_high_risk_auto`, run.md guard). A comment is never a declaration. -->
+
+> One file = one task. Fill sections top-to-bottom; the `add` skill drives each phase.
+> When a phase is unclear, read its book chapter in `.add/docs/` (linked per section).
+> The phase marker above is the single source of truth — keep it in sync via `add.py phase`.
+
+---
+
+## 0 · GROUND — the real codebase ▸ docs/02-the-flow.md
+
+Touches (files · symbols · signatures):
+- `.github/workflows/pages.yml` — NEW · the build+deploy workflow (triggers `push: main` + `workflow_dispatch`; jobs build [`pip install -r requirements-docs.txt` → `mkdocs build --strict`] → deploy via `actions/deploy-pages`).
+- `add-method/package.json` — EDIT · `homepage` currently `https://github.com/pilotspace/ADD#readme` → the Pages URL `https://pilotspace.github.io/ADD/`.
+- `add-method/pyproject.toml` — EDIT · `[project.urls]` (Homepage/Repository/Issues) → add `Documentation = "https://pilotspace.github.io/ADD/"`.
+- `README.md` (repo root, 6.6K) — EDIT · add a "Read the book online" link to the Pages site (the GitHub landing).
+- `mkdocs.yml` (repo root) — READ · `site_url: https://pilotspace.github.io/ADD/` is already set (site-scaffold); the workflow builds it.
+
+Context (working folder):
+- `.github/workflows/` — existing: `ci.yml` (unittest suite), `codeql.yml`, `publish.yml` (tag→npm/PyPI). The Pages workflow is a NEW sibling; reuse the `actions/checkout@v5` + `actions/setup-python@v6` pin style from ci.yml.
+- `add-method/README.md` — the PUBLISHED (npm/PyPI) README; line 11–12 already links the bundled `docs/`; can add an "online" link too.
+- the GitHub Pages source = "GitHub Actions" (not a branch) — set in repo Settings ▸ Pages (HUMAN-owned, one-time).
+
+Honors (patterns / conventions):
+- (PROJECT §Spec, release-altitude) engine/CI RECORDS + builds; the HUMAN ships — enabling Pages (Settings ▸ Pages ▸ Source = GitHub Actions) + the first publish are human-owned, never automated.
+- (CONVENTIONS) reuse the existing workflow action pins (`checkout@v5`, `setup-python@v6`); least-privilege `permissions:` (the Pages deploy needs `pages: write` + `id-token: write`, scoped to this workflow).
+- (ci.yml precedent) CI must `pip install -r requirements-docs.txt` so the `--strict` build has mkdocs-material (mirrors ci.yml's node-deps lesson: a missing build dep silently degrades a job).
+- bundle parity: `_bundled/` mirrors only `docs/ skill/ tooling/` — package.json/pyproject/README.md edits are NOT mirrored (parity untouched).
+
+Anchors the contract cites (the §3 names):
+- `.github/workflows/pages.yml` keys: `on.push.branches:[main]` + `on.workflow_dispatch` · `permissions: {contents: read, pages: write, id-token: write}` · `concurrency: pages` · job `build` (`mkdocs build --strict` + `upload-pages-artifact`) · job `deploy` (`environment: github-pages` + `deploy-pages`).
+- `add-method/package.json#homepage` · `add-method/pyproject.toml [project.urls].Documentation` · `README.md` site link · the Pages URL `https://pilotspace.github.io/ADD/`.
+- verifier: workflow YAML parses + asserts the keys above; the published packages' VERSIONS are unchanged; the live deploy is human/CI-verified on push (can't run GitHub Actions locally).
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+Feature: A GitHub Actions workflow that builds the MkDocs site `--strict` and deploys it to GitHub Pages on every push to main, plus homepage/README links pointing at the live site.
+Framings weighed: official GitHub Pages deploy actions (chosen — `configure/upload-pages-artifact` + `deploy-pages`, OIDC, no extra branch, matches publish.yml's modern style) · the `gh-pages` branch via `mkdocs gh-deploy`/peaceiris (older, pushes a build branch) · Netlify/Vercel (external host, off-platform).
+Must:
+<must>
+  - `.github/workflows/pages.yml` triggers on `push` to `main` AND `workflow_dispatch` (manual re-deploy).
+  - the build job runs `pip install -r requirements-docs.txt` then `mkdocs build --strict` and uploads `site/` via `actions/upload-pages-artifact`.
+  - the deploy job uses `actions/deploy-pages` with `environment: github-pages`, `permissions: {pages: write, id-token: write}`, and a `concurrency: pages` group (no overlapping deploys).
+  - `add-method/package.json` `homepage`, `add-method/pyproject.toml` `[project.urls]` (a `Documentation` entry), and the repo-root `README.md` point at the Pages URL `https://pilotspace.github.io/ADD/`.
+  - the published packages' VERSIONS (`package.json` `version`, `pyproject` `version`) are unchanged by this task; `add-method/docs/` + `_bundled/` stay byte-unchanged.
+</must>
+Reject:
+<reject>
+  - the workflow's deploy job lacks `pages: write` or `id-token: write` -> "insufficient_pages_permissions"   (the Pages deploy fails)
+  - the build job omits `pip install -r requirements-docs.txt` before `mkdocs build` -> "missing_build_dep"   (strict build fails in CI — the ci.yml node-deps lesson, applied)
+  - this task changes a package `version` field -> "version_drift"   (it touches URLs only; releasing is a separate scope)
+  - `homepage`/README still point only at the old `github.com/...#readme` with no Pages link -> "stale_homepage"
+</reject>
+After:
+<after>
+  - pushing to main runs `pages.yml`, which builds the book `--strict` and deploys it to GitHub Pages; the site is reachable at `https://pilotspace.github.io/ADD/`; `homepage`/README link to it; package versions are unchanged.
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ [contract/test] the LIVE deploy cannot be verified locally — there is no GitHub Actions runner here, so I can only assert the workflow YAML shape + the link edits; lowest confidence on whether the deploy job's environment/permissions exactly match THIS repo's Pages once enabled; if wrong: the first push's deploy job fails (visible in the Actions tab), fixed by a workflow tweak — and it REQUIRES the human to first set Settings ▸ Pages ▸ Source = "GitHub Actions".
+  - [ ] the Pages URL is `https://pilotspace.github.io/ADD/` (org `pilotspace`, project repo `ADD` — note the repo name's casing in the path) — confirm against the repo's actual Pages settings.
+  - [ ] `mkdocs-material` installs on the ubuntu CI runner via pip (it does on PyPI) — high confidence; the workflow pins setup-python to 3.12 (matches ci.yml).
+</assumptions>
+
+<!-- EXIT: every rule stated, every rejection named; assumptions ranked lowest-confidence first, the top one or two ⚠-flagged with why + cost (or, for trivial scope, an honest "none material" that still names the single biggest risk). -->
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: workflow triggers on push to main and manual dispatch
+  Given .github/workflows/pages.yml exists
+  When I read its `on:` block
+  Then it lists push to branch main AND workflow_dispatch
+
+Scenario: build job builds the site strictly with its deps
+  Given the build job
+  When I read its steps
+  Then it installs requirements-docs.txt, runs `mkdocs build --strict`, and uploads site/ via actions/upload-pages-artifact
+
+Scenario: deploy job has Pages permissions and environment
+  Given the deploy job
+  When I read its config
+  Then permissions include pages: write and id-token: write, environment is github-pages, and a concurrency: pages group is set
+
+Scenario: homepage and README point at the live site
+  Given the Pages URL https://pilotspace.github.io/ADD/
+  When I read package.json, pyproject.toml, and the repo-root README.md
+  Then each references the Pages URL (homepage / a Documentation url / a "read online" link)
+
+Scenario: the local strict build still passes (the workflow's build step)
+  Given the same `mkdocs build --strict` the workflow runs
+  When I run it locally
+  Then it exits 0 (the workflow's build step is real, not aspirational)
+
+# --- rejections ---
+
+Scenario: deploy without Pages permissions is rejected   # insufficient_pages_permissions
+  Given a pages.yml whose deploy job omits pages: write or id-token: write
+  When the workflow is validated
+  Then it is rejected as insufficient_pages_permissions
+  And the committed pages.yml DOES grant both (the guard test asserts presence)
+
+Scenario: build without its deps is rejected   # missing_build_dep
+  Given a build job that runs `mkdocs build` without installing requirements-docs.txt
+  When the workflow is validated
+  Then it is rejected as missing_build_dep
+  And the committed pages.yml DOES install requirements-docs.txt before mkdocs build
+
+Scenario: a version bump is out of scope   # version_drift
+  Given this task edits only URLs/links
+  When package.json and pyproject.toml are read
+  Then their `version` fields equal the pre-task values (1.9.0)
+  And no version field was changed
+
+Scenario: a stale-only homepage is rejected   # stale_homepage
+  Given homepage/README that link only to github.com/...#readme
+  When the link targets are checked
+  Then the absence of the Pages URL is rejected as stale_homepage
+  And the committed files DO include the Pages URL
+```
+
+</scenarios>
+
+<!-- EXIT: one scenario per Must AND per Reject; each result is observable. -->
+
+---
+
+## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
+
+```
+CI/CONFIG CONTRACT — a GitHub Pages deploy workflow + homepage/README links (no HTTP; shape = the workflow + link edits)
+
+FILE PRODUCED:
+  .github/workflows/pages.yml      (NEW)
+    name: docs
+    on:
+      push: { branches: [main] }
+      workflow_dispatch:
+    permissions: { contents: read, pages: write, id-token: write }
+    concurrency: { group: pages, cancel-in-progress: false }
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v5
+          - uses: actions/setup-python@v6   with: { python-version: '3.12' }
+          - run: pip install -r requirements-docs.txt
+          - run: mkdocs build --strict           # writes ./site
+          - uses: actions/configure-pages@v5
+          - uses: actions/upload-pages-artifact@v3   with: { path: site }
+      deploy:
+        needs: build
+        runs-on: ubuntu-latest
+        environment: { name: github-pages, url: ${{ steps.deployment.outputs.page_url }} }
+        steps:
+          - uses: actions/deploy-pages@v4   id: deployment
+
+FILES EDITED (link targets -> PAGES_URL = https://pilotspace.github.io/ADD/):
+  add-method/package.json     homepage -> PAGES_URL
+  add-method/pyproject.toml   [project.urls]  Documentation = PAGES_URL
+  README.md (repo root)       add a "Read the book online: PAGES_URL" line
+
+REJECTS (guard-test enforced on the committed files):
+  insufficient_pages_permissions — deploy lacks pages:write OR id-token:write
+  missing_build_dep              — build runs mkdocs without `pip install -r requirements-docs.txt` first
+  version_drift                  — package.json/pyproject `version` != 1.9.0 (unchanged)
+  stale_homepage                 — no file references PAGES_URL
+
+INVARIANTS (must hold):
+  - package.json.version == "1.9.0"  AND  pyproject.version == "1.9.0"  (unchanged)
+  - add-method/docs/ + add-method/src/add_method/_bundled/ byte-unchanged (no book/bundle touch)
+  - `mkdocs build --strict` (the workflow's build step) exits 0 locally
+```
+
+Status: FROZEN @ v1 — approved by Tin Dang
+Least-sure flag surfaced at freeze: ⚠ [contract/test] the live GitHub Pages deploy cannot be verified locally (no Actions runner) — I assert the workflow YAML shape + the homepage/README link edits + a local `mkdocs build --strict`; the real deploy is CI-verified on the first push AND requires the human to set Settings ▸ Pages ▸ Source = "GitHub Actions" first (engine/CI builds, human ships). Secondary [contract]: the Pages URL casing `https://pilotspace.github.io/ADD/` should be confirmed against the repo's Pages settings.
+<!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
+     points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
+     with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
+     too — see run.md). Approved -> Status: FROZEN @ vN — approved by <name>. Changing a frozen
+     contract = change request back to SPECIFY.
+     EXIT: frozen + every spec rejection has a contracted response + names match GLOSSARY + the
+     bundle's lowest-confidence flag was surfaced at the freeze (or an honest "none material"). -->
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: every Must + every Reject has one test (workflow YAML shape + link edits; the live deploy is CI-verified, not local).
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_workflow_triggers: parse pages.yml / assert on.push.branches==[main] AND on has workflow_dispatch
+  - test_build_job_strict_with_deps (missing_build_dep): build steps install requirements-docs.txt BEFORE `mkdocs build --strict`; uploads via actions/upload-pages-artifact
+  - test_deploy_job_permissions (insufficient_pages_permissions): permissions has pages: write AND id-token: write; deploy uses actions/deploy-pages; environment github-pages; concurrency group pages
+  - test_links_point_at_pages (stale_homepage): package.json homepage == PAGES_URL; pyproject [project.urls] has Documentation==PAGES_URL; repo-root README contains PAGES_URL
+  - test_versions_unchanged (version_drift): package.json version == "1.9.0" AND pyproject version == "1.9.0"
+  - test_book_and_bundle_unchanged: add-method/docs/ and _bundled/ git-status clean (no book/bundle touch)
+  - test_local_strict_build_ok: if mkdocs importable -> `mkdocs build --strict` exits 0 (the workflow's build step is real); else skip with reason
+</test_plan>
+
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+<!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
+     a token with "/" = project root · a bare name = sibling of the previous
+     token's dir · a directory counts its *.py files (non-recursive); reports
+     mark declared counts with † · anything resolving outside the project root counts 0 -->
+
+<!-- EXIT: one test per scenario; suite red for the RIGHT reason; target recorded. -->
+
+---
+
+## 5 · BUILD — AI writes code ▸ docs/07-step-5-build.md
+
+Scope (may touch): `.github/workflows/pages.yml` `add-method/package.json` `add-method/pyproject.toml` `add-method/../README.md`   <slash-bearing tokens resolve at project root; README.md uses the `add-method/..` climb (a bare name would resolve to the task dir — the site-scaffold scope_violation lesson). No book/bundle/engine edit.>
+Strategy (ordered batches):
+  1. write `.github/workflows/pages.yml` (build job: checkout → setup-python 3.12 → pip install requirements-docs.txt → mkdocs build --strict → configure-pages → upload-pages-artifact; deploy job: deploy-pages with github-pages env + pages/id-token perms + concurrency pages).
+  2. edit `add-method/package.json` `homepage` → PAGES_URL (leave `version` untouched).
+  3. edit `add-method/pyproject.toml` `[project.urls]` → add `Documentation = PAGES_URL` (leave `version` untouched).
+  4. edit repo-root `README.md` → add a "Read the book online: PAGES_URL" link.
+  5. confirm `mkdocs build --strict` still exits 0 locally (the workflow's build step is real).
+Safety rule (feature-specific): touch NO `version` field, NO file under `add-method/docs/` or `_bundled/`; never edit a test or the §3 contract to make a check pass.
+Code lives in: `.github/workflows/pages.yml` + the 3 link-target files (package.json, pyproject.toml, repo-root README.md).
+Constraints: do NOT change any test or the contract; no version bump; allow-list only (no new dependency); ask if unclear.
+
+<!-- Scope tokens, backticked, FIRST declaring line: `./…` = this task dir · a token
+     with "/" = project root · a bare name = sibling of the previous token's dir ·
+     outside-root resolutions are dropped fail-closed · a DIRECTORY token covers its
+     whole subtree (containment — diverges from §4's non-recursive counting) ·
+     absent line = UNDECLARED (pre-existing tasks grandfathered, never retro-red) ·
+     engine enforcement (touched ⊆ declared) lands in scope-gate-enforce.
+     EXIT: all green; coverage held; no test/contract touched; no unlisted dependency. -->
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [x] all tests pass — 7/7 green (workflow YAML shape, link edits, versions, book-unchanged, local strict build)
+- [x] coverage did not decrease — new task; 7 tests added (4 behavior + 3 invariant guards)
+- [x] no test or contract was altered during build — only §5-scoped files written; tamper snapshot intact
+- [x] the green was EARNED, not gamed — tests parse the REAL workflow (perms/triggers/step order) + assert exact URLs + run a REAL `mkdocs build --strict`; honest open item: the LIVE deploy is CI-verified on push (disclosed in the freeze ⚠ flag), not faked green here
+- [x] concurrency / timing — the workflow sets `concurrency: {group: pages, cancel-in-progress: false}` so deploys don't overlap (the one timing concern, handled)
+- [x] no exposed secrets, injection openings, or unexpected dependencies — least-privilege `permissions` (contents:read, pages:write, id-token:write); the only `${{ }}` is the trusted `steps.deployment.outputs.page_url`; NO untrusted event input in any `run:`; no secrets; no new dep
+- [x] layering & dependencies follow CONVENTIONS.md — action pins match ci.yml style (checkout@v5, setup-python@v6); the build-dep install mirrors the ci.yml node-deps lesson
+- [~] a person reviewed and approved the change — AUTO-RESOLVED under `autonomy: auto` (no security finding); the HUMAN owns the residual ship step (enable Settings ▸ Pages ▸ Source = GitHub Actions, then merge) — surfaced in the report, not hidden
+
+### Build expectations — what "correct" looks like (fill BEFORE build; confirm each at the gate)
+> Pre-declare the OBSERVABLE outcomes a correct build must produce — derived from §2 SCENARIOS
+> + §3 CONTRACT — so this gate checks the build is RIGHT, not merely that tests are green. Each
+> row is evidence you can SEE, not a restatement of a test name.
+- [x] `.github/workflows/pages.yml` parses as valid YAML with the build+deploy jobs, push:main + workflow_dispatch triggers, and pages/id-token permissions — confirmed: yaml.safe_load → jobs [build, deploy], perms {contents:read, pages:write, id-token:write}, on {push.branches:[main], workflow_dispatch}
+- [x] the build job installs requirements-docs.txt before `mkdocs build --strict` and uploads `site/` — confirmed by reading the step list (install → strict build → configure-pages → upload-pages-artifact path: site)
+- [x] package.json `homepage`, pyproject `Documentation` url, and repo-root README all contain `https://pilotspace.github.io/ADD/` — confirmed by grep (3/3)
+- [x] package versions still `1.9.0` and `add-method/docs/`+`_bundled/` byte-unchanged — confirmed: both versions == 1.9.0; `git status --porcelain` on docs/+_bundled clean
+- [x] `mkdocs build --strict` still exits 0 locally (the workflow's build step is honest) — confirmed: exit 0
+
+### Deep checks — do not skim (fill the path that applies; the resolver judges which)
+- [x] SEMANTIC (prose / non-code) — read in full, not skimmed: read `.github/workflows/pages.yml` end-to-end (two jobs; deploy `needs: build`; env github-pages; the page_url is the only template expr — trusted; paths-filter scopes re-deploys to docs/config changes) · read the package.json/pyproject/README hunks (Pages URL exactly, versions untouched) · confirmed the freeze ⚠: the live deploy needs the human to set Pages Source = GitHub Actions
+- [n/a] WIRING / DEAD-CODE (code) — no Python/JS symbols; artifacts are workflow YAML + URL string edits
+
+### GATE RECORD
+Outcome: PASS
+Auto-resolved: yes (run: pages-deploy verify; autonomy: auto) — evidence complete, residue checks clear (security reviewed: least-privilege perms, no untrusted-input injection, no secrets; the only timing concern — overlapping deploys — is handled by `concurrency: pages`). RESIDUAL human ship-step (NOT a gate failure): enable Settings ▸ Pages ▸ Source = "GitHub Actions" + merge to publish — surfaced to the human, engine/CI builds the rest.
+Reviewed by: auto-gate (autonomy: auto) · date: 2026-06-24
+
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): the `docs` workflow's run status on each push to main (a red build = a broken book link before it ships) · the deploy job's published URL matching the homepage/README links · package versions staying decoupled from this URL-only task.
+
+### Spec delta
+Forward changes for the next loop — each re-enters at Specify as the next task. One line
+each, tagged `[SPEC · open|seeded|dropped]`, with evidence (e.g. `[SPEC · open] rate-limit
+the retry path (evidence: prod herd spikes)`). See the `add` skill's `deltas.md`.
+- [SPEC · open] the docs `pages.yml` and the suite `ci.yml` both rebuild on docs changes; a future polish could fold the strict-build check into ci.yml so a broken book link fails a PR BEFORE merge, not only on the post-merge deploy (evidence: pages.yml only runs on push to main + dispatch, not PRs).
+- [SPEC · open] consider adding `requirements-docs.txt` (mkdocs-material) to Dependabot/renovate so the docs toolchain stays patched like the npm/pip deps (evidence: it's a new, separately-pinned dep file).
+
+### Competency deltas
+What did this loop teach the foundation? One line each, tagged by competency
+(`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
+<!-- e.g.  - [DDD · open] the model missed multi-tenancy (evidence: scenario_x failed) -->
+- [ADD · open] a deploy task whose final step is inherently human-and-remote (enable Pages, merge, live publish) is honestly verified by asserting the ARTIFACT shape (workflow YAML keys + a real local strict build) + DISCLOSING the un-local-verifiable deploy in the freeze flag — not by faking a green; the residual ship-step belongs to the human (release-altitude's "engine records, human ships") (evidence: gate PASS auto-resolved with the live-deploy residual surfaced, not hidden).
+- [SDD · open] YAML 1.1 parses a bare `on:` key as the boolean True — a workflow-shape test must read `cfg.get("on", cfg.get(True))` or it silently asserts against a missing key (evidence: the trigger test needed the True-key fallback to see the `on:` block).
+- [TDD · open] for a deploy task, the invariant guards (versions unchanged · book/bundle clean) are GREEN at red-time by design — they assert preservation; only the artifact-shape tests are red pre-build, and that mix is honest red (evidence: 4 behavior tests red + 3 invariant tests green before build → all 7 green after).

--- a/.add/tasks/pages-deploy/tests/test_pages_deploy.py
+++ b/.add/tasks/pages-deploy/tests/test_pages_deploy.py
@@ -1,0 +1,159 @@
+"""Red/green suite for the pages-deploy task (docs-site milestone).
+
+Pins the FROZEN §3 contract: a GitHub Actions workflow that builds the MkDocs site
+`--strict` and deploys it to GitHub Pages, plus homepage/README links to the live
+site, with package versions unchanged and book/bundle untouched.
+
+Runs RED until .github/workflows/pages.yml exists and the link edits land.
+Stdlib `unittest`; PyYAML parses the workflow (it ships with mkdocs-material).
+
+NB: in YAML 1.1 the bare key `on:` parses as the boolean True — so the workflow's
+`on:` block is read as cfg[True]; helpers below normalise that.
+
+Repo root is 4 parents above this file.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+WF = REPO / ".github" / "workflows" / "pages.yml"
+PKG_JSON = REPO / "add-method" / "package.json"
+PYPROJECT = REPO / "add-method" / "pyproject.toml"
+ROOT_README = REPO / "README.md"
+DOCS = REPO / "add-method" / "docs"
+BUNDLE_DOCS = REPO / "add-method" / "src" / "add_method" / "_bundled" / "docs"
+
+PAGES_URL = "https://pilotspace.github.io/ADD/"
+EXPECTED_VERSION = "1.9.0"
+
+
+def _load_yaml(path: Path) -> dict:
+    import yaml
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _on_block(cfg: dict):
+    # `on:` parses to the boolean True key under YAML 1.1
+    return cfg.get("on", cfg.get(True))
+
+
+def _all_steps(job: dict) -> list[dict]:
+    return [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+
+
+def _require_yaml(tc: unittest.TestCase):
+    try:
+        import yaml  # noqa: F401
+    except Exception:
+        tc.skipTest("PyYAML not installed — ships with mkdocs-material")
+
+
+class TestWorkflowTriggers(unittest.TestCase):
+    def test_workflow_triggers(self):
+        self.assertTrue(WF.is_file(), ".github/workflows/pages.yml must exist")
+        _require_yaml(self)
+        on = _on_block(_load_yaml(WF))
+        self.assertIsInstance(on, dict, "the workflow must have an `on:` block")
+        push = on.get("push") or {}
+        branches = push.get("branches") or []
+        self.assertIn("main", branches, "must trigger on push to main")
+        self.assertIn("workflow_dispatch", on, "must allow manual workflow_dispatch")
+
+
+class TestBuildJob(unittest.TestCase):
+    def test_build_job_strict_with_deps(self):
+        self.assertTrue(WF.is_file())
+        _require_yaml(self)
+        jobs = _load_yaml(WF).get("jobs") or {}
+        build = jobs.get("build") or {}
+        steps = _all_steps(build)
+        runs = [str(s.get("run", "")) for s in steps]
+        uses = [str(s.get("uses", "")) for s in steps]
+        # deps installed BEFORE mkdocs build (missing_build_dep guard)
+        install_idx = next((i for i, r in enumerate(runs) if "requirements-docs.txt" in r), -1)
+        build_idx = next((i for i, r in enumerate(runs) if "mkdocs build" in r and "--strict" in r), -1)
+        self.assertGreaterEqual(install_idx, 0, "build must `pip install -r requirements-docs.txt`")
+        self.assertGreaterEqual(build_idx, 0, "build must run `mkdocs build --strict`")
+        self.assertLess(install_idx, build_idx, "deps must be installed before the strict build")
+        self.assertTrue(any("upload-pages-artifact" in u for u in uses),
+                        "build must upload the site via actions/upload-pages-artifact")
+
+
+class TestDeployJob(unittest.TestCase):
+    def test_deploy_job_permissions(self):
+        self.assertTrue(WF.is_file())
+        _require_yaml(self)
+        cfg = _load_yaml(WF)
+        perms = cfg.get("permissions") or {}
+        self.assertEqual(perms.get("pages"), "write", "permissions.pages must be write")
+        self.assertEqual(perms.get("id-token"), "write", "permissions.id-token must be write")
+        jobs = cfg.get("jobs") or {}
+        deploy = jobs.get("deploy") or {}
+        uses = [str(s.get("uses", "")) for s in _all_steps(deploy)]
+        self.assertTrue(any("deploy-pages" in u for u in uses),
+                        "deploy must use actions/deploy-pages")
+        env = deploy.get("environment")
+        env_name = env if isinstance(env, str) else (env or {}).get("name")
+        self.assertEqual(env_name, "github-pages", "deploy environment must be github-pages")
+        conc = cfg.get("concurrency")
+        grp = conc if isinstance(conc, str) else (conc or {}).get("group")
+        self.assertEqual(grp, "pages", "a concurrency group `pages` must be set")
+
+
+class TestLinksAndVersions(unittest.TestCase):
+    def test_links_point_at_pages(self):
+        pkg = json.loads(PKG_JSON.read_text(encoding="utf-8"))
+        self.assertEqual(pkg.get("homepage"), PAGES_URL, "package.json homepage must be the Pages URL")
+        pyproject = PYPROJECT.read_text(encoding="utf-8")
+        self.assertRegex(pyproject, r"(?mi)^\s*Documentation\s*=\s*\"" + re.escape(PAGES_URL) + r"\"",
+                         "pyproject [project.urls] must have a Documentation = Pages URL")
+        self.assertIn(PAGES_URL, ROOT_README.read_text(encoding="utf-8"),
+                      "repo-root README must link the Pages URL")
+
+    def test_versions_unchanged(self):
+        pkg = json.loads(PKG_JSON.read_text(encoding="utf-8"))
+        self.assertEqual(pkg.get("version"), EXPECTED_VERSION, "package.json version must be unchanged")
+        pyproject = PYPROJECT.read_text(encoding="utf-8")
+        m = re.search(r'(?m)^version\s*=\s*"([^"]+)"', pyproject)
+        self.assertIsNotNone(m, "pyproject must declare a version")
+        self.assertEqual(m.group(1), EXPECTED_VERSION, "pyproject version must be unchanged")
+
+
+class TestBookUnchanged(unittest.TestCase):
+    def test_book_and_bundle_unchanged(self):
+        if shutil.which("git") is None:
+            self.skipTest("git unavailable")
+        out = subprocess.run(
+            ["git", "status", "--porcelain", "--",
+             "add-method/docs", "add-method/src/add_method/_bundled"],
+            cwd=str(REPO), capture_output=True, text=True,
+        ).stdout.strip()
+        self.assertEqual(out, "", f"book/bundle must be byte-unchanged, got:\n{out}")
+
+
+class TestLocalStrictBuild(unittest.TestCase):
+    def test_local_strict_build_ok(self):
+        try:
+            import mkdocs  # noqa: F401
+        except Exception:
+            if shutil.which("mkdocs") is None:
+                self.skipTest("mkdocs not installed — strict build is the workflow's job (CI)")
+        with tempfile.TemporaryDirectory() as td:
+            proc = subprocess.run(
+                [sys.executable, "-m", "mkdocs", "build", "--strict", "--site-dir", str(Path(td) / "s")],
+                cwd=str(REPO), capture_output=True, text=True,
+            )
+            self.assertEqual(proc.returncode, 0,
+                             f"the workflow's `mkdocs build --strict` must pass locally:\n{proc.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.add/tasks/site-scaffold/TASK.md
+++ b/.add/tasks/site-scaffold/TASK.md
@@ -1,0 +1,306 @@
+# TASK: MkDocs Material site scaffold over the canonical book
+
+slug: site-scaffold · created: 2026-06-24 · stage: mvp
+autonomy: auto   <!-- inherited from the project default (PROJECT.md); explicit level: manual < conservative < auto (visible · overridable) — lower below if a high-risk task needs it, or run `add.py autonomy set`. -->
+phase: done   <!-- ground -> specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+<!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower the
+     autonomy level to `manual` or `conservative` — the engine refuses an unguarded completion
+     (`unguarded_high_risk_auto`, run.md guard). A comment is never a declaration. -->
+
+> One file = one task. Fill sections top-to-bottom; the `add` skill drives each phase.
+> When a phase is unclear, read its book chapter in `.add/docs/` (linked per section).
+> The phase marker above is the single source of truth — keep it in sync via `add.py phase`.
+
+---
+
+## 0 · GROUND — the real codebase ▸ docs/02-the-flow.md
+
+Touches (files · symbols · signatures):
+- `mkdocs.yml` (repo root) — NEW · the site config: `site_name`, `docs_dir: add-method/docs`, `theme.name: material`, `nav:` (ordered), `plugins: [search]`, `theme.palette` (dark/light toggle). The riskiest contract.
+- `add-method/docs/index.md` — NEW · the home/landing page (docs_dir currently has `README.md` H1 "AI-Driven Development" 4.1K but NO `index.md`; Material uses index.md as site root).
+- `requirements-docs.txt` (repo root) — NEW · pins `mkdocs-material` (build-time only — keeps the published package zero-dep; see Honors).
+- `.gitignore` (repo root) — EDIT · add `site/` (MkDocs default build output, currently un-ignored).
+- READ-only source (the book, single source of truth): `add-method/docs/` = 17 chapters `00-introduction.md`→`16-releasing.md` + 7 appendices `appendix-a..g` + 4 PNG (`add-competencies/flow/foundation/hierarchy.png`). All 24 .md carry a clean `# ` H1 (nav labels). PNGs referenced `./<name>.png` (in-dir, relative). ~165 markdown links, ALL sibling-relative (`./x.md`/`#anchor`) — 0 parent/absolute/`.add/` links (grep-verified) → strict-build link resolution is in-tree.
+
+Context (working folder):
+- `add-method/pyproject.toml` — `pilotspace-add`, `dependencies = []` (the published package is zero-dep; do NOT add mkdocs there).
+- `add-method/package.json` — `@pilotspace/add` 1.9.0, `homepage` → GitHub README (pages-deploy task updates this, not this task).
+- `.gitignore` — already ignores `.add/docs/` (dogfood copy) + `add-method/.add/`; the site build reads `add-method/docs/` (canonical) only.
+- `add-method/docs/README.md` — present in docs_dir; with an explicit `nav:` it must be included OR excluded, else `--strict` warns "not in nav".
+
+Honors (patterns / conventions):
+- (CONVENTIONS) lean-dependency posture — engine is stdlib-only; the published package stays `dependencies = []`. mkdocs-material is a BUILD-TIME dep, declared in one place (`requirements-docs.txt`), never a runtime/package dep.
+- (PROJECT §Spec) "a new runtime dependency falsifies any zero-dep prose" — mkdocs is build-time, so it does NOT falsify the package's zero-dep claim; keep that boundary explicit.
+- (MILESTONE shared decisions) single source = canonical `add-method/docs/` in place (no copy); `mkdocs build --strict` is the red/green seam.
+
+Anchors the contract cites (the NEW config keys §3 freezes):
+- `mkdocs.yml` keys: `site_name` · `docs_dir: add-method/docs` · `theme.name: material` · `theme.palette` (scheme toggle) · `plugins: [search]` · `nav:` (ordered: Home=index.md → 00..16 → appendix a..g)
+- `add-method/docs/index.md` (site root) · `requirements-docs.txt` (mkdocs-material pin) · `.gitignore` += `site/`
+- verifier: `mkdocs build --strict` exits 0 producing `site/index.html` + every chapter/appendix HTML + the 4 PNGs.
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+Feature: MkDocs-Material site scaffold that renders the canonical AIDD book from `add-method/docs/` as a navigable, searchable static site.
+Framings weighed: explicit `nav:` in mkdocs.yml (chosen — deterministic order/labels, handles README, no extra plugin) · auto-nav via awesome-pages plugin (adds a dep + per-dir `.pages`, less control) · directory-URLs with no nav (loses chapter ordering).
+Must:
+<must>
+  - a `mkdocs.yml` at repo root sets `site_name`, `docs_dir: add-method/docs`, `theme.name: material`, a `theme.palette` dark/light scheme toggle, and `plugins: [search]`.
+  - the EXISTING `add-method/docs/README.md` is the site home — MkDocs maps `README.md` → `index.html` at the site root; NO new file is added to the book (book source stays byte-unchanged).
+  - `mkdocs.yml` carries an explicit ordered `nav:` — `Home: README.md` → chapters `00-introduction`…`16-releasing` (in number order) → appendices A…G. Every `docs_dir` book page is in nav (no orphan).
+  - the 4 PNG diagrams render in their chapters (they are inside `docs_dir`, so the build copies them).
+  - `requirements-docs.txt` at repo root pins `mkdocs-material` (build-time dependency only).
+  - `.gitignore` ignores the MkDocs build output `site/`.
+  - `mkdocs build --strict` exits 0 and writes `site/index.html` (from README.md) plus one HTML page per chapter and appendix.
+</must>
+Reject:
+<reject>
+  - a `nav:` entry points to a file not in `docs_dir` -> "nav_target_missing"   (strict build fails)
+  - a `.md` in `docs_dir` is in neither `nav:` -> "orphan_page"   (strict warns → fails under --strict; every book page must be listed)
+  - `mkdocs-material` is added to the PUBLISHED package deps (`pyproject.toml` `dependencies` / `package.json` `dependencies`) -> "runtime_dep_leak"
+  - the `site/` build output is left un-ignored (committable) -> "build_artifact_tracked"
+</reject>
+After:
+<after>
+  - running `mkdocs build --strict` from repo root produces a warning-free static `site/` containing the whole book (README home + 17 chapters + 7 appendices + 4 diagrams), with working client-side search and a dark/light toggle; the book source under `add-method/docs/` is byte-unchanged (no new file, no bundle/parity change), and the published package's dependency lists are unchanged (still empty).
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ MkDocs maps `README.md` → the directory home (`index.html`) when no `index.md` is present, and a nav entry `Home: README.md` resolves to it — lowest confidence because this is MkDocs default behavior I should confirm on the installed version (not a config I set); if wrong: the site root 404s or README strict-warns, fixed by either adding a thin site-only `index.md` OUTSIDE the bundle path or setting the nav home explicitly (localized to mkdocs.yml).
+  - [ ] `mkdocs-material` installs cleanly in the verify environment (it is on PyPI) — if the env is offline, the `--strict` verifier can't run; confirm pip access at tests/build.
+  - [ ] every chapter/README `[x](./y.md)` link resolves under --strict — grounding found 0 parent/abs/`.add` links (all in-tree); confirm clean at build.
+</assumptions>
+
+<!-- EXIT: every rule stated, every rejection named; assumptions ranked lowest-confidence first, the top one or two ⚠-flagged with why + cost (or, for trivial scope, an honest "none material" that still names the single biggest risk). -->
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: strict build produces the whole book
+  Given mkdocs.yml (docs_dir=add-method/docs) exists and README.md is the home
+  When I run `mkdocs build --strict` from the repo root
+  Then it exits 0 and site/index.html (from README.md) plus one HTML page per chapter (00..16) and appendix (a..g) is written
+  And the 4 PNG diagrams are copied into site/
+
+Scenario: nav is the full book in reading order
+  Given mkdocs.yml has an explicit nav
+  When I read the nav list
+  Then the entries are Home (README.md) then chapters 00-introduction..16-releasing in number order then appendices A..G
+
+Scenario: README is the home, book unchanged
+  Given add-method/docs/README.md already exists and no index.md is added
+  When site/index.html is rendered
+  Then it is README.md (what ADD is + the book TOC) served at the site root
+  And no new file was added to add-method/docs/ (the book source is byte-unchanged)
+
+Scenario: search and dark/light are on
+  Given the Material theme is configured
+  When I inspect mkdocs.yml
+  Then `plugins:` includes `search` and `theme.palette` defines a dark/light scheme toggle
+  And the built site/ contains the search index (search/search_index.json)
+
+Scenario: diagrams render in their chapters
+  Given the 4 PNGs sit in docs_dir next to the chapters that reference them with ./<name>.png
+  When the site builds
+  Then each referenced PNG resolves (no missing-image warning under --strict)
+
+Scenario: docs dependency is build-time only
+  Given requirements-docs.txt pins mkdocs-material
+  When I read add-method/pyproject.toml and add-method/package.json
+  Then mkdocs-material appears in neither's dependency list (the published package stays zero-dep)
+
+Scenario: build output is ignored
+  Given MkDocs writes site/ on build
+  When I read .gitignore
+  Then site/ is listed so the build output is never committed
+
+# --- rejections ---
+
+Scenario: a nav entry to a missing file fails the build   # nav_target_missing
+  Given a nav entry points at a file not in docs_dir
+  When I run `mkdocs build --strict`
+  Then it fails with a missing-doc error and writes no site/
+  And no partial/empty site/ is left committed (site/ stays ignored)
+
+Scenario: an un-listed page fails strict   # orphan_page
+  Given a book .md in docs_dir is absent from nav
+  When I run `mkdocs build --strict`
+  Then it fails on the not-in-nav warning
+  And the fix is to add it to nav (every book page is listed; no book file is deleted)
+
+Scenario: docs dep must not leak into the package   # runtime_dep_leak
+  Given mkdocs-material is the docs build dependency
+  When pyproject.toml `dependencies` and package.json `dependencies` are read
+  Then mkdocs-material is absent from both
+  And both dependency lists remain exactly as before this task (still empty)
+
+Scenario: the build artifact must stay untracked   # build_artifact_tracked
+  Given a `mkdocs build` has produced site/
+  When I run `git status`
+  Then site/ is ignored and shows no tracked files
+  And no file under site/ is added to the index
+```
+
+</scenarios>
+
+<!-- EXIT: one scenario per Must AND per Reject; each result is observable. -->
+
+---
+
+## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
+
+```
+CONFIG CONTRACT — a MkDocs site over the canonical book (no HTTP; the "shape" is the files + build behavior)
+
+FILES PRODUCED (exact paths):
+  mkdocs.yml                       (repo root, NEW) — required keys:
+      site_name: <string>
+      site_url:  <string>                         # the Pages URL (filled/confirmed in pages-deploy; placeholder OK here)
+      repo_url:  https://github.com/pilotspace/ADD
+      docs_dir:  add-method/docs
+      theme:
+        name: material
+        palette: [ {scheme: default,...}, {scheme: slate,...} ]   # dark/light toggle (≥2 entries)
+      plugins: [ search ]
+      nav:                                          # explicit + ordered, every book page listed:
+        - Home: README.md                           # MkDocs maps README.md -> index.html
+        - <17 chapters 00-introduction.md .. 16-releasing.md, in number order>
+        - <7 appendices appendix-a..g, in letter order>
+  requirements-docs.txt            (repo root, NEW) — exactly: mkdocs-material (pinned, e.g. >=9,<10)
+
+FILES EDITED:
+  .gitignore                       — add a line: site/
+
+NOT TOUCHED (decision: keep the home OUT of the book):
+  add-method/docs/**               — NO new file; README.md (existing) is the home; book source byte-unchanged
+  _bundled/docs/ + scripts/prepare_bundle.py — untouched (no bundle/parity change, since the book is unchanged)
+
+BUILD BEHAVIOR (the verifier):
+  `mkdocs build --strict`  (run from repo root)
+     exit 0  -> writes site/index.html (README.md) + 1 HTML page per chapter (00..16) + per appendix (a..g) + copies the 4 PNGs + search/search_index.json
+     exit !=0 -> on any of:  nav_target_missing (nav entry ∉ docs_dir) | orphan_page (docs_dir book .md ∉ nav) | a broken in-tree link
+
+INVARIANTS (must hold after build):
+  - add-method/pyproject.toml `dependencies` == []           (no runtime_dep_leak)
+  - add-method/package.json   `dependencies` unchanged       (no runtime_dep_leak)
+  - .gitignore contains `site/`                              (no build_artifact_tracked)
+  - add-method/docs/ is byte-unchanged — no file added, renamed, or deleted (README.md stays as-is)
+  - add-method/src/add_method/_bundled/docs/ untouched → test_bundle_parity stays green with no regeneration
+```
+
+Status: FROZEN @ v1 — approved by Tin Dang
+Least-sure flag surfaced at freeze: ⚠ [contract] README.md → site home relies on MkDocs' default README→index.html mapping (no index.md added) — if the installed MkDocs version doesn't map it, the site root 404s / strict-warns; fix is a thin site-only index.md outside the bundle path or an explicit nav home, localized to mkdocs.yml. Secondary [spec]: mkdocs-material must be pip-installable in the verify env (the build test skips + records if absent).
+<!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
+     points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
+     with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
+     too — see run.md). Approved -> Status: FROZEN @ vN — approved by <name>. Changing a frozen
+     contract = change request back to SPECIFY.
+     EXIT: frozen + every spec rejection has a contracted response + names match GLOSSARY + the
+     bundle's lowest-confidence flag was surfaced at the freeze (or an honest "none material"). -->
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: every Must + every Reject scenario has one test (config + build assertions; no Python src to cover).
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_mkdocs_config_keys: parse mkdocs.yml / assert site_name, docs_dir=="add-method/docs", theme.name=="material", plugins includes "search", theme.palette has ≥2 schemes (dark/light)
+  - test_nav_is_full_book_in_order: parse nav / assert order == Home(README.md) then 00..16 then appendix a..g; every nav target file exists in docs_dir
+  - test_readme_is_home_book_unchanged: assert nav home == README.md AND no index.md was added to add-method/docs/ (the book .md set is exactly the 24 known files — README + 17 chapters + 6... i.e. 7 appendices)
+  - test_search_and_palette_present: assert mkdocs.yml plugins has search AND palette toggle (two schemes with a switch)
+  - test_docs_dep_build_time_only (runtime_dep_leak): assert requirements-docs.txt pins mkdocs-material; assert "mkdocs" absent from pyproject.toml [project].dependencies AND package.json dependencies
+  - test_site_gitignored (build_artifact_tracked): assert ".gitignore" contains a "site/" line
+  - test_strict_build_produces_site (strict build + nav_target_missing + orphan_page + diagrams): if `mkdocs` importable -> run `mkdocs build --strict` in a tmp site_dir; assert exit 0, index.html (from README) + every chapter/appendix .html + the 4 PNGs + search_index.json present; else pytest.skip("mkdocs not installed") with a recorded reason
+</test_plan>
+
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+<!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
+     a token with "/" = project root · a bare name = sibling of the previous
+     token's dir · a directory counts its *.py files (non-recursive); reports
+     mark declared counts with † · anything resolving outside the project root counts 0 -->
+
+<!-- EXIT: one test per scenario; suite red for the RIGHT reason; target recorded. -->
+
+---
+
+## 5 · BUILD — AI writes code ▸ docs/07-step-5-build.md
+
+Scope (may touch): `add-method/../mkdocs.yml` `add-method/../requirements-docs.txt` `add-method/../.gitignore`   <repo-root files via the `add-method/..` climb — a slash-bearing token resolves at project root; a BARE name would resolve to the task dir (the cause of the first scope_violation). No add.py/engine/book/bundle edit.
+Strategy (ordered batches):
+  1. write `mkdocs.yml` (site_name · docs_dir: add-method/docs · material theme + palette toggle · search plugin · explicit ordered nav with `Home: README.md` first).
+  2. write `requirements-docs.txt` (`mkdocs-material` pinned).
+  3. add `site/` to `.gitignore`.
+  4. `pip install -r requirements-docs.txt` (or confirm mkdocs present) and run `mkdocs build --strict`; resolve any orphan/link warning by adjusting nav in mkdocs.yml only.
+Safety rule (feature-specific): touch NO file under `add-method/docs/` — the book (incl. README.md) stays byte-unchanged, so `_bundled/docs/` + bundle parity need no regeneration; never edit a test or the §3 contract to make strict pass — fix the config.
+Code lives in: repo root (`mkdocs.yml`, `requirements-docs.txt`, `.gitignore`) only.
+Constraints: do NOT change any test or the contract; allow-list packages only (mkdocs-material build-time only); ask if unclear.
+
+<!-- Scope tokens, backticked, FIRST declaring line: `./…` = this task dir · a token
+     with "/" = project root · a bare name = sibling of the previous token's dir ·
+     outside-root resolutions are dropped fail-closed · a DIRECTORY token covers its
+     whole subtree (containment — diverges from §4's non-recursive counting) ·
+     absent line = UNDECLARED (pre-existing tasks grandfathered, never retro-red) ·
+     engine enforcement (touched ⊆ declared) lands in scope-gate-enforce.
+     EXIT: all green; coverage held; no test/contract touched; no unlisted dependency. -->
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [x] all tests pass — 7/7 green (docs venv: mkdocs 1.6.1, mkdocs-material 9.x, PyYAML 6.0.3)
+- [x] coverage did not decrease — new task; 7 tests added (was 0), one per Must/Reject + a real strict build
+- [x] no test or contract was altered during build — only §5-scoped files written; tamper tripwire snapshot intact
+- [x] the green was EARNED, not gamed — the strict-build test runs a REAL `mkdocs build --strict` and asserts 24 chapter/appendix pages + README home + 4 PNGs + search index; config tests assert exact nav order + key values (no vacuous/overfit/stub)
+- [x] concurrency / timing — N/A (static site build, no concurrent/timed operation)
+- [x] no exposed secrets, injection openings, or unexpected dependencies — mkdocs.yml carries no secrets; one declared build-time dep (mkdocs-material) in requirements-docs.txt; no runtime dep added
+- [x] layering & dependencies follow CONVENTIONS.md — dep is build-time only; published packages stay `dependencies = []`; book/bundle untouched
+- [~] a person reviewed and approved the change — AUTO-RESOLVED under `autonomy: auto` (no security / no residue: infra/config, not a method/trust-layer edit); presented to the human as FYI; milestone CLOSE + pages-deploy remain human gates
+
+### Build expectations — what "correct" looks like (fill BEFORE build; confirm each at the gate)
+> Pre-declare the OBSERVABLE outcomes a correct build must produce — derived from §2 SCENARIOS
+> + §3 CONTRACT — so this gate checks the build is RIGHT, not merely that tests are green. Each
+> row is evidence you can SEE, not a restatement of a test name.
+- [x] `mkdocs build --strict` exits 0 with NO warnings — confirmed: exit=0; build log grepped, zero nav/link/image WARNINGs (the only red text is Material's MkDocs-2.0 vendor banner, not a build warning)
+- [x] the built `site/` has `index.html` + one page per chapter (00..16) + per appendix (a..g) + the 4 PNGs + `search/search_index.json` — confirmed by listing site/: index.html + 24 chapter/appendix pages + 4 PNGs + search/search_index.json
+- [x] opening the site shows a working dark/light toggle and a search box — confirmed by HTML grep of the rendered site/index.html: `data-md-component="search"` + `md-search__input`; `__palette` + `data-md-color-scheme` + "Switch to dark/light mode"
+- [x] `add-method/pyproject.toml`/`package.json` dependency lists are unchanged (still empty) — confirmed by `git status --porcelain` clean on both
+- [x] `add-method/docs/` is byte-unchanged (no new/renamed/deleted file) — confirmed by `git status --porcelain add-method/docs/ _bundled/docs/` clean; README is the home (MkDocs maps README→index.html), so no bundle regeneration was needed and parity holds untouched
+
+### Deep checks — do not skim (fill the path that applies; the resolver judges which)
+- [x] SEMANTIC (prose / non-code) — read in full, not skimmed: read mkdocs.yml end-to-end (every nav target maps to a real `add-method/docs/*.md`; docs_dir is canonical; palette has both schemes; only `search` plugin) · read requirements-docs.txt (mkdocs-material build-time only, pinned >=9,<10) · read the .gitignore hunk (`site/` added under Node block) · resolved the freeze ⚠ flag: MkDocs 1.6.1 DID map README.md→index.html (the site root is README), so no thin index.md fallback was needed
+- [n/a] WIRING / DEAD-CODE (code) — no Python/JS symbols produced; the artifacts are declarative config (mkdocs.yml, requirements-docs.txt, .gitignore)
+
+### GATE RECORD
+Outcome: PASS
+Auto-resolved: yes (run: site-scaffold verify; autonomy: auto) — evidence complete, residue checks clear (no security · no concurrency · no architecture/trust-layer residue: this is build-time docs infra). The freeze ⚠ flag was retired by the live strict build (README→home confirmed). Security: none found (declarative config, no secrets, no runtime dep).
+Reviewed by: auto-gate (autonomy: auto) · date: 2026-06-24
+
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): `mkdocs build --strict` exit code (must stay 0 as the book grows) · new book .md added to `add-method/docs/` without a matching nav entry (would orphan_page) · the published packages' dep lists staying empty.
+
+### Spec delta
+Forward changes for the next loop — each re-enters at Specify as the next task. One line
+each, tagged `[SPEC · open|seeded|dropped]`, with evidence (e.g. `[SPEC · open] rate-limit
+the retry path (evidence: prod herd spikes)`). See the `add` skill's `deltas.md`.
+- [SPEC · seeded] pages-deploy (task 2) — GitHub Actions workflow building `--strict` + deploying to Pages on push to main; set `site_url` + update `homepage`/README links (evidence: site builds locally; needs CI + the public URL to satisfy exit criteria 3–4).
+- [SPEC · open] a new book chapter/appendix added later must also be added to `mkdocs.yml` nav or `--strict` orphan-fails — consider a tiny guard test (assert every `add-method/docs/*.md` is in nav) so the book and site can't drift (evidence: nav is an explicit hand-maintained list).
+- [SPEC · open] nav labels are hand-typed in mkdocs.yml and duplicate each chapter's H1 — a future polish could derive them, low priority (evidence: 24 labels maintained by hand).
+
+### Competency deltas
+What did this loop teach the foundation? One line each, tagged by competency
+(`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
+<!-- e.g.  - [DDD · open] the model missed multi-tenancy (evidence: scenario_x failed) -->
+- [ADD · open] repo-root files in §5 Scope MUST use the `add-method/../<file>` climb — a bare token (`mkdocs.yml`) resolves to the TASK dir, not project root, tripping a false `scope_violation` at the gate; re-cross tests→build to re-anchor after fixing the declaration (evidence: gate returned-to-build attempt 1/3, healed by re-declaring + re-snapshot — reaffirms the close-book-align convention).
+- [UDD · open] keeping the site home OUT of the book (README→index.html via MkDocs default) is the lean choice for a book whose source is mirror-guarded — it adds zero new file, zero bundle/parity work, and the existing README already carries an intro + linked TOC that makes a good landing (evidence: human chose it over a new index.md; strict build confirmed README is the site root).
+- [TDD · open] a docs/config task with no Python src is still red/green-testable by asserting the declarative config shape + running the REAL `mkdocs build --strict` in a tmp dir (skip-with-reason if the tool is absent) — the strict build is the behavior seam, not a mock (evidence: 7 stdlib-unittest tests, RED before config existed → GREEN after).

--- a/.add/tasks/site-scaffold/tests/test_site_scaffold.py
+++ b/.add/tasks/site-scaffold/tests/test_site_scaffold.py
@@ -1,0 +1,189 @@
+"""Red/green suite for the site-scaffold task (docs-site milestone).
+
+Pins the FROZEN §3 contract: a MkDocs-Material site over the canonical book in
+`add-method/docs/`, with README.md as the home, deps build-time only, and `site/`
+ignored. Runs RED until mkdocs.yml / requirements-docs.txt / .gitignore exist.
+
+Stdlib `unittest` (the project's test framework; CI runs `unittest discover`).
+PyYAML is used to parse mkdocs.yml — it ships transitively with mkdocs-material,
+so it is present wherever the site can be built; tests skip cleanly if absent.
+
+Repo root is 4 parents above this file:
+  tests/ -> site-scaffold/ -> tasks/ -> .add/ -> <repo root>
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+DOCS = REPO / "add-method" / "docs"
+MKDOCS = REPO / "mkdocs.yml"
+REQS = REPO / "requirements-docs.txt"
+GITIGNORE = REPO / ".gitignore"
+
+CHAPTERS = [
+    "00-introduction.md", "01-principles.md", "02-the-flow.md",
+    "03-step-1-specify.md", "04-step-2-scenarios.md", "05-step-3-contract.md",
+    "06-step-4-tests.md", "07-step-5-build.md", "08-step-6-verify.md",
+    "09-the-loop.md", "10-setup-and-stages.md", "11-governance.md",
+    "12-roles.md", "13-adoption.md", "14-foundation.md",
+    "15-foundations-and-lineage.md", "16-releasing.md",
+]
+APPENDICES = [
+    "appendix-a-templates.md", "appendix-b-prompts.md", "appendix-c-glossary.md",
+    "appendix-d-worked-example.md", "appendix-e-checklists.md",
+    "appendix-f-requirements-matrix.md", "appendix-g-references.md",
+]
+PNGS = [
+    "add-competencies.png", "add-flow.png",
+    "add-foundation.png", "add-hierarchy.png",
+]
+# the full book .md set that must stay byte-stable (README + chapters + appendices)
+BOOK_MD = ["README.md", *CHAPTERS, *APPENDICES]
+
+
+def _load_mkdocs() -> dict:
+    """Parse mkdocs.yml tolerantly — ignore any `!!python/...`/`!` custom tags so a
+    Material config with emoji/icon tags still loads under SafeLoader."""
+    import yaml
+
+    class _Tolerant(yaml.SafeLoader):
+        pass
+
+    _Tolerant.add_multi_constructor("tag:yaml.org,2002:python/", lambda *_: None)
+    _Tolerant.add_multi_constructor("!", lambda *_: None)
+    return yaml.load(MKDOCS.read_text(encoding="utf-8"), Loader=_Tolerant)
+
+
+def _nav_files(nav) -> list[str]:
+    """Flatten nav (list of {label: target} / nested) to the ordered target paths."""
+    out: list[str] = []
+
+    def walk(node):
+        if isinstance(node, str):
+            out.append(node)
+        elif isinstance(node, list):
+            for it in node:
+                walk(it)
+        elif isinstance(node, dict):
+            for v in node.values():
+                walk(v)
+
+    walk(nav)
+    return out
+
+
+def _require_yaml(tc: unittest.TestCase):
+    try:
+        import yaml  # noqa: F401
+    except Exception:
+        tc.skipTest("PyYAML not installed — ships with mkdocs-material; asserted where the site builds")
+
+
+class TestMkdocsConfig(unittest.TestCase):
+    def test_mkdocs_config_keys(self):
+        self.assertTrue(MKDOCS.is_file(), "mkdocs.yml must exist at repo root")
+        _require_yaml(self)
+        cfg = _load_mkdocs()
+        self.assertTrue(cfg.get("site_name"), "site_name must be set")
+        self.assertEqual(cfg.get("docs_dir"), "add-method/docs")
+        self.assertEqual((cfg.get("theme") or {}).get("name"), "material")
+
+    def test_search_and_palette_present(self):
+        self.assertTrue(MKDOCS.is_file(), "mkdocs.yml must exist")
+        _require_yaml(self)
+        cfg = _load_mkdocs()
+        plugins = cfg.get("plugins") or []
+        names = [p if isinstance(p, str) else next(iter(p)) for p in plugins]
+        self.assertIn("search", names, "search plugin must be enabled")
+        palette = (cfg.get("theme") or {}).get("palette")
+        self.assertIsInstance(palette, list)
+        self.assertGreaterEqual(len(palette), 2, "palette must define >=2 schemes (dark/light)")
+        schemes = {(p or {}).get("scheme") for p in palette}
+        self.assertTrue({"default", "slate"} <= schemes,
+                        "palette must include default (light) and slate (dark)")
+
+
+class TestNavAndHome(unittest.TestCase):
+    def test_nav_is_full_book_in_order(self):
+        self.assertTrue(MKDOCS.is_file(), "mkdocs.yml must exist")
+        _require_yaml(self)
+        files = _nav_files(_load_mkdocs().get("nav"))
+        self.assertEqual(files, ["README.md", *CHAPTERS, *APPENDICES],
+                         "nav must be Home(README.md) then 00..16 then appendices A..G, in order")
+        for f in files:
+            self.assertTrue((DOCS / f).is_file(),
+                            f"nav target {f} must exist in docs_dir (no nav_target_missing)")
+
+    def test_readme_is_home_book_unchanged(self):
+        self.assertTrue(MKDOCS.is_file(), "mkdocs.yml must exist")
+        _require_yaml(self)
+        files = _nav_files(_load_mkdocs().get("nav"))
+        self.assertTrue(files and files[0] == "README.md",
+                        "the home (first nav entry) must be README.md")
+        self.assertFalse((DOCS / "index.md").exists(),
+                         "no index.md may be added to the book (keep the home out of the book)")
+        on_disk = sorted(p.name for p in DOCS.glob("*.md"))
+        self.assertEqual(on_disk, sorted(BOOK_MD),
+                         "book .md set must be exactly README + 17 chapters + 7 appendices (byte-unchanged)")
+
+
+class TestDepsAndIgnore(unittest.TestCase):
+    def test_docs_dep_build_time_only(self):
+        self.assertTrue(REQS.is_file(), "requirements-docs.txt must exist")
+        self.assertRegex(REQS.read_text(encoding="utf-8"), r"(?m)^\s*mkdocs-material\b",
+                         "requirements-docs.txt must pin mkdocs-material")
+        pyproject = (REPO / "add-method" / "pyproject.toml").read_text(encoding="utf-8")
+        m = re.search(r"(?ms)^dependencies\s*=\s*\[(.*?)\]", pyproject)
+        self.assertIsNotNone(m, "pyproject [project].dependencies must be present")
+        self.assertNotIn("mkdocs", m.group(1).lower(),
+                         "mkdocs must not be a published pyproject dependency (runtime_dep_leak)")
+        pkg = json.loads((REPO / "add-method" / "package.json").read_text(encoding="utf-8"))
+        deps = " ".join((pkg.get("dependencies") or {}).keys()).lower()
+        self.assertNotIn("mkdocs", deps, "mkdocs must not be a package.json dependency")
+
+    def test_site_gitignored(self):
+        self.assertTrue(GITIGNORE.is_file())
+        lines = [ln.strip() for ln in GITIGNORE.read_text(encoding="utf-8").splitlines()]
+        self.assertTrue(any(ln in ("site/", "/site/", "site") for ln in lines),
+                        ".gitignore must ignore the MkDocs build output site/")
+
+
+class TestStrictBuild(unittest.TestCase):
+    def test_strict_build_produces_site(self):
+        if not MKDOCS.is_file():
+            self.fail("mkdocs.yml must exist before a strict build")
+        try:
+            import mkdocs  # noqa: F401
+        except Exception:
+            if shutil.which("mkdocs") is None:
+                self.skipTest("mkdocs not installed — strict build asserted in CI (pages-deploy)")
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "site"
+            proc = subprocess.run(
+                [sys.executable, "-m", "mkdocs", "build", "--strict", "--site-dir", str(out)],
+                cwd=str(REPO), capture_output=True, text=True,
+            )
+            self.assertEqual(proc.returncode, 0,
+                             f"`mkdocs build --strict` must exit 0:\n{proc.stderr}")
+            self.assertTrue((out / "index.html").is_file(),
+                            "site/index.html (from README) must be produced")
+            for f in [*CHAPTERS, *APPENDICES]:
+                stem = f[:-3]
+                self.assertTrue((out / stem / "index.html").is_file() or (out / f"{stem}.html").is_file(),
+                                f"a page for {f} must be in the built site")
+            for png in PNGS:
+                self.assertTrue((out / png).is_file(), f"diagram {png} must be copied into the site")
+            self.assertTrue((out / "search" / "search_index.json").is_file(),
+                            "search index must be built")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,72 @@
+# Build the AIDD book (MkDocs Material) and deploy it to GitHub Pages.
+#
+# One-time human setup (engine/CI builds, the human ships):
+#   Settings ▸ Pages ▸ Build and deployment ▸ Source = "GitHub Actions"
+# After that, every push to main re-publishes the site at:
+#   https://pilotspace.github.io/ADD/
+# Use the Actions tab ▸ "docs" ▸ "Run workflow" to deploy manually (workflow_dispatch).
+#
+# The build job runs the SAME `mkdocs build --strict` used locally, so a broken
+# intra-book link or an orphaned page fails the deploy instead of shipping silently.
+#
+# Security note: the only template expression here is the trusted
+# `${{ steps.deployment.outputs.page_url }}` (GitHub-provided deploy output). No
+# untrusted event input (issue/PR/commit text) flows into any `run:` step.
+
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'add-method/docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# Least privilege: read the repo, write the Pages deployment, mint the OIDC token.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; don't cancel an in-flight publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site (mkdocs --strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install docs build deps
+        run: pip install -r requirements-docs.txt
+
+      - name: Build the site (strict)
+        run: mkdocs build --strict
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ dist/
 node_modules/
 *.tgz
 
+# MkDocs build output (the GitHub Pages docs site is built from add-method/docs/;
+# the static site/ is a build artifact, deployed by CI — never committed)
+site/
+
 # OS
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Edition:** 1.6.0 · **Type:** AI Workflow Methodology
 
+📖 **Read the book online:** <https://pilotspace.github.io/ADD/>
+
 ---
 
 ![Foundation Domain Documents](add-foundation.png)

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -46,7 +46,7 @@
     "type": "git",
     "url": "git+https://github.com/pilotspace/ADD.git"
   },
-  "homepage": "https://github.com/pilotspace/ADD#readme",
+  "homepage": "https://pilotspace.github.io/ADD/",
   "bugs": {
     "url": "https://github.com/pilotspace/ADD/issues"
   }

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -32,7 +32,8 @@ requires-python = ">=3.10"
 dependencies = []
 
 [project.urls]
-Homepage = "https://github.com/pilotspace/ADD"
+Homepage = "https://pilotspace.github.io/ADD/"
+Documentation = "https://pilotspace.github.io/ADD/"
 Repository = "https://github.com/pilotspace/ADD"
 Issues = "https://github.com/pilotspace/ADD/issues"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,90 @@
+# MkDocs site for the AIDD book — built from the canonical book in add-method/docs/.
+# The book is the single source of truth (docs_dir below); this file adds no book content.
+# Home is the existing README.md (MkDocs maps README.md -> index.html at the site root).
+# Build:  pip install -r requirements-docs.txt  &&  mkdocs build --strict
+# Serve:  mkdocs serve
+
+site_name: AI-Driven Development (ADD)
+site_description: >-
+  ADD (AI-Driven Development) — drive spec-and-tests-first development through the
+  CLI while the human owns direction and verification. The complete AIDD book.
+site_url: https://pilotspace.github.io/ADD/
+repo_url: https://github.com/pilotspace/ADD
+repo_name: pilotspace/ADD
+copyright: Copyright &copy; Pilotspace — ADD (AI-Driven Development)
+
+# Single source of truth: the canonical book. No content is copied or duplicated.
+docs_dir: add-method/docs
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - navigation.indexes
+    - toc.follow
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    # Light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    # Dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - tables
+  - attr_list
+  - md_in_html
+
+# Explicit, ordered nav. Grouped into the book's Parts; the flattened file order is
+# Home(README.md) -> chapters 00..16 -> appendices A..G (the frozen contract seam).
+nav:
+  - Home: README.md
+  - Part I — Foundations:
+      - "00 · The shift: why AIDD exists": 00-introduction.md
+      - "01 · Core principles": 01-principles.md
+      - "02 · The flow, and what is disposable": 02-the-flow.md
+  - Part II — The method, step by step:
+      - "03 · Step 1 — Specify": 03-step-1-specify.md
+      - "04 · Step 2 — Scenarios": 04-step-2-scenarios.md
+      - "05 · Step 3 — Contract": 05-step-3-contract.md
+      - "06 · Step 4 — Tests": 06-step-4-tests.md
+      - "07 · Step 5 — Build": 07-step-5-build.md
+      - "08 · Step 6 — Verify": 08-step-6-verify.md
+      - "09 · The loop — observe and learn": 09-the-loop.md
+  - Part III — Operating the method:
+      - "10 · Project setup and stages": 10-setup-and-stages.md
+      - "11 · Governance": 11-governance.md
+      - "12 · Roles and responsibilities": 12-roles.md
+      - "13 · Adoption and onboarding": 13-adoption.md
+      - "14 · The foundation": 14-foundation.md
+  - Lineage:
+      - "15 · Foundations & Lineage": 15-foundations-and-lineage.md
+  - Releasing:
+      - "16 · Releasing": 16-releasing.md
+  - Part IV — Reference:
+      - "Appendix A · Templates": appendix-a-templates.md
+      - "Appendix B · Prompt library": appendix-b-prompts.md
+      - "Appendix C · Glossary": appendix-c-glossary.md
+      - "Appendix D · The worked example, end to end": appendix-d-worked-example.md
+      - "Appendix E · Checklists": appendix-e-checklists.md
+      - "Appendix F · Document requirements matrix": appendix-f-requirements-matrix.md
+      - "Appendix G · References & lineage": appendix-g-references.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,6 @@
+# Build-time-only dependency for the GitHub Pages docs site (mkdocs.yml).
+# NOT a runtime dependency of the published packages — @pilotspace/add (npm) and
+# pilotspace-add (PyPI) stay zero-dependency. Install only to build/serve the docs:
+#   pip install -r requirements-docs.txt
+#   mkdocs build --strict   # or: mkdocs serve
+mkdocs-material>=9,<10


### PR DESCRIPTION
## Ship the AIDD book as a docs site on GitHub Pages

Renders the canonical AIDD book (`add-method/docs/`) as a browsable, searchable
**MkDocs Material** site and deploys it to **GitHub Pages** via CI. The book
**source is byte-unchanged** — this is new site/CI infrastructure, not new content.

### Built (ADD-driven, 2 tasks, both `gate=PASS`)
- **site-scaffold** — `mkdocs.yml` over `docs_dir: add-method/docs` (single source, no copy). The existing **`README.md` is the home** (MkDocs maps `README.md → index.html`), so **no new book file and no `_bundled/` parity change**. Explicit nav over all 17 chapters + 7 appendices (grouped into the book's Parts), Material theme, client-side search, dark/light toggle. `requirements-docs.txt` pins `mkdocs-material` **build-time only** — the published packages stay **zero-dependency**. `.gitignore` ignores `site/`.
- **pages-deploy** — `.github/workflows/pages.yml` builds `--strict` then deploys via the official Pages actions (`upload-pages-artifact` → `deploy-pages`), least-privilege `permissions` (`contents:read, pages:write, id-token:write`), `environment: github-pages`, `concurrency: pages`. `homepage` / `Documentation` / README links → `https://pilotspace.github.io/ADD/`. **No version bump.**

### Evidence
- `mkdocs build --strict` → **exit 0, zero warnings** (README home + 17 chapters + 7 appendices + 4 diagrams + search index)
- task suites **14/14 green** (stdlib `unittest`) · engine `check` **388/0** · `audit` **clean (76 tasks)**
- `add-method/docs/` + `_bundled/docs/` **byte-identical** (parity held) · versions unchanged at **1.9.0**

### 🔸 Required human ship-steps (engine/CI builds, human ships)
1. **Settings ▸ Pages ▸ Build and deployment ▸ Source = "GitHub Actions"** (one-time).
2. **Merge** → the `docs` workflow runs → site goes live at <https://pilotspace.github.io/ADD/> (closes milestone exit criteria 3–4).

> Note: `docs-site` is orthogonal to the package version — no release cut here.
