### PR TITLE
chore(release): cut ADD 1.10.0 — component-aware major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.10.0 — 2026-06-25
+
+- Docs site — ship the AIDD book to GitHub Pages — 6 carried · 0 key decision(s)
+- Loop Steering — 0 carried · 0 key decision(s)
+- Component-aware ADD — 4 carried · 0 key decision(s)
+
 ## 1.9.0 — 2026-06-24
 
 - lean-pass M3 · flow simplification — 0 carried · 0 key decision(s)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.10.0 — 2026-06-25
+milestones: docs-site, loop-steering, component-aware-add
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: suite 1745/0 · audit clean (74 tasks) · mkdocs --strict clean; bundles component-aware-add + docs-site + loop-steering + ccsk --rule-file
+
 ## 1.9.0 — 2026-06-24
 milestones: flow-simplification, skill-effectiveness, flow-enforcement, fast-lane
 waivers: none

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -6,17 +6,67 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 
 ## [Unreleased]
 
+## [1.10.0] — 2026-06-25
+
+Component-aware major — ADD now models every codebase as a **graph of components**,
+each owning a source root, its own green bar, and the contracts it produces or
+consumes, so **one milestone can ship a vertical slice across components** in a
+monorepo or across repos. Bundles the closed `component-aware-add` major plus the
+`docs-site` (the book as a live MkDocs site) and `loop-steering` milestones, and the
+ccsk `--rule-file` mode. Every new gate is **opt-in or grandfathered** — a project
+that declares no components is byte-identical to 1.9.0.
+
 ### Added
+- **Component registry (`component-aware-add`)** — declare parts of a multi-part
+  codebase in `.add/components.toml` under `[component.<name>]` (a `root` + a
+  `green-bar`). A task binds to one with a `component:` header line, which anchors its
+  §5 Scope to that component's root. Declared, never inferred; zero components ⇒
+  byte-identical to today.
+- **Per-component verify** — a bound task is held to ITS component's green-bar at the
+  verify gate (the cite-gate refuses `component_green_bar_uncited`), so two tasks in
+  one milestone can pass on two different toolchains (e.g. `pytest` and `vitest`). The
+  engine still never runs a suite — the AI runs it, the gate checks the right bar was
+  cited.
+- **Cross-component contracts (`produces:` / `consumes:`)** — declare `[contract.<id>]`
+  (producer + consumers). A producer's §3 freeze writes an immutable snapshot at
+  `.add/contracts/<id>.json`; a consumer pins its hash; a changed re-freeze flags every
+  consumer stale. A missing/malformed snapshot HARD-STOPS — never build against a
+  guessed shape.
+- **One milestone, full-stack slice** — a `consumes:` task is HELD from entering §3
+  (`producer_contract_unfrozen`) until its producer's contract is frozen, so a BE→FE
+  vertical slice ships in one milestone, ordered by the frozen contract.
+- **Multi-repo federation (`add.py federate pull <id>`)** — a consumer repo declares
+  `[federation.<id>]` (a `source` path + optional `pin`) and pulls a byte-for-byte copy
+  of a producer repo's published snapshot into its local `.add/contracts/`, where the
+  rest of ADD treats mono- and multi-repo identically. Fail-loud: unknown id /
+  unreadable source / invalid snapshot / version mismatch each HARD-STOPS and lands
+  nothing.
+- **Component pillar docs** — a new book chapter `17 · Components`, a skill guide
+  (`components.md`), and glossary terms (Component · Cross-component contract ·
+  Federation) teach the whole loop.
+- **The book as a live site (`docs-site`)** — the AIDD book ships to GitHub Pages as a
+  MkDocs-Material site (`mkdocs.yml` + `requirements-docs.txt`, build-time only — the
+  published packages stay zero-dependency); `mkdocs build --strict` fails the deploy on
+  a broken intra-book link.
 - **Rule-file mode for ccsk projects (`--rule-file`)** — when a project keeps its
-  workflow rules as separate files under `.claude/rules/` (the convention scaffolded
-  by ccsk — the Claude Code Starter Kit — detected by a `.ccsk/` dir), ADD relocates CLAUDE.md's
-  block to `.claude/rules/add-workflows.md` and leaves a single reference bullet under a
-  Workflows/Rules heading in CLAUDE.md, instead of inlining. Triggers three ways
-  (re-derived from disk each phase, no persisted state): the explicit `--rule-file` flag on
-  `init` / `sync-guidelines` / the installer, a `.ccsk/` directory, or a rule file already
-  present. **CLAUDE-only** — `AGENTS.md` / `.clinerules` keep the inline block. Migrates a
-  prior inline block out (`.bak` on change), idempotent, and fail-soft. Mirrored across all
-  three installers (engine `add.py`, pip `_installer.py`, npm `cli.js`).
+  workflow rules under `.claude/rules/` (the ccsk convention, detected by a `.ccsk/`
+  dir), ADD relocates CLAUDE.md's block to `.claude/rules/add-workflows.md` and leaves a
+  single reference bullet, instead of inlining. Triggers three ways (the explicit
+  `--rule-file` flag, a `.ccsk/` directory, or a rule file already present),
+  **CLAUDE-only**, migrates a prior inline block out (`.bak` on change), idempotent and
+  fail-soft. Mirrored across all three installers (engine `add.py`, pip `_installer.py`,
+  npm `cli.js`).
+
+### Changed
+- **Guided dynamic loop (`loop-steering`)** — `status` and `guide` now STEER into the
+  build→verify loop at the loop juncture rather than only reporting it, so an agent is
+  pointed at the next loop step instead of having to infer it.
+
+### Compatibility
+- Python 3.11+ is required to USE the component pillar (it parses `components.toml` with
+  the stdlib `tomllib`); on 3.10 the engine runs unchanged but a declared
+  `components.toml` fails loud (`components_malformed`). The published packages remain
+  zero-dependency.
 
 ## [1.9.0] — 2026-06-24
 

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.9.0"
+version = "1.10.0"
 description = "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — install the ADD skill, tooling, and AIDD book into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.9.0"
+__version__ = "1.10.0"

--- a/add-method/tooling/test_release_1_10_0.py
+++ b/add-method/tooling/test_release_1_10_0.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.9.0 release readiness (lean-pass major bundle).
+"""Red/green tests for the 1.10.0 release readiness (component-aware major bundle).
 
-Bundles four closed milestones — skill-effectiveness (M1), flow-simplification (M3),
-flow-enforcement (M4), and the fast-lane sub-milestone.
+Bundles the closed `component-aware-add` major plus the `docs-site` and `loop-steering`
+milestones and the ccsk `--rule-file` mode.
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.9.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.10.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_9_0 -v
+    python3 -m unittest test_release_1_10_0 -v
 """
 import hashlib
 import json
@@ -24,19 +24,20 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.9.0"
-PRIOR_VERSIONS = ("1.8.0", "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0",
-                  "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
+VERSION = "1.10.0"
+PRIOR_VERSIONS = ("1.9.0", "1.8.0", "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0",
+                  "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")   # the changelog must keep its lineage
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline capabilities the release notes must name (the lean-pass bundle:
-# fast lane + the three engine-enforced fill-seams + the lighter skill tree)
-FEATURE_ANCHORS = ("fast-lane", "--fast", "Freeze-before-build", "flow-enforcement",
-                   "Gate-record write-back", "Skill tree 25% lighter", "Confirm-parent")
+# the headline capabilities the release notes must name (the component-aware bundle:
+# the component registry, cross-component contracts, multi-repo federation, the live
+# MkDocs site, and the ccsk rule-file mode)
+FEATURE_ANCHORS = ("components.toml", "produces:", "Cross-component", "federate pull",
+                   "MkDocs", "--rule-file")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_9_0_entry(self):
+    def test_changelog_has_1_10_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -45,7 +46,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.9.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.10.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -84,9 +85,25 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    # The live version-equality asserts (package.json / pyproject / plugin / __init__ all == the
-    # shipped version) MOVED FORWARD to test_release_1_10_0.py — only the current cut owns them, so
-    # the lineage tests below stay green after the bump. This file keeps the version-AGNOSTIC checks.
+    def test_versions_agree_at_1_10_0(self):
+        pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
+        py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
+                       (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
+        self.assertEqual((pkg, py), (VERSION, VERSION),
+                         "publish.yml's guard would fail this release closed")
+
+    def test_plugin_version_agrees(self):
+        plugin = json.loads(
+            (PKG / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+        self.assertEqual(plugin, VERSION,
+                         "the Claude Code plugin manifest must match the shipped version")
+
+    def test_runtime_version_agrees(self):
+        init = (PKG / "src" / "add_method" / "__init__.py").read_text(encoding="utf-8")
+        runtime = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', init).group(1)
+        self.assertEqual(runtime, VERSION,
+                         "add_method.__version__ must match the shipped version")
 
     def test_getting_started_mentions_guide_line(self):
         text = (PKG / "GETTING-STARTED.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## ADD 1.10.0 — component-aware major

Cuts the **1.10.0** release. Bundles three closed milestones plus the ccsk
`--rule-file` mode that was riding in `[Unreleased]`.

### What ships
- **`component-aware-add` (headline)** — model a codebase as a graph of
  **components**, each owning a source root, its own green-bar, and the contracts
  it produces/consumes, so **one milestone ships a vertical slice across
  components** in a monorepo or across repos. Registry (`components.toml`),
  per-component verify (cite-gate), cross-component contracts (`produces:` /
  `consumes:` + frozen snapshots), the BE→FE intra-milestone HOLD, and multi-repo
  `add.py federate pull <id>` (fail-loud).
- **`docs-site`** — the AIDD book as a live **MkDocs-Material** site on GitHub
  Pages (`mkdocs build --strict` gates the deploy; packages stay zero-dependency).
- **`loop-steering`** — `status`/`guide` now steer into the build→verify loop
  rather than only reporting it.
- **ccsk `--rule-file`** — relocate the CLAUDE.md block to
  `.claude/rules/add-workflows.md` for `.ccsk/` projects.

### Release mechanics
- 4 version sources + `package-lock.json` → `1.10.0`.
- Rich `## [1.10.0]` entry in `add-method/CHANGELOG.md`; engine `add.py release`
  wrote the terse root `CHANGELOG.md` render + the `RELEASES.md` ledger row
  (3 milestones recorded, evidence attached).
- Forward-pin migrated: `test_release_1_9_0.py` stripped of its version-equality
  asserts; new `test_release_1_10_0.py` carries them.

### Compatibility
Every new gate is **opt-in or grandfathered** — a project that declares no
components is byte-identical to 1.9.0. Python **3.11+** is required to *use* the
component pillar (stdlib `tomllib`); on 3.10 the engine runs unchanged and a
declared `components.toml` fails loud. Published packages remain zero-dependency.

### Evidence
- suite **1745/0** · `check` **378/0** · `audit` clean (74 tasks)
- `mkdocs build --strict` clean · `npm ci` lock in sync

After merge, the human runs the gated `git tag v1.10.0` → publish (npm + PyPI).

author: Tin Dang <tindang.ht97@gmail.com>
