### PR TITLE
release(1.12.0): milestone-naming — descriptive-slug nudge + full-ISO created stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12.0 — 2026-06-26
+
+- (no milestone bundled)
+
 ## 1.11.0 — 2026-06-26
 
 - Audit hardening — close gate/atomicity/coverage gaps — 3 carried · 0 key decision(s)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 1.12.0 — 2026-06-26
+milestones: none
+loose tasks: milestone-naming
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: milestone-naming feature (bare-version slug nudge + full-ISO created stamp); suite 1972/0; ENGINE_MD5 acda5c26
+
 ## 1.11.0 — 2026-06-26
 milestones: audit-hardening, engine-modularization
 loose tasks: add-check, quickstart-guide, milestone-layer, onboarding-align, question-summary-layer, intake-interview, ubiquitous-language, wave-ledger, wave-status-hint, wave-protocol-runtime, engine-argv-portability, engine-merge-base-enforcement, gitignore-scaffold, autonomy-command, standalone-fast-task, todo-capture, flag-mode-quickref, loose-task-release, soul-seed-npm-parity, gitignore-bak-seed, setup-commit-prompt, ground-phase-harden, lean-tree-baseline-derive, atomic-scope-sidecar, audit-ungated-verdict, test-tempdir-cleanup, scope-level-enum-reconcile

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 
 ## [Unreleased]
 
+## [1.12.0] — 2026-06-26
+
+Milestone-naming polish — `new-milestone` now steers toward legible names and
+records a precise creation time. Backward-compatible; no breaking change.
+
+### Added
+- **Descriptive-slug nudge.** A milestone slug that is a bare version number
+  (`v2`, `v1-1`, `1.2` — matched by `^v?\d+([._-]\d+)*$`) now prints an advisory
+  `note:` suggesting a short descriptive name (e.g. `payment-retries`) and **still
+  creates the milestone**. It never blocks — a deliberate version slug is honored.
+  Keeps the `status` milestones list legible instead of a column of `v1-1 / v2 / v3`.
+
+### Changed
+- **Full-ISO `created:` stamp in MILESTONE.md.** The human-facing `created:` line
+  goes from a date (`2026-06-26`) to the full UTC ISO timestamp
+  (`2026-06-26T03:47:28+00:00`). A single `_now()` instant feeds both the rendered
+  file and the `state.json` record, so the two are provably equal.
+
+Built end-to-end through ADD's own spec→tests→build→verify flow as a dogfood of the
+1.11.0 engine; the two design choices (warn-not-block · upgrade `created:`) were
+human-decided at the contract freeze.
+
 ## [1.11.0] — 2026-06-26
 
 Engine-modularization + audit-hardening release — the 7k-line monolith becomes a

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.11.0"
+version = "1.12.0"
 description = "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — install the ADD skill, tooling, and AIDD book into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.11.0"
+__version__ = "1.12.0"

--- a/add-method/tooling/test_release_1_12_0.py
+++ b/add-method/tooling/test_release_1_12_0.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.11.0 release readiness (engine-modularization +
-audit-hardening + the standalone lane).
+"""Red/green tests for the 1.12.0 release readiness (milestone-naming feature).
 
-Bundles the closed `audit-hardening` and `engine-modularization` milestones plus
-27 loose tasks. No behavior change — internal architecture + gate hardening.
+Bundles one loose task: `milestone-naming` — new-milestone nudges bare-version
+slugs toward descriptive names + stamps MILESTONE.md `created:` with the full ISO
+timestamp. Backward-compatible (advisory; never blocks).
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.11.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.12.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_11_0 -v
+    python3 -m unittest test_release_1_12_0 -v
 """
 import hashlib
 import json
@@ -25,18 +25,17 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.11.0"
-PRIOR_VERSIONS = ("1.10.0", "1.9.0", "1.8.0", "1.7.3", "1.7.2", "1.7.1", "1.7.0",
-                  "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")
+VERSION = "1.12.0"
+PRIOR_VERSIONS = ("1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.3", "1.7.2", "1.7.1",
+                  "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline capabilities the release notes must name (the 14-module engine
-# package + the two-pin model + the standalone-lane additions)
-FEATURE_ANCHORS = ("add_engine", "ENGINE_PKG_MD5", "todo", "loose tasks")
+# the headline the release notes must name (the milestone-naming bundle)
+FEATURE_ANCHORS = ("new-milestone", "descriptive", "created:")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_11_0_entry(self):
+    def test_changelog_has_1_12_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -45,7 +44,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.11.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.12.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -84,10 +83,25 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    # NOTE: the version-equality asserts (package.json / pyproject / plugin / __version__
-    # all == "1.11.0") migrated FORWARD to test_release_1_12_0.py when the version bumped
-    # off 1.11.0 — the live version is pinned by exactly one release test at a time. The
-    # 1.11.0 changelog-lineage + workflow-hygiene + ship-channel guards below stay valid.
+    def test_versions_agree_at_1_12_0(self):
+        pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
+        py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
+                       (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
+        self.assertEqual((pkg, py), (VERSION, VERSION),
+                         "publish.yml's guard would fail this release closed")
+
+    def test_plugin_version_agrees(self):
+        plugin = json.loads(
+            (PKG / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+        self.assertEqual(plugin, VERSION,
+                         "the Claude Code plugin manifest must match the shipped version")
+
+    def test_runtime_version_agrees(self):
+        init = (PKG / "src" / "add_method" / "__init__.py").read_text(encoding="utf-8")
+        runtime = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', init).group(1)
+        self.assertEqual(runtime, VERSION,
+                         "add_method.__version__ must match the shipped version")
 
     def test_getting_started_mentions_guide_line(self):
         text = (PKG / "GETTING-STARTED.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What
Cuts **ADD 1.12.0** — bundles one loose task (`milestone-naming`) since 1.11.0. Backward-compatible, no breaking change.

- **Descriptive-slug nudge:** `new-milestone v2` (or `v1-1`, `1.2`) prints an advisory `note:` suggesting a descriptive name and **still creates** it (never blocks).
- **Full-ISO `created:`:** MILESTONE.md `created:` goes date-only → full UTC ISO, equal to the `state.json` record.

## Release mechanics
- 5 version sources bumped to 1.12.0; `add.py release` wrote root CHANGELOG + RELEASES.md row (1 loose task: milestone-naming); rich `## [1.12.0]` hand-authored in add-method/CHANGELOG.md; forward-pin migrated (new `test_release_1_12_0.py`).

## Evidence
- Full suite **1980/0** · `add.py check` **421/0** · seam audit **clean (88)** · ENGINE_MD5 `acda5c26` · 3-tree byte-identical

## After merge (human-gated)
Tag `v1.12.0` → publish.yml (npm + PyPI). Not yet tagged/published.

author: Tin Dang