### PR TITLE
feat(method): pull build strategy + known-problem solutions from §5 into spawns

### DIFF
--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "guarantee-audit-lints",
+  "active_task": "skill-todo-flag",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -1949,10 +1949,51 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "skill-todo-flag": {
+      "title": "Capture/list/close todos via /add --todo flag",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": null,
+      "depends_on": [],
+      "created": "2026-06-27T15:30:29+00:00",
+      "updated": "2026-06-27T15:44:39+00:00",
+      "fast": true,
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-06-27T15:33:57+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "ee00d2a94d967dcd7d4b3127884c825e",
+        "tests": {
+          "add-method/tooling/test_skill_todo_flag.py": "bbb7d4f0cbaf5d7efdb946b46d5a4f97"
+        }
+      },
+      "scope": {
+        "declared": [
+          "add-method/skill/add/SKILL.md",
+          ".claude/skills/add/SKILL.md",
+          "add-method/src/add_method/_bundled/skill/add/SKILL.md",
+          "add-method/tooling/test_skill_lean.py"
+        ],
+        "snapshot_md5": "0086b8f90ee5ac2ea70b7b27b4fefeb2"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-06-27T15:15:17+00:00",
+  "updated": "2026-06-27T15:44:39+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -2739,7 +2780,7 @@
   ],
   "active_tasks": {
     "flow-simplification": "phase-review",
-    "flow-honesty": "guarantee-audit-lints"
+    "flow-honesty": "skill-todo-flag"
   },
   "todos": [
     {
@@ -2836,7 +2877,7 @@
       "id": 16,
       "text": "list",
       "created": "2026-06-26T09:33:31+00:00",
-      "status": "open"
+      "status": "done"
     },
     {
       "id": 17,
@@ -2854,6 +2895,18 @@
       "id": 19,
       "text": "GROUND phase (phases/0-ground.md) retrieves CONVENTIONS + foundation decisions (Honors field <- PROJECT.md/CONVENTIONS.md) + code-level decisions (Touches <- grep/symbol search), but has NO explicit field to retrieve prior TASK-level DECISIONS: sibling frozen \u00a73 contracts, \u00a76 GATE RECORD outcomes (PASS/RISK-ACCEPTED ledger), or open \u00a77 spec deltas this task depends on / shares a surface with. Consider a 'Prior decisions' ground input (or an  recall helper) so a new task grounds on adjacent decisions, not just conventions + raw code.",
       "created": "2026-06-27T15:15:17+00:00",
+      "status": "open"
+    },
+    {
+      "id": 20,
+      "text": "list",
+      "created": "2026-06-27T15:23:25+00:00",
+      "status": "done"
+    },
+    {
+      "id": 21,
+      "text": "how are AI retrieve decision in ground phase",
+      "created": "2026-06-27T15:24:54+00:00",
       "status": "open"
     }
   ]

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "skill-todo-flag",
+  "active_task": "streams-strategy-pull",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -1990,10 +1990,105 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "build-strategy-solutions": {
+      "title": "\u00a75 Strategy & known-problem solutions, fed consistently into subagent spawns",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": null,
+      "depends_on": [],
+      "created": "2026-06-27T16:08:49+00:00",
+      "updated": "2026-06-27T16:31:13+00:00",
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-06-27T16:21:49+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "fe0e8c83ff820ff64a384dfd0137b370",
+        "tests": {
+          "add-method/tooling/test_scope_decl_template.py": "a7da044251a671eebc5d57ffbb3b4a1c",
+          "add-method/tooling/test_advisor_strategy.py": "bfceab42bb8a3d65679f2627415c667b",
+          "add-method/tooling/test_skill_lean.py": "26cee9de7405a75cfd50e5568f1c511c"
+        }
+      },
+      "scope": {
+        "declared": [
+          "add-method/tooling/templates/TASK.md.tmpl",
+          "add-method/tooling/templates/TASK.fast.md.tmpl",
+          "add-method/src/add_method/_bundled/tooling/templates/TASK.md.tmpl",
+          "add-method/src/add_method/_bundled/tooling/templates/TASK.fast.md.tmpl",
+          ".add/tooling/templates/TASK.md.tmpl",
+          ".add/tooling/templates/TASK.fast.md.tmpl",
+          "add-method/skill/add/advisor.md",
+          "add-method/src/add_method/_bundled/skill/add/advisor.md",
+          ".claude/skills/add/advisor.md",
+          "add-method/tooling/test_scope_decl_template.py",
+          "add-method/tooling/test_advisor_strategy.py",
+          "add-method/tooling/test_skill_lean.py"
+        ],
+        "snapshot_md5": "19faccd53b5308fb27bedc31b532e1c8"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
+    },
+    "streams-strategy-pull": {
+      "title": "Extend the \u00a75-strategy pull to streams.md's worker contract",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": null,
+      "depends_on": [],
+      "created": "2026-06-27T16:34:30+00:00",
+      "updated": "2026-06-27T16:40:59+00:00",
+      "from_delta": "build-strategy-solutions",
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-06-27T16:37:30+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "4dc67d0325806bbb9030c677f4a82598",
+        "tests": {
+          "add-method/tooling/test_streams.py": "348a2d06d6920486bcd1f272d6be9f3d",
+          "add-method/tooling/test_xml_convention.py": "a220611f34d64c51116a3e9106e6a357",
+          "add-method/tooling/test_skill_lean.py": "ad2ffed44bfedb13141fabaf7159c4c6"
+        }
+      },
+      "scope": {
+        "declared": [
+          "add-method/skill/add/streams.md",
+          "add-method/src/add_method/_bundled/skill/add/streams.md",
+          ".claude/skills/add/streams.md",
+          "add-method/tooling/test_xml_convention.py",
+          "add-method/tooling/test_streams.py",
+          "add-method/tooling/test_skill_lean.py"
+        ],
+        "snapshot_md5": "0232fa7e8dcda0de3d4beb6793f3c966"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-06-27T15:44:39+00:00",
+  "updated": "2026-06-27T16:40:59+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -2780,7 +2875,7 @@
   ],
   "active_tasks": {
     "flow-simplification": "phase-review",
-    "flow-honesty": "skill-todo-flag"
+    "flow-honesty": "streams-strategy-pull"
   },
   "todos": [
     {
@@ -2889,7 +2984,7 @@
       "id": 18,
       "text": "advisor.md subagent-spawn template has NO explicit implementation-strategy field \u2014 strategy is delegated to whatever the orchestrator writes into {{PIECE}}; only the persona's generic step-2 ('do the work in small steps, honoring the orchestrator's plan') nods to it. Consider adding an ordered-batches / dependency-aware strategy section (cf. the richer global-CLAUDE.md Rule-5 persona step-plan + success_criteria), weighed against the lean-pass skill byte budget.",
       "created": "2026-06-27T15:14:28+00:00",
-      "status": "open"
+      "status": "done"
     },
     {
       "id": 19,

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "streams-strategy-pull",
+  "active_task": "strategy-soft-not-hard",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -2085,10 +2085,57 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "strategy-soft-not-hard": {
+      "title": "Soften the <strategy> block: \u00a75 is preferred, builder self-improves + reports actual strategy for audit",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": null,
+      "depends_on": [],
+      "created": "2026-06-27T17:03:22+00:00",
+      "updated": "2026-06-27T17:16:52+00:00",
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-06-27T17:11:59+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "223f592a55127bf6bfd2c7032eb10ec6",
+        "tests": {
+          "add-method/tooling/test_advisor_strategy.py": "48e32f1b6c3265105ed194ab41321433",
+          "add-method/tooling/test_streams.py": "aa17b7200da15183078c02f78defeb91",
+          "add-method/tooling/test_skill_lean.py": "f1eeb288386e457e78f5d21b632b49cd"
+        }
+      },
+      "scope": {
+        "declared": [
+          "add-method/skill/add/advisor.md",
+          "add-method/skill/add/streams.md",
+          ".claude/skills/add/advisor.md",
+          ".claude/skills/add/streams.md",
+          "add-method/src/add_method/_bundled/skill/add/advisor.md",
+          "add-method/src/add_method/_bundled/skill/add/streams.md",
+          "add-method/tooling/test_advisor_strategy.py",
+          "add-method/tooling/test_streams.py",
+          "add-method/tooling/test_skill_lean.py"
+        ],
+        "snapshot_md5": "03d71dd159af4eaab369140ee068d1c3"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-06-27T16:40:59+00:00",
+  "updated": "2026-06-27T17:16:52+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -2875,7 +2922,7 @@
   ],
   "active_tasks": {
     "flow-simplification": "phase-review",
-    "flow-honesty": "streams-strategy-pull"
+    "flow-honesty": "strategy-soft-not-hard"
   },
   "todos": [
     {
@@ -3002,6 +3049,12 @@
       "id": 21,
       "text": "how are AI retrieve decision in ground phase",
       "created": "2026-06-27T15:24:54+00:00",
+      "status": "open"
+    },
+    {
+      "id": 22,
+      "text": "Harden decision/ADR recording at the OBSERVE phase \u2014 capture decisions made by BOTH human and AI (who decided, what, why, alternatives) as a durable Architecture-Decision-Record-style artifact, not just spec/competency deltas",
+      "created": "2026-06-27T16:45:08+00:00",
       "status": "open"
     }
   ]

--- a/.add/tasks/build-strategy-solutions/TASK.md
+++ b/.add/tasks/build-strategy-solutions/TASK.md
@@ -1,0 +1,273 @@
+# TASK: §5 Strategy & known-problem solutions, fed consistently into subagent spawns
+
+slug: build-strategy-solutions · created: 2026-06-27 · stage: mvp
+autonomy: auto   <!-- inherited from the project default (PROJECT.md); explicit level: manual < conservative < auto (visible · overridable) — lower below if a high-risk task needs it, or run `add.py autonomy set`. Multi-component repo (monorepo/multi-repo)? add a `component: <name>` line (declared in `.add/components.toml`) to ADD that component's root to your §5 Scope; omit for single-component projects (byte-identical default). -->
+phase: done   <!-- ground -> specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+<!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower the
+     autonomy level to `manual` or `conservative` — the engine refuses an unguarded completion
+     (`unguarded_high_risk_auto`, run.md guard). A comment is never a declaration. -->
+
+> One file = one task. Fill sections top-to-bottom; the `add` skill drives each phase.
+> When a phase is unclear, read its book chapter in `.add/docs/` (linked per section).
+> The phase marker above is the single source of truth — keep it in sync via `add.py phase`.
+
+---
+
+## 0 · GROUND — the real codebase ▸ docs/02-the-flow.md
+
+Touches (files · symbols · signatures):
+  - `add-method/tooling/templates/TASK.md.tmpl` §5 BUILD — has `Scope (may touch):` + `Strategy (ordered batches):` + `Safety rule…` lines; ADD a plain-text `Known-problem fixes:` line (additive, NOT an XML tag — `FROZEN_TAGS` census is frozen)
+  - `add-method/tooling/templates/TASK.fast.md.tmpl` §5 BUILD — currently Scope+Code+Constraints only (NO strategy); ADD a condensed `Strategy & known-problem fixes:` line
+  - `add-method/skill/add/advisor.md` — the fenced ```xml plan-following template (`<objective>`/`<persona>`/`<context_files>`/`<return>`); ADD a `<strategy>` element INSIDE the fence that points the subagent at the task's §5
+  - 3-tree parity: each of the above also in `.add/tooling/templates/` + `add-method/src/add_method/_bundled/tooling/templates/` (templates) and `.claude/skills/add/` + `add-method/src/add_method/_bundled/skill/add/` (advisor.md) — byte-identical
+Context (working folder):
+  - `add-method/tooling/test_scope_decl_template.py` — the precedent prose/template red-green suite for §5 (`STRATEGY_LABEL`, `EXISTING_LINES` byte-identical, 3-tree md5, `FROZEN_TAGS`, add.py==ENGINE_MD5) — EXTEND it for the new line
+  - `add-method/tooling/test_advisor_strategy.py` — guards advisor.md (`_TEMPLATE_TAGS={objective,persona,return}` fenced; outside-fence vocab=={constraints}) — EXTEND for `<strategy>`
+  - `add-method/tooling/test_skill_lean.py` — advisor.md ∈ orchestration pool (target 38995 B, headroom 82 B) → REBASELINE baseline 51994 += ⌈grow/0.75⌉
+  - `add-method/tooling/test_xml_convention.py` — `WORKER_CONTRACT_TAGS` (streams.md home); advisor `<strategy>` stays fenced ⇒ exempt
+Honors (patterns / conventions):
+  - additive-only template edit (3 §5 lines byte-identical) + 3-tree byte parity (test_bundle_parity/test_tree_parity) — the scope-decl-template precedent
+  - prose/template-only task: add.py + add_engine/*.py UNTOUCHED ⇒ ENGINE_MD5/ENGINE_PKG_MD5 unchanged (do NOT edit constants.py fallbacks — they stay floor-only)
+  - lean-fence rebaseline = the documented "rebaseline for human-approved new surface" method (ratio kept, baseline += surface÷ratio)
+  - red/green TDD (CLAUDE.md Rule 3); freeze §3 before build; no pre-stamping the human freeze
+Anchors the contract cites: `TASK.md.tmpl` §5 `Known-problem fixes:` line · `TASK.fast.md.tmpl` §5 `Strategy & known-problem fixes:` line · `advisor.md` fenced `<strategy>` element · `test_scope_decl_template.py` · `test_advisor_strategy.py` · `test_skill_lean.py` orchestration baseline
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+Feature: §5 carries strategy + known-problem solutions, and the advisor spawn template pulls from it
+Framings weighed: source-of-truth-in-§5 + spawn-references-it (chosen) · spawn-only (rejected: TASK.md stays the consistency anchor) · rename-Strategy-line (rejected: EXISTING_LINES byte-identity)
+Must:
+<must>
+  - the full `TASK.md.tmpl` §5 BUILD gains a plain-text `Known-problem fixes:` line (the planned fix for each anticipated trap), placed ADDITIVELY — the 3 pre-existing §5 lines stay byte-identical
+  - the fast `TASK.fast.md.tmpl` §5 BUILD (today: no strategy line) gains ONE condensed `Strategy & known-problem fixes:` line
+  - `advisor.md`'s fenced ```xml plan-following template gains a `<strategy>` element (INSIDE the fence) directing the subagent to follow the task's §5 Strategy (ordered batches) + Known-problem fixes
+  - all edits are byte-identical across the 3 trees (canonical · _bundled · dogfood)
+  - prose/template-only: `add.py` + `add_engine/*.py` UNTOUCHED ⇒ ENGINE_MD5 / ENGINE_PKG_MD5 unchanged
+  - a fresh `new-task` scaffold (full AND `--fast`) carries the new §5 line(s)
+  - the orchestration lean-pool fence is rebaselined (ratio 0.75 kept; baseline += ⌈advisor-growth ÷ 0.75⌉) — admit the new surface, preserve the won ground
+</must>
+Reject:
+<reject>
+  - any of the 3 pre-existing §5 lines changed (non-additive) -> "non_additive_edit"
+  - a NEW XML tag added to `TASK.md.tmpl` (the §5 line must be plain text) -> "frozen_tag_census"
+  - `<strategy>` placed OUTSIDE the advisor.md code fence -> "vocab_offmidiom"
+  - `add.py` / `add_engine/*.py` edited -> "engine_touched"
+  - one tree edited but not all three -> "parity_break"
+</reject>
+After:
+<after>
+  - every newly scaffolded task (full + fast) records strategy AND known-problem solutions in §5, and the advisor spawn template tells the subagent to follow them — closing the doc-vs-reality gap the ai-proxy trace exposed (strategy lived in global Rule-5, never pulled from §5)
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ the exact WORDING/SHAPE of the three additions (a separate `Known-problem fixes:` line vs. folding into Strategy; a dedicated `<strategy>` tag vs. extending `<persona>` step-2) — lowest confidence because it is a method-voice choice the human owns; if wrong: re-edit prose across 6 files + re-rebaseline (cheap but churny) — THIS is the freeze flag
+  - [ ] streams.md (the worker-contract HOME) stays UNCHANGED — the advisor fenced `<strategy>` needs no matching streams.md worker-contract tag / WORKER_CONTRACT_TAGS update; if wrong: a consistency gap between single-advisor and parallel-streams spawns (carry as a spec-delta, don't widen scope now)
+  - [ ] the fast lane SHOULD carry strategy too (the human chose "Both"); if leanness should win, drop the fast-template edit
+</assumptions>
+
+<!-- EXIT: every rule stated, every rejection named; assumptions ranked lowest-confidence first, the top one or two ⚠-flagged with why + cost (or, for trivial scope, an honest "none material" that still names the single biggest risk). -->
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: full template §5 carries known-problem fixes
+  Given add-method/tooling/templates/TASK.md.tmpl
+  When I read its §5 BUILD block
+  Then a plain-text "Known-problem fixes:" line is present, below "Strategy (ordered batches):"
+  And the 3 pre-existing §5 lines (Safety rule / Code lives / Constraints) are byte-identical
+
+Scenario: fast template §5 carries strategy & known-problem fixes
+  Given add-method/tooling/templates/TASK.fast.md.tmpl
+  When I read its §5 BUILD block
+  Then a single "Strategy & known-problem fixes:" line is present
+  And the pre-existing "Scope (may touch):" line is unchanged
+
+Scenario: advisor spawn template carries a fenced <strategy> that points at §5
+  Given add-method/skill/add/advisor.md
+  When I read the plan-following ```xml template
+  Then a <strategy> element is present INSIDE the code fence and names the task's §5
+  And after stripping code fences no <strategy> tag remains (it stays fenced/exempt)
+
+Scenario: a fresh scaffold carries the new §5 lines
+  Given a temp project after init + lock
+  When I run new-task (full) and new-task --fast
+  Then the full TASK.md shows "Known-problem fixes:" and the fast TASK.md shows "Strategy & known-problem fixes:"
+
+Scenario: three trees stay byte-identical
+  Given the canonical, _bundled, and dogfood copies of each edited file
+  When I md5 each trio (TASK.md.tmpl, TASK.fast.md.tmpl, advisor.md)
+  Then each trio is a single digest
+
+Scenario: prose/template-only — engine untouched
+  Given add.py and add_engine/*.py
+  When I digest them
+  Then ENGINE_MD5 and ENGINE_PKG_MD5 are unchanged from the current pin
+
+Scenario: lean fence stays green after rebaseline
+  Given test_skill_lean.py with the orchestration baseline rebaselined (ratio 0.75 kept)
+  When I run the suite
+  Then the orchestration pool and whole-tree fences pass
+
+Scenario: reject a non-additive edit
+  Given the §5 edit
+  When any pre-existing §5 line (Strategy / Safety rule / Code lives / Constraints) is altered
+  Then test_scope_decl_template fails -> "non_additive_edit"
+  And the edit is rejected
+
+Scenario: reject a new XML tag in the template
+  Given TASK.md.tmpl's frozen tag census
+  When the new §5 element is added as an XML tag instead of plain text
+  Then the FROZEN_TAGS assertion fails -> "frozen_tag_census"
+  And the tag census is unchanged
+
+Scenario: reject <strategy> outside the fence
+  Given advisor.md's outside-fence vocab == {constraints}
+  When <strategy> is placed OUTSIDE the ```xml fence
+  Then test_advisor_strategy / test_xml_convention fail -> "vocab_offmidiom"
+  And the outside-fence vocab stays {constraints}
+```
+
+</scenarios>
+
+<!-- EXIT: one scenario per Must AND per Reject; each result is observable. -->
+
+---
+
+## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
+
+```
+THREE LITERAL ADDITIONS (each applied byte-identically across canonical · _bundled · dogfood):
+
+ADD-1 · full TASK.md.tmpl §5 BUILD — insert AFTER the "Strategy (ordered batches):" line,
+        BEFORE "Safety rule (feature-specific):" (so Scope < Strategy < Known-problem fixes < Safety rule):
+    Known-problem fixes: <trap → planned fix — the failure modes this build must dodge; guidance, not enforced>
+
+ADD-2 · fast TASK.fast.md.tmpl §5 BUILD — insert AFTER the "Scope (may touch):" line,
+        BEFORE "Code lives in:":
+    Strategy & known-problem fixes: <ordered build steps · the trap each known problem must dodge>
+
+ADD-3 · advisor.md fenced ```xml template — insert a <strategy> block AFTER </persona>,
+        BEFORE <context_files> (INSIDE the existing code fence):
+    <strategy>
+    Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build order
+    and the Known-problem fixes (trap → fix for each anticipated failure mode).
+    </strategy>
+  + one prose clause in "## The plan-following prompt template" naming that <strategy> mirrors §5.
+
+INVARIANTS (frozen):
+  INV-1 additive — the 3 pre-existing full-§5 lines + the fast "Scope (may touch):" line stay byte-identical
+  INV-2 plain-text in templates — NO new XML tag in TASK.md.tmpl (FROZEN_TAGS unchanged); <strategy> lives ONLY in advisor.md's fence
+  INV-3 fenced — advisor <strategy> inside the ```xml block; advisor outside-fence vocab stays {constraints}
+  INV-4 parity — every edited file's canonical/_bundled/dogfood trio is a single md5
+  INV-5 engine untouched — add.py + add_engine/*.py digests == current pins (ENGINE_MD5 / ENGINE_PKG_MD5)
+  INV-6 lean fence — orchestration baseline rebaselined (ratio 0.75 kept, baseline += ⌈advisor-growth ÷ 0.75⌉); suite green
+Tests: EXTEND test_scope_decl_template.py (ADD-1/2 + parity + engine-untouched) + test_advisor_strategy.py (ADD-3 fenced).
+```
+
+`Least-sure flag surfaced at freeze:` [spec/contract] the exact WORDING of ADD-1/2/3 (a separate `Known-problem fixes:` line vs. folding it into Strategy; a dedicated `<strategy>` tag vs. extending `<persona>` step-2) — a method-voice choice you own; if wrong, re-edit 6 prose files + re-rebaseline (cheap, churny).
+
+Status: FROZEN @ v1 — approved by Tin Dang
+<!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
+     points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
+     with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
+     too — see run.md). Approved -> Status: FROZEN @ vN — approved by <name>. Changing a frozen
+     contract = change request back to SPECIFY.
+     EXIT: frozen + every spec rejection has a contracted response + names match GLOSSARY + the
+     bundle's lowest-confidence flag was surfaced at the freeze (or an honest "none material"). -->
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: behavior-anchored (prose/template task — no src/ %); every scenario has ≥1 assertion across the 2 extended suites
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_full_template_known_problem_fixes_line (ADD-1): Strategy < Known-problem fixes < Safety rule; EXISTING_LINES byte-identical — RED ✓
+  - test_fast_template_strategy_line (ADD-2): fast §5 has 'Strategy & known-problem fixes:' below Scope — RED ✓
+  - test_fast_template_mirrors: fast-template trio single md5 (parity)
+  - test_scaffold_carries_strategy_solutions (ADD-1/2): fresh new-task + new-task --fast carry the lines — RED ✓
+  - test_strategy_block_fenced_and_points_at_section5 (ADD-3, in test_advisor_strategy.py): <strategy> present raw, gone after fence-strip, names §5 — RED ✓
+  - reject guards already live: EXISTING_LINES (non_additive_edit) · FROZEN_TAGS (frozen_tag_census) · test_vocab_subset_outside_fence (vocab_offmidiom) · test_mirrors_and_engine_untouched (engine_touched + parity_break)
+  - test_skill_lean rebaselined → GREEN (regression fence, ratio 0.75 kept)
+</test_plan>
+
+Tests live in: `add-method/tooling/test_scope_decl_template.py` `add-method/tooling/test_advisor_strategy.py` `add-method/tooling/test_skill_lean.py` · MUST run red (missing implementation) before Build.
+<!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
+     a token with "/" = project root · a bare name = sibling of the previous
+     token's dir · a directory counts its *.py files (non-recursive); reports
+     mark declared counts with † · anything resolving outside the project root counts 0 -->
+
+<!-- EXIT: one test per scenario; suite red for the RIGHT reason; target recorded. -->
+
+---
+
+## 5 · BUILD — AI writes code ▸ docs/07-step-5-build.md
+
+Scope (may touch): `add-method/tooling/templates/TASK.md.tmpl` `add-method/tooling/templates/TASK.fast.md.tmpl` `add-method/src/add_method/_bundled/tooling/templates/TASK.md.tmpl` `add-method/src/add_method/_bundled/tooling/templates/TASK.fast.md.tmpl` `.add/tooling/templates/TASK.md.tmpl` `.add/tooling/templates/TASK.fast.md.tmpl` `add-method/skill/add/advisor.md` `add-method/src/add_method/_bundled/skill/add/advisor.md` `.claude/skills/add/advisor.md` `add-method/tooling/test_scope_decl_template.py` `add-method/tooling/test_advisor_strategy.py` `add-method/tooling/test_skill_lean.py`
+Strategy (ordered batches): 1. extend test_scope_decl_template.py (ADD-1/2 + parity + engine-untouched) and test_advisor_strategy.py (ADD-3 fenced) RED · 2. apply ADD-1/2 to all 6 template copies + ADD-3 to all 3 advisor copies (byte-identical) · 3. measure advisor growth, rebaseline orchestration baseline (ratio 0.75 kept) · 4. run full suite green
+Known-problem fixes: tree-parity drift (edit one copy, forget the others) → edit all 3 copies of each file in the same batch + the parity md5 test catches it · stale `wc -c` math on the rebaseline → recompute from the real bytes after the edit, never hand-estimate · a multibyte char (→ ⚠) miscounted → byte count not char count, matching the fence's `wc -c ÷ 4` proxy
+Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>
+Code lives in: the files named in Scope (no `./src/` — this is a method/template task)
+Constraints: do NOT change any test or the contract; allow-list packages only; ask if unclear.
+
+<!-- Scope tokens, backticked, FIRST declaring line: `./…` = this task dir · a token
+     with "/" = project root · a bare name = sibling of the previous token's dir ·
+     outside-root resolutions are dropped fail-closed · a DIRECTORY token covers its
+     whole subtree (containment — diverges from §4's non-recursive counting) ·
+     absent line = UNDECLARED (pre-existing tasks grandfathered, never retro-red) ·
+     engine enforcement (touched ⊆ declared) lands in scope-gate-enforce.
+     EXIT: all green; coverage held; no test/contract touched; no unlisted dependency. -->
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [x] all tests pass — full tooling suite 2107/0; check 457/0
+- [x] coverage did not decrease — behavior-anchored prose/template task; 5 new assertions added, none removed
+- [x] no test or contract was altered during build — all test edits done in the TESTS phase; build touched only the 9 method/template files (git status confirms)
+- [x] the green was EARNED, not gamed — refute-read: the scaffold test invokes real `new-task` + `new-task --fast` and reads the scaffolded TASK.md (end-to-end, not a fixture); `<strategy>` test asserts present-raw + gone-after-fence-strip + names §5; templates are pure insertions (1+/0-), advisor's lone "-1" is the intro sentence extended in place (no content lost)
+- [x] concurrency / timing of the risky operation is safe — N/A: static prose/template files, no runtime path
+- [x] no exposed secrets, injection openings, or unexpected dependencies — N/A: no code, no deps; allow-list untouched
+- [x] layering & dependencies follow CONVENTIONS.md — mirrors the scope-decl-template precedent (additive §5 line + 3-tree parity + engine-untouched)
+- [x] a person reviewed and approved the change — Tin Dang approved the §3 freeze @ v1 (the one human gate); auto-gated on complete evidence under `autonomy: auto`
+
+### Build expectations — what "correct" looks like (fill BEFORE build; confirm each at the gate)
+> Pre-declare the OBSERVABLE outcomes a correct build must produce — derived from §2 SCENARIOS
+> + §3 CONTRACT — so this gate checks the build is RIGHT, not merely that tests are green. Each
+> row is evidence you can SEE, not a restatement of a test name.
+- [x] a freshly scaffolded full task shows `Known-problem fixes:` in §5; a `--fast` task shows `Strategy & known-problem fixes:` — confirmed by test_scaffold_carries_strategy_solutions running real new-task in a temp project
+- [x] the advisor spawn template tells a subagent to follow the task's §5 — confirmed by reading the shipped `<strategy>` block (names §5 + Strategy + Known-problem fixes), fenced
+- [x] the addition cost nothing elsewhere — confirmed: engine pins unchanged (no add.py/add_engine in git status), orchestration lean pool 39265 ≤ 39348 target (ratio 0.75 kept)
+
+### Deep checks — do not skim (fill the path that applies; the resolver judges which)
+- [x] SEMANTIC (prose / non-code) — read in full, not skimmed: the §5 additions (full + fast) read as additive, in-place, ordered correctly (Scope < Strategy < Known-problem fixes < Safety rule); the advisor `<strategy>` block + intro clause read as consistent with §5's two field labels; no existing line lost; the lean rebaseline comment documents the +352 B / +470 baseline per the won-ground method
+
+### GATE RECORD
+Outcome: PASS
+If RISK-ACCEPTED -> owner: <name> · ticket: <link> · expires: <date>   (never for a security gap)
+Reviewed by: Tin Dang · date: 2026-06-27
+
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): whether scaffolded tasks actually FILL the new §5 lines (a blank `Known-problem fixes:` is a non-use signal); whether spawned subagents cite §5 strategy in their returns
+
+### Spec delta
+Forward changes for the next loop — each re-enters at Specify as the next task. One line
+each, tagged `[SPEC · open|seeded|dropped]`, with evidence (e.g. `[SPEC · open] rate-limit
+the retry path (evidence: prod herd spikes)`). See the `add` skill's `deltas.md`.
+- [SPEC · seeded] extend the SAME §5-strategy pull to streams.md's worker contract (the parallel-spawn HOME) + WORKER_CONTRACT_TAGS, so parallel workers and the single advisor are consistent (evidence: this task wired only advisor.md; the ai-proxy trace showed executors were parallel `streams.md`-style spawns, which still carry no §5 link) [→ streams-strategy-pull]
+
+### Competency deltas
+What did this loop teach the foundation? One line each, tagged by competency
+(`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
+- [ADD · open] a spawn template that doesn't reference the task's own §5 plan lets each spawn re-invent strategy (the ai-proxy trace: 319 spawns pulled strategy from global Rule-5, never from §5) — fixed for the advisor; streams.md still open (evidence: test_advisor_strategy now asserts the <strategy>→§5 link)

--- a/.add/tasks/skill-todo-flag/TASK.md
+++ b/.add/tasks/skill-todo-flag/TASK.md
@@ -1,0 +1,136 @@
+# TASK: Capture/list/close todos via /add --todo flag
+
+slug: skill-todo-flag · created: 2026-06-27 · stage: mvp
+autonomy: auto
+phase: done   <!-- fast lane: ground -> specify -> contract -> tests -> build -> verify -> observe -> done -->
+fast: true   <!-- the fast lane: a small task, collapsed flow + minimal template. Omit --fast for full rigor. -->
+
+> Fast lane — one small task, minimal sections, filled top-to-bottom. The trust floor still
+> holds: a FROZEN §3 contract · ≥1 red test before build · a recorded §6 gate (security = HARD-STOP).
+> The acceptance scenario collapses into §1 `Accept:`; OBSERVE is one optional line at the gate.
+
+---
+
+## 0 · GROUND — the real codebase
+
+Touches (files · symbols):
+  - `add-method/skill/add/SKILL.md` — canonical orchestrator instructions; the `argument-hint:` frontmatter line + the "Always start here" / "Flag mode" section where the `--todo` fast-path doc goes. THE change is here (prose only).
+  - `.claude/skills/add/SKILL.md` + `add-method/src/add_method/_bundled/skill/add/SKILL.md` — byte-identical mirrors; propagated by `cp` (not re-authored).
+  - `add-method/tooling/add.py:cmd_todo` (lines 1040–1076) — the engine command the fast-path routes to; UNCHANGED. It already exposes the full mirror: `[--done ID] [text]` + bare = list.
+  - NEW guard test `add-method/tooling/test_skill_todo_flag.py` — asserts SKILL.md documents the `--todo` fast-path (presence/format, canonical tree).
+Context (working folder):
+  - `add-method/tooling/test_skill_lean.py` — core pool (SKILL.md+intake.md) baseline 19675 · ratio 0.88 · target 17314; current 17171 → only 143 B headroom, so the new surface needs a human-approved rebaseline.
+  - `add-method/tooling/test_tree_parity.py` + `test_bundle_parity.py` — the 3-tree byte-identical guards that catch un-propagated edits.
+Honors (patterns / conventions):
+  - 3-tree byte-identical parity (canonical = dogfood = _bundled) — cp, never hand-edit twice.
+  - Lean "rebaseline-for-human-approved-new-surface": keep the ratio EXACTLY, grow baseline by surface÷ratio (the won compaction stays pinned).
+  - Presence/format guard anchored on a DISCLOSURE-UNIQUE token, not a common word (lesson from security-escalation-disclosure).
+  - Fast-lane floor: FROZEN §3 · ≥1 red test before build · recorded §6 gate.
+Anchors the contract cites:
+  - the `--todo` fast-path block + the `argument-hint:` line in `SKILL.md`
+  - `test_skill_todo_flag.py` (the new red guard)
+  - `cmd_todo` in `add.py` (the route target, unchanged)
+
+---
+
+## 1 · SPECIFY — the rules
+
+Feature: `--todo` flag on the `/add` skill — a front-of-skill fast-path that routes a todo
+capture/list/close straight to the engine, bypassing the orient/status flow.
+
+Must:
+  - SKILL.md documents a `--todo` fast-path the orchestrator checks BEFORE orienting: when the
+    skill ARGUMENTS begin with `--todo`, route the remainder to `python3 .add/tooling/add.py todo …`,
+    print the engine's output, and STOP (no status/resume flow).
+  - The doc covers the full mirror of `cmd_todo`: `--todo <text>` → capture · `--todo` (no
+    remainder) → list open todos · `--todo --done <id>` → close.
+  - Engine errors are surfaced verbatim, never swallowed (`todo_empty` on blank text,
+    `todo_unknown` on a bad id) — no silent pass.
+  - The `argument-hint:` frontmatter names `--todo`, and the fast-path is byte-identical across
+    all three skill trees (canonical · dogfood · _bundled).
+
+Reject:
+  - `--todo` with blank text -> engine emits "todo_empty" (surfaced, not hidden)
+  - `--todo --done <unknown-id>` -> engine emits "todo_unknown" (surfaced, not hidden)
+
+Accept: Given the canonical SKILL.md, when the lean+parity suite runs, then SKILL.md contains a
+`--todo` fast-path block documenting all three sub-forms (capture/list/close) AND `argument-hint`
+names `--todo` AND all three trees stay byte-identical — drives the §4 guard test.
+
+Assumptions: ⚠ A presence/format guard proves the INSTRUCTION is written, NOT that the LLM
+orchestrator obeys it at runtime — same epistemic blind spot as the security-escalation
+disclosure (the engine cannot test an instruction-to-the-AI). If wrong: the doc is present but
+ignored and `/add --todo` falls through to orient; cost = one mis-routed invocation, self-evident
+to the user. Mitigation: put the fast-path FIRST in SKILL.md (first thing read) + anchor the guard
+on a disclosure-unique token. No engine code changes (cmd_todo already does the work).
+
+---
+
+## 3 · CONTRACT — freeze the shape
+
+```
+SKILL.md `--todo` fast-path — checked at the TOP of the skill, BEFORE the orient/status flow:
+
+  /add --todo <text>       → run: add.py todo "<text>"     → "captured todo #N: <text>"
+  /add --todo              → run: add.py todo              → lists open todos (or "no open todos")
+  /add --todo --done <id>  → run: add.py todo --done <id>  → "todo #id done"
+  then STOP — do not run status/resume. Engine errors surfaced verbatim
+  (todo_empty on blank text · todo_unknown on a bad id).
+
+argument-hint frontmatter: names "--todo <text>" (discoverable cue).
+
+Doc surface: present + byte-identical in all 3 skill trees
+  (add-method/skill/add/ · .claude/skills/add/ · add-method/src/add_method/_bundled/skill/add/).
+
+Guard (test_skill_todo_flag.py, canonical tree only):
+  - SKILL.md contains a `--todo` fast-path block naming all 3 sub-forms
+    (the `--todo` token, the `--done` close form, and capture + list)
+  - the `argument-hint:` line names `--todo`
+  (presence/format only — it cannot prove the orchestrator OBEYS, see §1 Assumptions)
+
+No engine change: cmd_todo (add.py:1040–1076) already implements capture/list/close.
+```
+
+`Least-sure flag surfaced at freeze:` [contract] how tightly the guard pins wording. Too strict →
+a future lean-compaction reword trips the fence (cost: a fence edit); too loose → vacuous pass,
+doc drift undetected (cost: silent regression). Chosen middle: assert the disclosure-unique multi-token
+set (`--todo` + `--done` + capture/list semantics), not the exact sentence.
+Status: FROZEN @ v1 — approved by Tin Dang
+<!-- The freeze IS the one approval. Approved -> Status: FROZEN @ vN — approved by <name>.
+     Changing a frozen contract = change request back to SPECIFY. -->
+
+---
+
+## 4 · TESTS — failing-first (red)
+
+Plan: test_skill_todo_flag.py — 4 cases: the fast-path block marker · the 3 sub-forms
+(capture/list/close) · routes to `add.py todo` · `argument-hint` names `--todo`. RED before build:
+3/4 fail (the `add.py todo` route token already exists in the Flag-mode line, so that 1 case is
+green from the start; the 3 meaningful guards are red — verified).
+Tests live in: `add-method/tooling/test_skill_todo_flag.py` · MUST run red (missing doc) before Build.
+
+---
+
+## 5 · BUILD — AI writes code
+
+Scope (may touch): `add-method/skill/add/SKILL.md` · `.claude/skills/add/SKILL.md` · `add-method/src/add_method/_bundled/skill/add/SKILL.md` · `add-method/tooling/test_skill_lean.py`
+Code lives in: `add-method/skill/add/SKILL.md` (canonical prose) → cp to the 2 mirrors · Constraints: change no §4 test, no frozen §3; SKILL.md prose only + the core lean-fence rebaseline (human-approved new surface, ratio 0.88 kept).
+
+---
+
+## 6 · VERIFY — evidence + gate
+
+- [x] all tests pass · coverage held · no test or contract altered during build — full suite 2102/0; §4 test_skill_todo_flag.py + frozen §3 unchanged during build (tripwire clean); changed files (SKILL.md ×3 + test_skill_lean.py) all within §5 scope
+- [x] green was EARNED — no overfit / vacuous asserts / stubbed-away logic — the guard asserts the disclosure-unique `--todo` fast-path marker + all 3 sub-forms + route + arg-hint (the honest blind spot — it can't prove runtime obedience — is disclosed in §1, not papered over)
+- [x] no exposed secrets, injection openings, or unexpected dependencies (security = HARD-STOP) — prose + a test-fence only; NO engine change (ENGINE_MD5 untouched), zero new deps
+
+Build expectations (from §1 Accept + §3 CONTRACT): canonical SKILL.md gains a `--todo` fast-path block
+(capture/list/close routing to `add.py todo`, then STOP) + `argument-hint` names `--todo`; cp'd byte-identical
+to the 2 mirrors; core lean fence rebaselined (ratio kept). Confirmed by: test_skill_todo_flag (4/4 green) +
+test_skill_lean + test_tree_parity + test_bundle_parity all green.
+
+### GATE RECORD
+Outcome: PASS
+Reviewed by: Tin Dang · date: 2026-06-27
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass.
+     OBSERVE (optional): one `[SPEC · open]` or competency-delta line here if the loop taught the foundation something. -->

--- a/.add/tasks/strategy-soft-not-hard/TASK.md
+++ b/.add/tasks/strategy-soft-not-hard/TASK.md
@@ -1,0 +1,252 @@
+# TASK: Soften the <strategy> block: §5 is preferred, builder self-improves + reports actual strategy for audit
+
+slug: strategy-soft-not-hard · created: 2026-06-28 · stage: mvp
+autonomy: auto   <!-- inherited from the project default (PROJECT.md); explicit level: manual < conservative < auto (visible · overridable) — lower below if a high-risk task needs it, or run `add.py autonomy set`. Multi-component repo (monorepo/multi-repo)? add a `component: <name>` line (declared in `.add/components.toml`) to ADD that component's root to your §5 Scope; omit for single-component projects (byte-identical default). -->
+phase: done   <!-- ground -> specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+<!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower the
+     autonomy level to `manual` or `conservative` — the engine refuses an unguarded completion
+     (`unguarded_high_risk_auto`, run.md guard). A comment is never a declaration. -->
+
+> One file = one task. Fill sections top-to-bottom; the `add` skill drives each phase.
+> When a phase is unclear, read its book chapter in `.add/docs/` (linked per section).
+> The phase marker above is the single source of truth — keep it in sync via `add.py phase`.
+
+---
+
+## 0 · GROUND — the real codebase ▸ docs/02-the-flow.md
+
+Touches (files · symbols · signatures):
+  - `add-method/skill/add/advisor.md` — the plan-following template: (a) the intro clause "The `<strategy>` block mirrors … builds in the planned order and dodges the known traps" (outside the fence) + (b) the fenced `<strategy>` block (after `</persona>`); SOFTEN both — §5 becomes the PREFERRED path (drop "do not invent your own"), builder self-improves + reports the actual strategy for audit
+  - `add-method/skill/add/streams.md` — the worker-contract `<strategy>` block (same fenced block, byte-identical to advisor's); SOFTEN to match
+  - 3-tree byte parity for BOTH files: also `.claude/skills/add/…` + `add-method/src/add_method/_bundled/skill/add/…`
+  - `add-method/tooling/test_advisor_strategy.py` `test_strategy_block_fenced_and_points_at_section5` — ADD softening assertions (preferred/not-hard · self-improve · report-for-audit · rigid phrase gone)
+  - `add-method/tooling/test_streams.py` `WorkerStrategyPullTest` — ADD the same softening assertions
+  - `add-method/tooling/test_skill_lean.py` — orchestration baseline 52731 → 53125 (+⌈295/0.75⌉=394; ratio 0.75 kept)
+Context (working folder): the just-shipped PR #106 (build-strategy-solutions + streams-strategy-pull) whose block reads "Follow … do not invent your own" — the user feedback: strategy is PREFERRED not hard; builder self-improves + reports actual strategy for audit (ties to ADR-at-observe todo #22)
+Honors (patterns / conventions): change-request discipline (the edited §3 wording RE-freezes @ v1); 3-tree byte parity; prose/skill-only ⇒ ENGINE_MD5/ENGINE_PKG_MD5 untouched; lean rebaseline = documented "human-approved surface" (ratio kept); WORKER_CONTRACT_TAGS keeps "strategy" (no regression)
+Anchors the contract cites: advisor.md intro clause + `<strategy>` block · streams.md `<strategy>` block · the two blocks byte-identical · `test_skill_lean` orchestration baseline 53125
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+Feature: soften the `<strategy>` spawn-prompt block — §5 is the builder's PREFERRED plan it self-improves and reports on, not a hard directive (change-request on PR #106, per user feedback)
+Framings weighed: soften-block-and-intro (chosen — the intro still says "builds in the planned order", which contradicts a softened block) · block-only (rejected: leaves the rigid intro) · add-the-§5-writeback-engine-now (rejected: that audit-record mechanism is the bigger todo #22; this task is wording only)
+Must:
+<must>
+  - the `<strategy>` block (advisor.md + streams.md, byte-identical) frames the task's §5 as the PREFERRED starting path, explicitly "not a hard rule"; instructs the builder to improve on it when a better strategy emerges during build; and on done to report the strategy ACTUALLY used so the orchestrator can update §5 for the audit trail
+  - the rigid phrase "do not invent your own" is GONE from both blocks
+  - advisor.md's intro clause is softened to match (no "builds in the planned order and dodges the known traps")
+  - the two `<strategy>` blocks stay byte-identical to each other AND across the 3 trees each (advisor.md + streams.md)
+  - skill-prose-only: `add.py` + `add_engine/*.py` UNTOUCHED ⇒ ENGINE_MD5 / ENGINE_PKG_MD5 unchanged
+  - WORKER_CONTRACT_TAGS still includes "strategy"; the block stays inside the ```xml fence (no regression of the PR #106 guard)
+  - the orchestration lean pool is rebaselined 52731 → 53125 (ratio 0.75 kept; +⌈295/0.75⌉)
+</must>
+Reject:
+<reject>
+  - "do not invent your own" (or any hard-rule phrasing) left in either block -> "rigid_strategy"
+  - advisor `<strategy>` block text ≠ streams `<strategy>` block text (drift) -> "block_drift"
+  - one tree edited but not all three, for either file -> "parity_break"
+  - `<strategy>` moved OUTSIDE the ```xml fence -> "vocab_offmidiom"
+  - `add.py` / `add_engine/*.py` edited -> "engine_touched"
+</reject>
+After:
+<after>
+  - both spawn homes tell the builder: follow §5 as your PREFERRED plan, self-improve to the best strategy as you build, and report what you ACTUALLY used so §5 is updated for the audit trail — the "too rigid" feedback is closed
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ that the EXISTING positive tests (test_advisor_strategy / test_streams asserting "§5" present + fenced) stay green under the new wording — lowest confidence because dropping "§5" from the block would break them; mitigated: the new block keeps "§5" verbatim; if wrong: those two go red in the build run — cheap to spot — THIS is the freeze flag
+  - [ ] reusing the SAME softened block text in advisor + streams (byte-identical) is right vs a worker-flavored variant — identical maximizes consistency; the established choice from PR #106
+</assumptions>
+
+<!-- EXIT: every rule stated, every rejection named; assumptions ranked lowest-confidence first, the top one or two ⚠-flagged with why + cost (or, for trivial scope, an honest "none material" that still names the single biggest risk). -->
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: the strategy block frames §5 as preferred, not hard
+  Given advisor.md and streams.md <strategy> blocks
+  When I read each block
+  Then it states §5 is the PREFERRED path / "not a hard rule"
+  And the phrase "do not invent your own" is absent
+
+Scenario: the block tells the builder to self-improve and report for audit
+  Given each <strategy> block
+  When I read it
+  Then it instructs improving on the plan when a better strategy emerges
+  And reporting the strategy actually used so §5 is updated for the audit trail
+
+Scenario: advisor and streams blocks stay byte-identical
+  Given the two <strategy> blocks
+  When I compare their text
+  Then they are byte-identical
+
+Scenario: each file stays byte-identical across the three trees
+  Given canonical / _bundled / dogfood advisor.md and streams.md
+  When I md5 each file's trio
+  Then each is a single digest
+
+Scenario: the block stays fenced and registered
+  Given WORKER_CONTRACT_TAGS includes "strategy"
+  When test_engine_worker_contract_preserved runs
+  Then strategy is present-raw AND gone after fence-strip (still fenced)
+
+Scenario: skill-prose-only — engine untouched
+  Given add.py and add_engine/*.py
+  When I digest them
+  Then ENGINE_MD5 and ENGINE_PKG_MD5 are unchanged
+
+Scenario: lean fence green after rebaseline
+  Given the orchestration baseline 53125 (ratio 0.75 kept)
+  When I run the suite
+  Then the orchestration pool and whole-tree fences pass
+
+Scenario: reject rigid phrasing
+  Given the softened block
+  When "do not invent your own" (hard-rule phrasing) is present in a block
+  Then the softening assertion fails -> "rigid_strategy"
+  And the block is not shipped
+
+Scenario: reject block drift
+  Given advisor + streams blocks must match
+  When their text differs
+  Then the byte-identity assertion fails -> "block_drift"
+  And neither half ships alone
+```
+
+</scenarios>
+
+<!-- EXIT: one scenario per Must AND per Reject; each result is observable. -->
+
+---
+
+## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
+
+```
+ARTIFACT: the <strategy> block — fenced (inside the worker / plan-following xml code fence),
+byte-identical in advisor.md (after </persona>) and streams.md (after </persona>, before <touch_boundary>)
+
+FROZEN BLOCK TEXT (327 B · byte-identical in both files · all 3 trees):
+<strategy>
+The task's §5 plan — the Strategy (ordered batches) order and the Known-problem fixes — is
+your PREFERRED starting path, not a hard rule. Improve on it when a better strategy emerges
+as you build; on done, report the strategy you ACTUALLY used so the orchestrator can update
+§5 for the audit trail.
+</strategy>
+
+FROZEN ADVISOR INTRO CLAUSE (188 B · advisor.md only · prose above the fence):
+The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes) as the subagent's PREFERRED path — it self-improves on that plan and reports the strategy it actually used.
+
+INVARIANTS:
+INV-1  both <strategy> blocks byte-identical to each other and to the FROZEN BLOCK TEXT
+INV-2  advisor.md AND streams.md each byte-identical across canonical / _bundled / dogfood
+INV-3  "do not invent your own" absent from both blocks
+INV-4  WORKER_CONTRACT_TAGS still includes "strategy"; block stays inside the xml fence
+INV-5  add.py + add_engine/*.py untouched -> ENGINE_MD5 / ENGINE_PKG_MD5 unchanged
+INV-6  orchestration lean baseline 52731 -> 53125 (ratio 0.75 kept; +ceil(295/0.75)=394)
+error codes: rigid_strategy · block_drift · parity_break · vocab_offmidiom · engine_touched
+```
+
+Least-sure flag surfaced at freeze: [test] the existing positive tests assert "§5" is present in the block — the new wording keeps "§5" verbatim, so they stay green; had I dropped it they'd go red (caught in the build run). No other material risk: pure prose, no engine, byte-parity + lean enforced.
+Status: FROZEN @ v1 — approved by Tin Dang
+<!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
+     points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
+     with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
+     too — see run.md). Approved -> Status: FROZEN @ vN — approved by <name>. Changing a frozen
+     contract = change request back to SPECIFY.
+     EXIT: frozen + every spec rejection has a contracted response + names match GLOSSARY + the
+     bundle's lowest-confidence flag was surfaced at the freeze (or an honest "none material"). -->
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: behavior-anchored (skill/test-only); every Must + Reject has ≥1 assertion
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_strategy_block_is_preferred_not_hard (test_advisor_strategy.py): block has "not a hard rule" + "Improve on it" + "report the strategy" + "audit"; "do not invent your own" absent; advisor intro softened ("self-improves on that plan", no "builds in the planned order") — RED ✓
+  - test_strategy_block_is_preferred_not_hard (test_streams.py): same block assertions for streams.md — RED ✓
+  - test_block_byte_identical_to_advisor (test_streams.py): the two <strategy> blocks byte-identical (block_drift guard) — green now (both old), stays green after identical edit
+  - test_strategy_block_fenced_and_points_at_section5 (existing): §5 + fenced preserved
+  - test_engine_worker_contract_preserved / WORKER_CONTRACT_TAGS: "strategy" still present-raw + fenced
+  - three-trees byte-identity (existing, advisor + streams): single md5 each after the mirror cp
+  - test_skill_lean rebaselined 53125 → GREEN (ratio 0.75 kept)
+  - ENGINE_MD5 / ENGINE_PKG_MD5 suites: unchanged (no engine touched)
+</test_plan>
+
+Tests live in: `add-method/tooling/test_advisor_strategy.py` `add-method/tooling/test_streams.py` `add-method/tooling/test_skill_lean.py` · MUST run red (missing implementation) before Build.
+<!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
+     a token with "/" = project root · a bare name = sibling of the previous
+     token's dir · a directory counts its *.py files (non-recursive); reports
+     mark declared counts with † · anything resolving outside the project root counts 0 -->
+
+<!-- EXIT: one test per scenario; suite red for the RIGHT reason; target recorded. -->
+
+---
+
+## 5 · BUILD — AI writes code ▸ docs/07-step-5-build.md
+
+Scope (may touch): `add-method/skill/add/advisor.md` `add-method/skill/add/streams.md` `.claude/skills/add/advisor.md` `.claude/skills/add/streams.md` `add-method/src/add_method/_bundled/skill/add/advisor.md` `add-method/src/add_method/_bundled/skill/add/streams.md` `add-method/tooling/test_advisor_strategy.py` `add-method/tooling/test_streams.py` `add-method/tooling/test_skill_lean.py`
+Strategy (ordered batches): 1. TESTS — add softening assertions to test_advisor_strategy + test_streams (preferred/not-hard · self-improve · report-for-audit · "do not invent your own" absent) and rebaseline lean to 53125 (all red/adjusted before build). 2. BUILD — edit canonical advisor.md (intro clause + `<strategy>` block) and streams.md (`<strategy>` block), then cp canonical → both mirrors for each file. 3. Verify the two blocks are byte-identical to each other + each file's trio is one md5; run the suite green.
+Known-problem fixes: greedy block-match catching the intro's backtick `<strategy>` reference → anchor the block regex to a line-start `\n<strategy>\n` · a stray bracketed tag (e.g. `<return>`) inside the block confusing the convention parser → keep tag-like words out of the prose · forgetting a mirror → always cp from canonical and md5 the trio · editing a test during BUILD trips the tamper tripwire → do ALL test edits (incl. the lean rebaseline) in the TESTS phase
+Safety rule (feature-specific): edit the canonical file, then cp to BOTH mirrors in the same batch — never hand-type a mirror (keeps the 3-tree md5 single)
+Code lives in: `./src/`
+Constraints: do NOT change any test or the contract; allow-list packages only; ask if unclear.
+
+<!-- Scope tokens, backticked, FIRST declaring line: `./…` = this task dir · a token
+     with "/" = project root · a bare name = sibling of the previous token's dir ·
+     outside-root resolutions are dropped fail-closed · a DIRECTORY token covers its
+     whole subtree (containment — diverges from §4's non-recursive counting) ·
+     absent line = UNDECLARED (pre-existing tasks grandfathered, never retro-red) ·
+     engine enforcement (touched ⊆ declared) lands in scope-gate-enforce.
+     EXIT: all green; coverage held; no test/contract touched; no unlisted dependency. -->
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [x] all tests pass — full tooling suite 2112/0; check 464/0
+- [x] coverage did not decrease — +3 softening tests (advisor + streams + block-identity); none removed
+- [x] no test or contract was altered during build — all test edits in the TESTS phase; build touched only the 6 skill copies (git status confirms)
+- [x] the green was EARNED, not gamed — refute-read: the softening tests proved RED against the old "do not invent your own" block, then GREEN after the edit; block-identity + 3-tree md5 enforce no drift; the §5 marker survives so the existing positive tests still bind
+- [x] concurrency / timing of the risky operation is safe — N/A: static skill prose
+- [x] no exposed secrets, injection openings, or unexpected dependencies — N/A: no code/deps
+- [x] layering & dependencies follow CONVENTIONS.md — block stays fenced; intro stays outside-fence; mirrors the established <strategy> pattern
+- [x] a person reviewed and approved the change — Tin Dang approved the §3 re-freeze @ v1 (and the before/after wording before the task); auto-gated on complete evidence
+
+### Build expectations — what "correct" looks like (fill BEFORE build; confirm each at the gate)
+- [x] the block now reads "PREFERRED starting path, not a hard rule … Improve on it … report the strategy you ACTUALLY used … for the audit trail" — confirmed by reading the shipped block in advisor.md + streams.md
+- [x] the rigid framing is gone from BOTH homes — confirmed: "do not invent your own" in advisor=False, in streams=False; advisor intro no longer says "builds in the planned order"
+- [x] no cost elsewhere — confirmed: engine pins unchanged (no add.py/add_engine in git status); blocks byte-identical (True); 3-tree md5 = 1 each; lean pool green at 53125 (ratio 0.75 kept)
+
+### Deep checks
+- [x] SEMANTIC (prose / non-code) — read in full, not skimmed: the new block reads as a preference (preferred path / not a hard rule), invites self-improvement (Improve on it when a better strategy emerges), and closes the loop (report the strategy actually used → §5 audit trail); the advisor intro now mirrors that framing; both blocks fenced, identical, registered (WORKER_CONTRACT_TAGS keeps "strategy")
+
+### GATE RECORD
+Outcome: PASS
+If RISK-ACCEPTED -> owner: <name> · ticket: <link> · expires: <date>   (never for a security gap)
+Reviewed by: Tin Dang · date: 2026-06-28
+
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): a future spawn prompt drifting back to a hard directive (grep the blocks for "do not invent your own" / "must follow"); the two blocks drifting apart (block_drift)
+
+### Spec delta
+Forward changes for the next loop — each re-enters at Specify as the next task. One line
+each, tagged `[SPEC · open|seeded|dropped]`, with evidence (e.g. `[SPEC · open] rate-limit
+the retry path (evidence: prod herd spikes)`). See the `add` skill's `deltas.md`.
+- [SPEC · open] make the report→§5 loop real at OBSERVE — the builder's reported actual-strategy is written back into §5 as a durable ADR-style record for BOTH human and AI decisions, not just prose guidance (evidence: this task only softened the prompt wording; the write-back is still manual — ties to todo #22)
+
+### Competency deltas
+What did this loop teach the foundation? One line each, tagged by competency
+(`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
+- [ADD · open] spawn-prompt strategy guidance must be PREFERRED-not-hard + self-improve-during-build + report-actual-for-audit, never a rigid "do not invent your own" (evidence: the shipped block contradicted advisor.md's own confidence.md self-score/refine ethos; the user flagged it as too hard)

--- a/.add/tasks/streams-strategy-pull/TASK.md
+++ b/.add/tasks/streams-strategy-pull/TASK.md
@@ -1,0 +1,246 @@
+# TASK: Extend the §5-strategy pull to streams.md's worker contract
+
+slug: streams-strategy-pull · created: 2026-06-27 · stage: mvp
+autonomy: auto   <!-- inherited from the project default (PROJECT.md); explicit level: manual < conservative < auto (visible · overridable) — lower below if a high-risk task needs it, or run `add.py autonomy set`. Multi-component repo (monorepo/multi-repo)? add a `component: <name>` line (declared in `.add/components.toml`) to ADD that component's root to your §5 Scope; omit for single-component projects (byte-identical default). -->
+phase: done   <!-- ground -> specify -> scenarios -> contract -> tests -> build -> verify -> observe -> done -->
+<!-- high-risk/method-defining scope? declare `risk: high` on the slug line above and lower the
+     autonomy level to `manual` or `conservative` — the engine refuses an unguarded completion
+     (`unguarded_high_risk_auto`, run.md guard). A comment is never a declaration. -->
+
+> One file = one task. Fill sections top-to-bottom; the `add` skill drives each phase.
+> When a phase is unclear, read its book chapter in `.add/docs/` (linked per section).
+> The phase marker above is the single source of truth — keep it in sync via `add.py phase`.
+
+---
+
+## 0 · GROUND — the real codebase ▸ docs/02-the-flow.md
+
+Touches (files · symbols · signatures):
+  - `add-method/skill/add/streams.md` — the worker-contract ```xml fence (§ "## The worker contract"); has `<objective>`/`<persona>`/`<touch_boundary>`/`<context_files>`/`<expertise>`/`<tools>`/`<return>`; ADD a `<strategy>` block AFTER `</persona>`, BEFORE `<touch_boundary>` (INSIDE the fence) — same 200 B block shipped to advisor.md
+  - 3-tree parity: also `.claude/skills/add/streams.md` + `add-method/src/add_method/_bundled/skill/add/streams.md` — byte-identical
+  - `add-method/tooling/test_xml_convention.py:190` `WORKER_CONTRACT_TAGS` — ADD `"strategy"` so test_engine_worker_contract_preserved requires it present-raw + gone-after-strip (fenced)
+  - `add-method/tooling/test_skill_lean.py` — streams.md ∈ orchestration pool → REBASELINE 52464 → 52731 (+⌈200/0.75⌉=267); ratio 0.75 kept
+Context (working folder):
+  - `add-method/tooling/test_streams.py` — guards streams.md worker contract (does NOT assert the XML tag set; that's test_xml_convention) — ADD one positive test: `<strategy>` present, fenced, names §5
+  - the just-shipped `advisor.md` `<strategy>` block (build-strategy-solutions) — reuse the EXACT same text for consistency
+Honors (patterns / conventions):
+  - mirror the just-merged advisor pattern (fenced <strategy> → task §5); 3-tree byte parity; prose/skill-only ⇒ ENGINE_MD5 untouched
+  - lean rebaseline = documented "rebaseline for human-approved new surface" (ratio kept, baseline += surface÷ratio)
+  - red/green TDD; freeze §3 before build; resolves the build-strategy-solutions [SPEC · seeded] delta
+Anchors the contract cites: `streams.md` worker-contract `<strategy>` block · `WORKER_CONTRACT_TAGS` += "strategy" · `test_skill_lean.py` orchestration baseline 52731 · `test_streams.py` strategy test
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+Feature: extend the SAME §5-strategy pull to streams.md's worker contract (the parallel-spawn HOME) + WORKER_CONTRACT_TAGS, so parallel workers and the single advisor are consistent (from build-strategy-solutions spec-delta)
+Framings weighed: register-in-WORKER_CONTRACT_TAGS (chosen — the home guards it like every other worker tag) · advisor-only (rejected: leaves the parallel-spawn home inconsistent) · prose-only-no-tag (rejected: a tag is what the worker-contract preserve-test enforces)
+Must:
+<must>
+  - streams.md's worker-contract ```xml fence gains a `<strategy>` block (AFTER `</persona>`, BEFORE `<touch_boundary>`) — the EXACT same 200 B text shipped to advisor.md, pointing the worker at the task's §5 Strategy + Known-problem fixes
+  - `WORKER_CONTRACT_TAGS` (test_xml_convention.py) gains `"strategy"`, so test_engine_worker_contract_preserved requires it present-raw AND gone-after-fence-strip (fenced/exempt)
+  - all edits byte-identical across the 3 streams.md trees (canonical · _bundled · dogfood)
+  - skill-prose-only: `add.py` + `add_engine/*.py` UNTOUCHED ⇒ ENGINE_MD5 / ENGINE_PKG_MD5 unchanged
+  - the orchestration lean-pool fence rebaselined 52464 → 52731 (ratio 0.75 kept; +⌈200/0.75⌉)
+  - resolves the build-strategy-solutions [SPEC · seeded] delta (advisor + streams now both pull §5)
+</must>
+Reject:
+<reject>
+  - `<strategy>` placed OUTSIDE the streams.md fence -> "vocab_offmidiom" (worker tags must stay fenced)
+  - `WORKER_CONTRACT_TAGS` left without "strategy" while the block is added (or vice-versa) -> "preserve_test_red"
+  - one streams.md tree edited but not all three -> "parity_break"
+  - `add.py` / `add_engine/*.py` edited -> "engine_touched"
+</reject>
+After:
+<after>
+  - both spawn homes — the single advisor (advisor.md) AND the parallel worker (streams.md) — direct the spawned agent to follow the task's §5 plan; the consistency gap the ai-proxy trace exposed is fully closed
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ that adding "strategy" to WORKER_CONTRACT_TAGS has no OTHER consumer that breaks — lowest confidence because the constant is imported by test_advisor_strategy (_TEMPLATE_TAGS is a separate local set, but worth a grep); if wrong: a sibling test goes red — cheap to spot in the red run — THIS is the freeze flag
+  - [ ] reusing the advisor block VERBATIM in streams.md is the right call (vs. a worker-flavored wording); identical text maximizes consistency and is the lean choice
+</assumptions>
+
+<!-- EXIT: every rule stated, every rejection named; assumptions ranked lowest-confidence first, the top one or two ⚠-flagged with why + cost (or, for trivial scope, an honest "none material" that still names the single biggest risk). -->
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: streams worker contract carries a fenced <strategy> that points at §5
+  Given add-method/skill/add/streams.md
+  When I read the worker-contract ```xml fence
+  Then a <strategy> element is present between </persona> and <touch_boundary>, naming §5
+  And after stripping code fences no <strategy> tag remains (fenced/exempt)
+
+Scenario: the worker-contract preserve-test recognises strategy
+  Given WORKER_CONTRACT_TAGS includes "strategy"
+  When test_engine_worker_contract_preserved runs
+  Then strategy is in raw tags AND absent from fence-stripped tags
+  And the other worker tags (objective…return) stay present + fenced
+
+Scenario: three streams.md trees stay byte-identical
+  Given the canonical, _bundled, and dogfood streams.md
+  When I md5 the trio
+  Then it is a single digest
+
+Scenario: skill-prose-only — engine untouched
+  Given add.py and add_engine/*.py
+  When I digest them
+  Then ENGINE_MD5 and ENGINE_PKG_MD5 are unchanged
+
+Scenario: lean fence stays green after rebaseline
+  Given test_skill_lean orchestration baseline 52731 (ratio 0.75 kept)
+  When I run the suite
+  Then the orchestration pool and whole-tree fences pass
+
+Scenario: the seeded spec-delta is resolved
+  Given build-strategy-solutions' [SPEC · seeded] streams delta
+  When this task reaches done
+  Then advisor.md AND streams.md both direct the spawn at the task's §5
+
+Scenario: reject <strategy> outside the fence
+  Given streams.md worker tags must stay fenced
+  When <strategy> is placed OUTSIDE the ```xml fence
+  Then test_engine_worker_contract_preserved fails -> "vocab_offmidiom"
+  And the worker tags stay fenced
+
+Scenario: reject a block/tag mismatch
+  Given the <strategy> block and WORKER_CONTRACT_TAGS must move together
+  When only one is changed
+  Then the preserve-test fails -> "preserve_test_red"
+  And neither half ships alone
+```
+
+</scenarios>
+
+<!-- EXIT: one scenario per Must AND per Reject; each result is observable. -->
+
+---
+
+## 3 · CONTRACT — freeze the shape ▸ docs/05-step-3-contract.md
+
+```
+TWO LITERAL ADDITIONS (byte-identical across canonical · _bundled · dogfood):
+
+ADD-A · streams.md worker-contract ```xml fence — insert AFTER </persona>, BEFORE
+        <touch_boundary> (INSIDE the fence), the EXACT block shipped to advisor.md:
+    <strategy>
+    Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
+    order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+    </strategy>
+
+ADD-B · test_xml_convention.py WORKER_CONTRACT_TAGS — add "strategy" to the set.
+
+INVARIANTS (frozen):
+  INV-1 fenced — <strategy> inside the worker-contract ```xml; present-raw, gone-after-strip
+  INV-2 paired-move — the block (ADD-A) and the tag registration (ADD-B) ship together
+  INV-3 parity — the streams.md canonical/_bundled/dogfood trio is a single md5
+  INV-4 engine untouched — add.py + add_engine/*.py == current pins (ENGINE_MD5 / ENGINE_PKG_MD5)
+  INV-5 lean fence — orchestration baseline 52464 → 52731 (ratio 0.75 kept, +⌈200/0.75⌉=267); suite green
+  INV-6 delta — resolves build-strategy-solutions [SPEC · seeded] → [SPEC · folded/resolved]
+Tests: ADD-B turns test_engine_worker_contract_preserved RED→GREEN; + a positive test in test_streams.py (<strategy> fenced + names §5).
+```
+
+`Least-sure flag surfaced at freeze:` [test] adding "strategy" to WORKER_CONTRACT_TAGS — grep CONFIRMED its only consumer is test_engine_worker_contract_preserved (test_advisor_strategy uses a separate local _TEMPLATE_TAGS); risk fully retired. Otherwise a faithful mirror of the v1 you just approved.
+
+Status: FROZEN @ v1 — approved by Tin Dang
+<!-- The freeze IS the one approval — lead it with the bundle's lowest-confidence flag: the 1–2
+     points most likely wrong across the whole bundle, tagged [spec|scenario|contract|test], each
+     with why + cost (the §1 ⚠ assumptions feed it; a flag may point at a scenario or the contract
+     too — see run.md). Approved -> Status: FROZEN @ vN — approved by <name>. Changing a frozen
+     contract = change request back to SPECIFY.
+     EXIT: frozen + every spec rejection has a contracted response + names match GLOSSARY + the
+     bundle's lowest-confidence flag was surfaced at the freeze (or an honest "none material"). -->
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: behavior-anchored (skill/test-only); every scenario has ≥1 assertion
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_strategy_block_present_and_names_section5 (test_streams.py): <strategy> present, between </persona> and <touch_boundary>, names §5 — RED ✓
+  - test_strategy_stays_fenced (test_streams.py): <strategy> gone after fence-strip
+  - test_engine_worker_contract_preserved (test_xml_convention.py): WORKER_CONTRACT_TAGS now includes "strategy" → requires it present-raw + fenced — RED ✓
+  - test_streams_mirror (existing): the 3 streams.md trees single md5 (parity guard)
+  - reject guards reused: preserve-test (vocab_offmidiom if unfenced; preserve_test_red if block/tag mismatch) · ENGINE_MD5 suites (engine_touched)
+  - test_skill_lean rebaselined 52731 → GREEN (ratio 0.75 kept)
+</test_plan>
+
+Tests live in: `add-method/tooling/test_streams.py` `add-method/tooling/test_xml_convention.py` `add-method/tooling/test_skill_lean.py` · MUST run red (missing implementation) before Build.
+<!-- declare paths as backticked tokens on this line: `./…` = this task dir ·
+     a token with "/" = project root · a bare name = sibling of the previous
+     token's dir · a directory counts its *.py files (non-recursive); reports
+     mark declared counts with † · anything resolving outside the project root counts 0 -->
+
+<!-- EXIT: one test per scenario; suite red for the RIGHT reason; target recorded. -->
+
+---
+
+## 5 · BUILD — AI writes code ▸ docs/07-step-5-build.md
+
+Scope (may touch): `add-method/skill/add/streams.md` `add-method/src/add_method/_bundled/skill/add/streams.md` `.claude/skills/add/streams.md` `add-method/tooling/test_xml_convention.py` `add-method/tooling/test_streams.py` `add-method/tooling/test_skill_lean.py`
+Strategy (ordered batches): 1. add "strategy" to WORKER_CONTRACT_TAGS + a positive test_streams.py test RED · 2. insert the <strategy> block into all 3 streams.md copies (byte-identical, reuse advisor text) · 3. rebaseline orchestration 52464→52731 · 4. full suite green + resolve the seeded delta
+Known-problem fixes: tree-parity drift → edit all 3 streams.md in one batch + parity md5 catches it · forgetting WORKER_CONTRACT_TAGS while adding the block → the preserve-test goes red (paired-move enforced) · stale rebaseline math → recompute from real bytes (block measured at 200 B)
+Safety rule (feature-specific): the block (ADD-A) and tag (ADD-B) move together — neither half ships alone
+Code lives in: the files named in Scope (skill/test, not `./src/`)
+Constraints: do NOT change any test logic beyond the named additions or the contract; allow-list only.
+
+<!-- Scope tokens, backticked, FIRST declaring line: `./…` = this task dir · a token
+     with "/" = project root · a bare name = sibling of the previous token's dir ·
+     outside-root resolutions are dropped fail-closed · a DIRECTORY token covers its
+     whole subtree (containment — diverges from §4's non-recursive counting) ·
+     absent line = UNDECLARED (pre-existing tasks grandfathered, never retro-red) ·
+     engine enforcement (touched ⊆ declared) lands in scope-gate-enforce.
+     EXIT: all green; coverage held; no test/contract touched; no unlisted dependency. -->
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [x] all tests pass — full tooling suite 2109/0; check 461/0
+- [x] coverage did not decrease — 2 new test_streams assertions + WORKER_CONTRACT_TAGS now guards strategy; none removed
+- [x] no test or contract was altered during build — all test edits in the TESTS phase; build touched only the 3 streams.md copies (git status confirms)
+- [x] the green was EARNED, not gamed — refute-read: the preserve-test now FAILS if strategy is absent or unfenced (proved red first); the streams positive test asserts placement (between </persona> and <touch_boundary>) + §5 reference + fenced; streams.md is a pure insertion
+- [x] concurrency / timing of the risky operation is safe — N/A: static skill prose
+- [x] no exposed secrets, injection openings, or unexpected dependencies — N/A: no code/deps
+- [x] layering & dependencies follow CONVENTIONS.md — mirrors the advisor.md pattern + worker-contract fence convention exactly
+- [x] a person reviewed and approved the change — Tin Dang approved the §3 freeze @ v1; auto-gated on complete evidence under `autonomy: auto`
+
+### Build expectations — what "correct" looks like (fill BEFORE build; confirm each at the gate)
+> Pre-declare the OBSERVABLE outcomes a correct build must produce — derived from §2 SCENARIOS
+> + §3 CONTRACT — so this gate checks the build is RIGHT, not merely that tests are green. Each
+> row is evidence you can SEE, not a restatement of a test name.
+- [x] streams.md's worker contract directs the worker at the task's §5 — confirmed by reading the shipped `<strategy>` block (names §5 + both field labels), fenced, between persona and touch_boundary
+- [x] both spawn homes now consistent — confirmed: advisor.md (single) + streams.md (parallel) carry the SAME `<strategy>` block; the seeded delta is resolved
+- [x] no cost elsewhere — confirmed: engine pins unchanged (no add.py/add_engine in git status), orchestration pool 39465 ≤ 39548 target (ratio 0.75 kept)
+
+### Deep checks — do not skim (fill the path that applies; the resolver judges which)
+- [x] SEMANTIC (prose / non-code) — read in full, not skimmed: the streams.md `<strategy>` block reads identically to advisor's (deliberate consistency), sits correctly inside the worker-contract fence, and the WORKER_CONTRACT_TAGS addition is the single guard that now binds it; no worker-contract tag lost (preserve-test green)
+
+### GATE RECORD
+Outcome: PASS
+If RISK-ACCEPTED -> owner: <name> · ticket: <link> · expires: <date>   (never for a security gap)
+Reviewed by: Tin Dang · date: 2026-06-27
+
+<!-- A security finding is ALWAYS HARD-STOP. Record exactly one outcome — no silent pass. -->
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): <error rate / per-rejection rate / latency>
+
+### Spec delta
+Forward changes for the next loop — each re-enters at Specify as the next task. One line
+each, tagged `[SPEC · open|seeded|dropped]`, with evidence (e.g. `[SPEC · open] rate-limit
+the retry path (evidence: prod herd spikes)`). See the `add` skill's `deltas.md`.
+
+### Competency deltas
+What did this loop teach the foundation? One line each, tagged by competency
+(`DDD · SDD · UDD · TDD · ADD`), status `open`, with evidence. See the `add` skill's `deltas.md`.
+<!-- e.g.  - [DDD · open] the model missed multi-tenancy (evidence: scenario_x failed) -->

--- a/.add/tooling/templates/TASK.fast.md.tmpl
+++ b/.add/tooling/templates/TASK.fast.md.tmpl
@@ -55,6 +55,7 @@ Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
 ## 5 · BUILD — AI writes code
 
 Scope (may touch): `./src/`   <every file the build may write — declared before the §3 freeze>
+Strategy & known-problem fixes: <ordered build steps · the trap each known problem must dodge>
 Code lives in: `./src/`   ·   Constraints: change no test, no contract; allow-list packages only.
 
 ---

--- a/.add/tooling/templates/TASK.md.tmpl
+++ b/.add/tooling/templates/TASK.md.tmpl
@@ -108,6 +108,7 @@ Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
 
 Scope (may touch): `./src/`   <fill before the §3 freeze — every file the build may write>
 Strategy (ordered batches): <1. … 2. … — the planned build order; guidance, not enforced>
+Known-problem fixes: <trap → planned fix — the failure modes this build must dodge; guidance, not enforced>
 Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>
 Code lives in: `./src/`
 Constraints: do NOT change any test or the contract; allow-list packages only; ask if unclear.

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 when_to_use: "Invoke in any repo with a `.add/` directory, or when the user wants spec/tests-first feature work, resumes ADD work, or asks to start/advance a task."
 category: workflows
 keywords: [add, aidd, ai-driven-development, spec-first, tdd, contract, scenarios, verify, milestone, task-orchestration]
-argument-hint: "status | init | continue | [describe new short goals or expectation]"
+argument-hint: "status | init | continue | --todo <text> | [describe new short goals or expectation]"
 license: MIT
 metadata:
   author: add
@@ -31,6 +31,10 @@ result through passing evidence rather than a plausible-looking diff.
 **One file = one task.** Each feature is one `.add/tasks/<slug>/TASK.md` — a §0 ground
 preamble plus seven step sections, filled top to bottom. The Python tool tracks where you
 are so context never rots across sessions.
+
+**The `--todo` fast-path.** When the skill ARGUMENTS begin with `--todo`, skip orienting: route to
+`add.py todo` and print its output — `--todo <text>` captures · `--todo` lists open todos ·
+`--todo --done <id>` closes (engine errors surfaced verbatim) — then STOP.
 
 ## Always start here (orient — do not skip)
 

--- a/.claude/skills/add/advisor.md
+++ b/.claude/skills/add/advisor.md
@@ -24,7 +24,7 @@ independent enough to earn it. When in doubt, do it in-context.
 
 Give the subagent the *piece of your plan it owns* and a fixed return shape. This reuses
 `streams.md`'s worker-contract tags for a single advisory subagent — the contract is identical
-on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes), so the subagent builds in the planned order and dodges the known traps.
+on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes) as the subagent's PREFERRED path — it self-improves on that plan and reports the strategy it actually used.
 
 ```xml
 <objective>
@@ -41,8 +41,10 @@ Work step by step, following the plan:
 </persona>
 
 <strategy>
-Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
-order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+The task's §5 plan — the Strategy (ordered batches) order and the Known-problem fixes — is
+your PREFERRED starting path, not a hard rule. Improve on it when a better strategy emerges
+as you build; on done, report the strategy you ACTUALLY used so the orchestrator can update
+§5 for the audit trail.
 </strategy>
 
 <context_files>

--- a/.claude/skills/add/advisor.md
+++ b/.claude/skills/add/advisor.md
@@ -24,7 +24,7 @@ independent enough to earn it. When in doubt, do it in-context.
 
 Give the subagent the *piece of your plan it owns* and a fixed return shape. This reuses
 `streams.md`'s worker-contract tags for a single advisory subagent — the contract is identical
-on any runner; only the spawn adapter (see `streams.md`) changes.
+on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes), so the subagent builds in the planned order and dodges the known traps.
 
 ```xml
 <objective>
@@ -39,6 +39,11 @@ Work step by step, following the plan:
 2. Do the work in small steps, honoring the orchestrator's plan and constraints.
 3. Self-score your result with confidence.md; if any dimension < 0.9, refine before returning.
 </persona>
+
+<strategy>
+Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
+order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+</strategy>
 
 <context_files>
 the plan / task files the piece needs (read-only unless the piece says otherwise)

--- a/.claude/skills/add/streams.md
+++ b/.claude/skills/add/streams.md
@@ -180,8 +180,10 @@ Self-Eval; if any < 0.9, refine before returning.
 </persona>
 
 <strategy>
-Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
-order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+The task's §5 plan — the Strategy (ordered batches) order and the Known-problem fixes — is
+your PREFERRED starting path, not a hard rule. Improve on it when a better strategy emerges
+as you build; on done, report the strategy you ACTUALLY used so the orchestrator can update
+§5 for the audit trail.
 </strategy>
 
 <touch_boundary>   <!-- from run.md; the worker's contract, identical on every runner -->

--- a/.claude/skills/add/streams.md
+++ b/.claude/skills/add/streams.md
@@ -179,6 +179,11 @@ Score confidence (0-1) on Completeness · Clarity · Practicality · Optimizatio
 Self-Eval; if any < 0.9, refine before returning.
 </persona>
 
+<strategy>
+Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
+order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+</strategy>
+
 <touch_boundary>   <!-- from run.md; the worker's contract, identical on every runner -->
 MAY:  rewrite code in src/ · drive tests green WITHOUT weakening them · gather verify evidence.
 MUST NOT: edit the frozen CONTRACT or locked scope · weaken/delete/skip any test ·

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 when_to_use: "Invoke in any repo with a `.add/` directory, or when the user wants spec/tests-first feature work, resumes ADD work, or asks to start/advance a task."
 category: workflows
 keywords: [add, aidd, ai-driven-development, spec-first, tdd, contract, scenarios, verify, milestone, task-orchestration]
-argument-hint: "status | init | continue | [describe new short goals or expectation]"
+argument-hint: "status | init | continue | --todo <text> | [describe new short goals or expectation]"
 license: MIT
 metadata:
   author: add
@@ -31,6 +31,10 @@ result through passing evidence rather than a plausible-looking diff.
 **One file = one task.** Each feature is one `.add/tasks/<slug>/TASK.md` — a §0 ground
 preamble plus seven step sections, filled top to bottom. The Python tool tracks where you
 are so context never rots across sessions.
+
+**The `--todo` fast-path.** When the skill ARGUMENTS begin with `--todo`, skip orienting: route to
+`add.py todo` and print its output — `--todo <text>` captures · `--todo` lists open todos ·
+`--todo --done <id>` closes (engine errors surfaced verbatim) — then STOP.
 
 ## Always start here (orient — do not skip)
 

--- a/add-method/skill/add/advisor.md
+++ b/add-method/skill/add/advisor.md
@@ -24,7 +24,7 @@ independent enough to earn it. When in doubt, do it in-context.
 
 Give the subagent the *piece of your plan it owns* and a fixed return shape. This reuses
 `streams.md`'s worker-contract tags for a single advisory subagent — the contract is identical
-on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes), so the subagent builds in the planned order and dodges the known traps.
+on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes) as the subagent's PREFERRED path — it self-improves on that plan and reports the strategy it actually used.
 
 ```xml
 <objective>
@@ -41,8 +41,10 @@ Work step by step, following the plan:
 </persona>
 
 <strategy>
-Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
-order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+The task's §5 plan — the Strategy (ordered batches) order and the Known-problem fixes — is
+your PREFERRED starting path, not a hard rule. Improve on it when a better strategy emerges
+as you build; on done, report the strategy you ACTUALLY used so the orchestrator can update
+§5 for the audit trail.
 </strategy>
 
 <context_files>

--- a/add-method/skill/add/advisor.md
+++ b/add-method/skill/add/advisor.md
@@ -24,7 +24,7 @@ independent enough to earn it. When in doubt, do it in-context.
 
 Give the subagent the *piece of your plan it owns* and a fixed return shape. This reuses
 `streams.md`'s worker-contract tags for a single advisory subagent — the contract is identical
-on any runner; only the spawn adapter (see `streams.md`) changes.
+on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes), so the subagent builds in the planned order and dodges the known traps.
 
 ```xml
 <objective>
@@ -39,6 +39,11 @@ Work step by step, following the plan:
 2. Do the work in small steps, honoring the orchestrator's plan and constraints.
 3. Self-score your result with confidence.md; if any dimension < 0.9, refine before returning.
 </persona>
+
+<strategy>
+Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
+order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+</strategy>
 
 <context_files>
 the plan / task files the piece needs (read-only unless the piece says otherwise)

--- a/add-method/skill/add/streams.md
+++ b/add-method/skill/add/streams.md
@@ -180,8 +180,10 @@ Self-Eval; if any < 0.9, refine before returning.
 </persona>
 
 <strategy>
-Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
-order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+The task's §5 plan — the Strategy (ordered batches) order and the Known-problem fixes — is
+your PREFERRED starting path, not a hard rule. Improve on it when a better strategy emerges
+as you build; on done, report the strategy you ACTUALLY used so the orchestrator can update
+§5 for the audit trail.
 </strategy>
 
 <touch_boundary>   <!-- from run.md; the worker's contract, identical on every runner -->

--- a/add-method/skill/add/streams.md
+++ b/add-method/skill/add/streams.md
@@ -179,6 +179,11 @@ Score confidence (0-1) on Completeness · Clarity · Practicality · Optimizatio
 Self-Eval; if any < 0.9, refine before returning.
 </persona>
 
+<strategy>
+Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
+order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+</strategy>
+
 <touch_boundary>   <!-- from run.md; the worker's contract, identical on every runner -->
 MAY:  rewrite code in src/ · drive tests green WITHOUT weakening them · gather verify evidence.
 MUST NOT: edit the frozen CONTRACT or locked scope · weaken/delete/skip any test ·

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 when_to_use: "Invoke in any repo with a `.add/` directory, or when the user wants spec/tests-first feature work, resumes ADD work, or asks to start/advance a task."
 category: workflows
 keywords: [add, aidd, ai-driven-development, spec-first, tdd, contract, scenarios, verify, milestone, task-orchestration]
-argument-hint: "status | init | continue | [describe new short goals or expectation]"
+argument-hint: "status | init | continue | --todo <text> | [describe new short goals or expectation]"
 license: MIT
 metadata:
   author: add
@@ -31,6 +31,10 @@ result through passing evidence rather than a plausible-looking diff.
 **One file = one task.** Each feature is one `.add/tasks/<slug>/TASK.md` — a §0 ground
 preamble plus seven step sections, filled top to bottom. The Python tool tracks where you
 are so context never rots across sessions.
+
+**The `--todo` fast-path.** When the skill ARGUMENTS begin with `--todo`, skip orienting: route to
+`add.py todo` and print its output — `--todo <text>` captures · `--todo` lists open todos ·
+`--todo --done <id>` closes (engine errors surfaced verbatim) — then STOP.
 
 ## Always start here (orient — do not skip)
 

--- a/add-method/src/add_method/_bundled/skill/add/advisor.md
+++ b/add-method/src/add_method/_bundled/skill/add/advisor.md
@@ -24,7 +24,7 @@ independent enough to earn it. When in doubt, do it in-context.
 
 Give the subagent the *piece of your plan it owns* and a fixed return shape. This reuses
 `streams.md`'s worker-contract tags for a single advisory subagent — the contract is identical
-on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes), so the subagent builds in the planned order and dodges the known traps.
+on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes) as the subagent's PREFERRED path — it self-improves on that plan and reports the strategy it actually used.
 
 ```xml
 <objective>
@@ -41,8 +41,10 @@ Work step by step, following the plan:
 </persona>
 
 <strategy>
-Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
-order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+The task's §5 plan — the Strategy (ordered batches) order and the Known-problem fixes — is
+your PREFERRED starting path, not a hard rule. Improve on it when a better strategy emerges
+as you build; on done, report the strategy you ACTUALLY used so the orchestrator can update
+§5 for the audit trail.
 </strategy>
 
 <context_files>

--- a/add-method/src/add_method/_bundled/skill/add/advisor.md
+++ b/add-method/src/add_method/_bundled/skill/add/advisor.md
@@ -24,7 +24,7 @@ independent enough to earn it. When in doubt, do it in-context.
 
 Give the subagent the *piece of your plan it owns* and a fixed return shape. This reuses
 `streams.md`'s worker-contract tags for a single advisory subagent — the contract is identical
-on any runner; only the spawn adapter (see `streams.md`) changes.
+on any runner; only the spawn adapter (see `streams.md`) changes. The `<strategy>` block mirrors the task's §5 (Strategy + Known-problem fixes), so the subagent builds in the planned order and dodges the known traps.
 
 ```xml
 <objective>
@@ -39,6 +39,11 @@ Work step by step, following the plan:
 2. Do the work in small steps, honoring the orchestrator's plan and constraints.
 3. Self-score your result with confidence.md; if any dimension < 0.9, refine before returning.
 </persona>
+
+<strategy>
+Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
+order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+</strategy>
 
 <context_files>
 the plan / task files the piece needs (read-only unless the piece says otherwise)

--- a/add-method/src/add_method/_bundled/skill/add/streams.md
+++ b/add-method/src/add_method/_bundled/skill/add/streams.md
@@ -180,8 +180,10 @@ Self-Eval; if any < 0.9, refine before returning.
 </persona>
 
 <strategy>
-Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
-order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+The task's §5 plan — the Strategy (ordered batches) order and the Known-problem fixes — is
+your PREFERRED starting path, not a hard rule. Improve on it when a better strategy emerges
+as you build; on done, report the strategy you ACTUALLY used so the orchestrator can update
+§5 for the audit trail.
 </strategy>
 
 <touch_boundary>   <!-- from run.md; the worker's contract, identical on every runner -->

--- a/add-method/src/add_method/_bundled/skill/add/streams.md
+++ b/add-method/src/add_method/_bundled/skill/add/streams.md
@@ -179,6 +179,11 @@ Score confidence (0-1) on Completeness · Clarity · Practicality · Optimizatio
 Self-Eval; if any < 0.9, refine before returning.
 </persona>
 
+<strategy>
+Follow the task's §5 plan — do not invent your own: the Strategy (ordered batches) build
+order and the Known-problem fixes (trap → fix for each anticipated failure mode).
+</strategy>
+
 <touch_boundary>   <!-- from run.md; the worker's contract, identical on every runner -->
 MAY:  rewrite code in src/ · drive tests green WITHOUT weakening them · gather verify evidence.
 MUST NOT: edit the frozen CONTRACT or locked scope · weaken/delete/skip any test ·

--- a/add-method/src/add_method/_bundled/tooling/templates/TASK.fast.md.tmpl
+++ b/add-method/src/add_method/_bundled/tooling/templates/TASK.fast.md.tmpl
@@ -55,6 +55,7 @@ Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
 ## 5 · BUILD — AI writes code
 
 Scope (may touch): `./src/`   <every file the build may write — declared before the §3 freeze>
+Strategy & known-problem fixes: <ordered build steps · the trap each known problem must dodge>
 Code lives in: `./src/`   ·   Constraints: change no test, no contract; allow-list packages only.
 
 ---

--- a/add-method/src/add_method/_bundled/tooling/templates/TASK.md.tmpl
+++ b/add-method/src/add_method/_bundled/tooling/templates/TASK.md.tmpl
@@ -108,6 +108,7 @@ Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
 
 Scope (may touch): `./src/`   <fill before the §3 freeze — every file the build may write>
 Strategy (ordered batches): <1. … 2. … — the planned build order; guidance, not enforced>
+Known-problem fixes: <trap → planned fix — the failure modes this build must dodge; guidance, not enforced>
 Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>
 Code lives in: `./src/`
 Constraints: do NOT change any test or the contract; allow-list packages only; ask if unclear.

--- a/add-method/tooling/templates/TASK.fast.md.tmpl
+++ b/add-method/tooling/templates/TASK.fast.md.tmpl
@@ -55,6 +55,7 @@ Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
 ## 5 · BUILD — AI writes code
 
 Scope (may touch): `./src/`   <every file the build may write — declared before the §3 freeze>
+Strategy & known-problem fixes: <ordered build steps · the trap each known problem must dodge>
 Code lives in: `./src/`   ·   Constraints: change no test, no contract; allow-list packages only.
 
 ---

--- a/add-method/tooling/templates/TASK.md.tmpl
+++ b/add-method/tooling/templates/TASK.md.tmpl
@@ -108,6 +108,7 @@ Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
 
 Scope (may touch): `./src/`   <fill before the §3 freeze — every file the build may write>
 Strategy (ordered batches): <1. … 2. … — the planned build order; guidance, not enforced>
+Known-problem fixes: <trap → planned fix — the failure modes this build must dodge; guidance, not enforced>
 Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>
 Code lives in: `./src/`
 Constraints: do NOT change any test or the contract; allow-list packages only; ask if unclear.

--- a/add-method/tooling/test_advisor_strategy.py
+++ b/add-method/tooling/test_advisor_strategy.py
@@ -95,6 +95,18 @@ class TestAdvisorStrategy(unittest.TestCase):
         self.assertEqual(_xmlconv.ENGINE_FILES["advisor.md"]["tags"], {"constraints"},
                          "advisor.md must register tags={'constraints'}")
 
+    def test_strategy_block_fenced_and_points_at_section5(self) -> None:
+        # build-strategy-solutions ADD-3: the fenced template gains a <strategy> element that
+        # mirrors the task's §5 (Strategy + Known-problem fixes). It must stay INSIDE the fence
+        # (present raw, gone after fence-strip) so the outside-fence vocab stays {constraints}.
+        self.assertIn("strategy", _xmlconv._paired_tags(self.text),
+                      "fenced plan-following template missing the <strategy> element")
+        self.assertNotIn("strategy", _xmlconv._paired_tags(self.stripped),
+                         "<strategy> leaked OUTSIDE the code fence — must stay fenced/exempt")
+        block = re.search(r"<strategy>(.*?)</strategy>", self.text, re.DOTALL)
+        self.assertIsNotNone(block, "no <strategy>…</strategy> block")
+        self.assertIn("§5", block.group(1), "the <strategy> block must point at the task's §5")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/add-method/tooling/test_advisor_strategy.py
+++ b/add-method/tooling/test_advisor_strategy.py
@@ -107,6 +107,24 @@ class TestAdvisorStrategy(unittest.TestCase):
         self.assertIsNotNone(block, "no <strategy>…</strategy> block")
         self.assertIn("§5", block.group(1), "the <strategy> block must point at the task's §5")
 
+    def test_strategy_block_is_preferred_not_hard(self) -> None:
+        # strategy-soft-not-hard: §5 is the builder's PREFERRED plan it self-improves on and
+        # reports for audit — NOT a hard "do not invent your own" directive.
+        block = re.search(r"\n<strategy>\n(.*?)\n</strategy>", self.text, re.DOTALL)
+        self.assertIsNotNone(block, "no line-anchored <strategy> block")
+        body = block.group(1)
+        self.assertIn("not a hard rule", body, "block must frame §5 as preferred, not a hard rule")
+        self.assertIn("Improve on it", body, "block must invite the builder to self-improve the plan")
+        self.assertIn("report the strategy", body, "block must ask the builder to report the strategy used")
+        self.assertIn("audit", body, "the report must feed the §5 audit trail")
+        self.assertNotIn("do not invent your own", self.text,
+                         "the rigid 'do not invent your own' phrasing must be gone")
+        # the advisor intro clause is softened to match (no rigid 'builds in the planned order')
+        self.assertNotIn("builds in the planned order", self.text,
+                         "advisor intro clause is still rigid")
+        self.assertIn("self-improves on that plan", self.text,
+                      "advisor intro must describe the preferred/self-improve framing")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/add-method/tooling/test_scope_decl_template.py
+++ b/add-method/tooling/test_scope_decl_template.py
@@ -34,6 +34,11 @@ CANON_TMPL = HERE / "templates" / "TASK.md.tmpl"
 DOG_TMPL = REPO / ".add" / "tooling" / "templates" / "TASK.md.tmpl"
 BUNDLE_TMPL = BUNDLE / "tooling" / "templates" / "TASK.md.tmpl"
 
+# fast-lane template trio (build-strategy-solutions ADD-2)
+CANON_FAST = HERE / "templates" / "TASK.fast.md.tmpl"
+DOG_FAST = REPO / ".add" / "tooling" / "templates" / "TASK.fast.md.tmpl"
+BUNDLE_FAST = BUNDLE / "tooling" / "templates" / "TASK.fast.md.tmpl"
+
 CANON_BUILD = ADD_METHOD / "skill" / "add" / "phases" / "5-build.md"
 DOG_BUILD = REPO / ".claude" / "skills" / "add" / "phases" / "5-build.md"
 BUNDLE_BUILD = BUNDLE / "skill" / "add" / "phases" / "5-build.md"
@@ -47,6 +52,9 @@ ADDPY_TRIO = (HERE / "add.py", REPO / ".add" / "tooling" / "add.py",
 
 SCOPE_LABEL = "Scope (may touch):"
 STRATEGY_LABEL = "Strategy (ordered batches):"
+KNOWN_FIX_LABEL = "Known-problem fixes:"             # ADD-1 (full §5)
+FAST_STRATEGY_LABEL = "Strategy & known-problem fixes:"  # ADD-2 (fast §5)
+SAFETY_LINE = "Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>"
 SECTION_HEADING = "## Declaring the scope of impact"
 # the three pre-existing §5 lines that MUST stay byte-identical (additive change)
 EXISTING_LINES = (
@@ -149,6 +157,51 @@ class ScopeDeclTemplateTest(unittest.TestCase):
                                      CANON_TMPL.read_text(encoding="utf-8"))))
         self.assertEqual(tags, FROZEN_TAGS,
                          "template tag census changed - the v16 vocab is frozen")
+
+    # ---- build-strategy-solutions ADD-1: full §5 gains a Known-problem fixes line --
+    def test_full_template_known_problem_fixes_line(self):
+        text = CANON_TMPL.read_text(encoding="utf-8")
+        self.assertIn(KNOWN_FIX_LABEL, text, "full §5 missing the Known-problem fixes line")
+        # additive placement: Strategy < Known-problem fixes < Safety rule
+        self.assertLess(text.index(STRATEGY_LABEL), text.index(KNOWN_FIX_LABEL),
+                        "Known-problem fixes must sit BELOW Strategy")
+        self.assertLess(text.index(KNOWN_FIX_LABEL),
+                        text.index("Safety rule (feature-specific):"),
+                        "Known-problem fixes must sit ABOVE the Safety rule line")
+        for line in EXISTING_LINES:
+            self.assertIn(line, text, "pre-existing §5 line changed - the add is additive")
+
+    # ---- ADD-2: fast §5 gains a single strategy & known-problem fixes line --------
+    def test_fast_template_strategy_line(self):
+        text = CANON_FAST.read_text(encoding="utf-8")
+        self.assertIn(FAST_STRATEGY_LABEL, text, "fast §5 missing the strategy line")
+        self.assertLess(text.index(SCOPE_LABEL), text.index(FAST_STRATEGY_LABEL),
+                        "the fast strategy line must sit BELOW Scope")
+
+    def test_fast_template_mirrors(self):
+        self.assertEqual(_md5(CANON_FAST), _md5(DOG_FAST), "fast template: dogfood diverged")
+        self.assertEqual(_md5(CANON_FAST), _md5(BUNDLE_FAST), "fast template: bundle diverged")
+
+    # ---- ADD-1/2: a fresh scaffold carries the new lines (full + fast) ------------
+    def test_scaffold_carries_strategy_solutions(self):
+        cwd = Path.cwd()
+        tmp = Path(tempfile.mkdtemp(prefix="add-strat-sol-")).resolve()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        self.addCleanup(os.chdir, os.getcwd())
+        try:
+            os.chdir(tmp)
+            buf, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(buf), redirect_stderr(err):
+                add.main(["init", "--name", "demo"])
+                add.main(["lock", "--force"])
+                add.main(["new-task", "fullx", "--title", "fullx"])
+                add.main(["new-task", "fastx", "--title", "fastx", "--fast"])
+            full = (tmp / ".add" / "tasks" / "fullx" / "TASK.md").read_text(encoding="utf-8")
+            fast = (tmp / ".add" / "tasks" / "fastx" / "TASK.md").read_text(encoding="utf-8")
+            self.assertIn(KNOWN_FIX_LABEL, full, "full scaffold missing Known-problem fixes")
+            self.assertIn(FAST_STRATEGY_LABEL, fast, "fast scaffold missing the strategy line")
+        finally:
+            os.chdir(cwd)
 
 
 if __name__ == "__main__":

--- a/add-method/tooling/test_skill_lean.py
+++ b/add-method/tooling/test_skill_lean.py
@@ -54,7 +54,11 @@ POOLS = [
     # `new-milestone --queued`, promote with `activate`) — +1064 B human-approved surface (milestone
     # multi-milestone-intake 2/3, contract FROZEN @ v1). RATIO 0.88 kept EXACTLY; baseline grows by
     # surface ÷ ratio (+⌈1064/0.88⌉=1210). The won compaction on SKILL.md + intake.md is untouched.
-    {"name": "core",          "ratio": 0.88, "baseline": 19675,
+    # core 19675 → 20004 @ skill-todo-flag (same method): SKILL.md gains a front-of-skill `--todo`
+    # fast-path block (route `/add --todo` to `add.py todo`: capture/list/close, then STOP) + the
+    # argument-hint names --todo — +289 B human-approved surface (loose fast-lane task, contract FROZEN
+    # @ v1). RATIO 0.88 kept EXACTLY; baseline grows by surface ÷ ratio (+⌈289/0.88⌉=329). Won ground untouched.
+    {"name": "core",          "ratio": 0.88, "baseline": 20004,
      "guides": ["SKILL.md", "intake.md"]},
     # orchestration 50098 → 51732 @ design-intake-beat (same "rebaseline for human-approved new surface"
     # method): design.md's UDD loop gains a NEW front beat `### 0 · design-intake` (the four design axes

--- a/add-method/tooling/test_skill_lean.py
+++ b/add-method/tooling/test_skill_lean.py
@@ -78,7 +78,12 @@ POOLS = [
     # ```xml fence gains the SAME fenced <strategy> block (mirrors the task's §5), so the parallel-spawn
     # home matches the single advisor — +200 B human-approved surface (loose task, contract FROZEN @ v1).
     # RATIO 0.75 kept EXACTLY; baseline grows by surface ÷ ratio (+⌈200/0.75⌉=267). The won compaction is untouched.
-    {"name": "orchestration", "ratio": 0.75, "baseline": 52731,
+    # orchestration 52731 → 53125 @ strategy-soft-not-hard (change-request, §3 FROZEN @ v1): the <strategy>
+    # block is SOFTENED (preferred-not-hard + self-improve + report-the-strategy-used-for-audit) in BOTH
+    # advisor.md and streams.md, and advisor's intro clause softened to match — +295 B human-approved surface
+    # (block 198→327 ×2 files = +258, advisor intro 151→188 = +37). RATIO 0.75 kept EXACTLY; baseline grows
+    # by surface ÷ ratio (+⌈295/0.75⌉=394). The won compaction is untouched.
+    {"name": "orchestration", "ratio": 0.75, "baseline": 53125,
      "guides": ["run.md", "streams.md", "advisor.md", "loop.md", "design.md"]},
     # phases 39008 → 39446 @ security-escalation-disclosure (same method): phases/6-verify.md's Security
     # residue bullet gains the disclosure that `unescalated_security_note` sees only a MARKED note — a

--- a/add-method/tooling/test_skill_lean.py
+++ b/add-method/tooling/test_skill_lean.py
@@ -70,7 +70,15 @@ POOLS = [
     # AI SURFACES; one it misses is invisible to the engine → human spot-audit is the only backstop"
     # disclosure — +196 B human-approved surface (milestone flow-honesty, contract FROZEN @ v1). RATIO
     # 0.75 kept EXACTLY; baseline grows by surface ÷ ratio (+⌈196/0.75⌉=262). The won compaction is untouched.
-    {"name": "orchestration", "ratio": 0.75, "baseline": 51994,
+    # orchestration 51994 → 52464 @ build-strategy-solutions (same method): advisor.md's fenced plan-following
+    # template gains a <strategy> block (mirrors the task's §5 Strategy + Known-problem fixes) + a prose clause —
+    # +352 B human-approved surface (loose task, contract FROZEN @ v1). RATIO 0.75 kept EXACTLY; baseline grows
+    # by surface ÷ ratio (+⌈352/0.75⌉=470). The won compaction is untouched.
+    # orchestration 52464 → 52731 @ streams-strategy-pull (same method): streams.md's worker-contract
+    # ```xml fence gains the SAME fenced <strategy> block (mirrors the task's §5), so the parallel-spawn
+    # home matches the single advisor — +200 B human-approved surface (loose task, contract FROZEN @ v1).
+    # RATIO 0.75 kept EXACTLY; baseline grows by surface ÷ ratio (+⌈200/0.75⌉=267). The won compaction is untouched.
+    {"name": "orchestration", "ratio": 0.75, "baseline": 52731,
      "guides": ["run.md", "streams.md", "advisor.md", "loop.md", "design.md"]},
     # phases 39008 → 39446 @ security-escalation-disclosure (same method): phases/6-verify.md's Security
     # residue bullet gains the disclosure that `unescalated_security_note` sees only a MARKED note — a

--- a/add-method/tooling/test_skill_todo_flag.py
+++ b/add-method/tooling/test_skill_todo_flag.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Guard: SKILL.md documents the `--todo` fast-path (task: skill-todo-flag).
+
+The `/add --todo` flag is an INSTRUCTION to the orchestrator (the AI), not engine code — so the
+only thing the engine can test is that the instruction is WRITTEN and complete. This is a
+presence/format fence, not a behavioural one: it proves the doc names the full mirror of the
+engine's `cmd_todo` (capture · list · close) and that `argument-hint` advertises the flag. It
+CANNOT prove the orchestrator obeys at runtime (the honest blind spot disclosed in §1 Assumptions,
+same class as the security-escalation disclosure).
+
+Anchored on the disclosure-unique marker `` `--todo` fast-path `` (not a bare common word, which a
+keyword-only assert would vacuously satisfy — lesson from security-escalation-disclosure). Reads the
+CANONICAL tree only; 3-tree parity is guarded by test_tree_parity + test_bundle_parity.
+
+Run: python3 -m unittest test_skill_todo_flag -v
+"""
+import re
+import unittest
+from pathlib import Path
+
+_CANON = Path(__file__).resolve().parent.parent / "skill" / "add"
+_SKILL = _CANON / "SKILL.md"
+
+
+class SkillTodoFlagTest(unittest.TestCase):
+    def setUp(self):
+        self.skill = _SKILL.read_text()
+
+    def test_fastpath_block_present(self):
+        """The fast-path is documented under a disclosure-unique marker."""
+        self.assertIn(
+            "`--todo` fast-path", self.skill,
+            "SKILL.md must document the `--todo` fast-path block (orchestrator routes to the engine).",
+        )
+
+    def test_full_mirror_three_subforms(self):
+        """All three sub-forms of cmd_todo are named: capture · list · close."""
+        for token, what in [
+            ("--todo <text>", "capture form"),
+            ("lists open todos", "list form (bare --todo)"),
+            ("--todo --done <id>", "close form"),
+        ]:
+            self.assertIn(token, self.skill, f"--todo fast-path is missing the {what} ('{token}').")
+
+    def test_routes_to_engine(self):
+        """The fast-path routes to the engine command, it does not reimplement it."""
+        self.assertIn(
+            "add.py todo", self.skill,
+            "the --todo fast-path must route to `add.py todo …` (cmd_todo), not swallow it.",
+        )
+
+    def test_argument_hint_advertises_todo(self):
+        """The frontmatter argument-hint names --todo so the flag is discoverable."""
+        m = re.search(r"^argument-hint:.*$", self.skill, re.MULTILINE)
+        self.assertIsNotNone(m, "argument-hint frontmatter line is missing.")
+        self.assertIn("--todo", m.group(0), "argument-hint must name --todo (discoverable cue).")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/add-method/tooling/test_streams.py
+++ b/add-method/tooling/test_streams.py
@@ -239,6 +239,30 @@ class WorkerStrategyPullTest(unittest.TestCase):
         self.assertNotIn("<strategy>", stripped,
                          "<strategy> leaked OUTSIDE the worker-contract code fence")
 
+    def test_strategy_block_is_preferred_not_hard(self):
+        # strategy-soft-not-hard: §5 is the worker's PREFERRED plan it self-improves on and
+        # reports for audit — NOT a hard "do not invent your own" directive.
+        block = re.search(r"\n<strategy>\n(.*?)\n</strategy>", self.text, re.DOTALL)
+        self.assertIsNotNone(block, "no line-anchored <strategy> block")
+        body = block.group(1)
+        self.assertIn("not a hard rule", body, "block must frame §5 as preferred, not a hard rule")
+        self.assertIn("Improve on it", body, "block must invite the worker to self-improve the plan")
+        self.assertIn("report the strategy", body, "block must ask the worker to report the strategy used")
+        self.assertIn("audit", body, "the report must feed the §5 audit trail")
+        self.assertNotIn("do not invent your own", self.text,
+                         "the rigid 'do not invent your own' phrasing must be gone")
+
+    def test_block_byte_identical_to_advisor(self):
+        # the two spawn homes must carry the SAME <strategy> block (no drift -> block_drift)
+        adv = (SKILL / "advisor.md").read_text(encoding="utf-8")
+        pat = r"\n<strategy>\n.*?\n</strategy>"
+        s_block = re.search(pat, self.text, re.DOTALL)
+        a_block = re.search(pat, adv, re.DOTALL)
+        self.assertIsNotNone(s_block, "streams.md <strategy> block not found")
+        self.assertIsNotNone(a_block, "advisor.md <strategy> block not found")
+        self.assertEqual(s_block.group(0), a_block.group(0),
+                         "advisor.md and streams.md <strategy> blocks have drifted")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/add-method/tooling/test_streams.py
+++ b/add-method/tooling/test_streams.py
@@ -23,6 +23,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import tempfile
 import shutil
 import unittest
@@ -33,6 +34,8 @@ import add
 _TOOLING = Path(__file__).resolve().parent
 _ADD_METHOD = _TOOLING.parent
 SKILL = _ADD_METHOD / "skill" / "add"
+
+_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 
 
 def _run(argv):
@@ -213,6 +216,28 @@ class WaveProtocolRuntimeTest(unittest.TestCase):
                          f"all 3 streams.md copies must exist: {[str(p) for p in _STREAMS_TREES]}")
         hashes = {hashlib.md5(p.read_bytes()).hexdigest() for p in present}
         self.assertEqual(len(hashes), 1, f"streams.md mirror_drift across the 3 copies: {hashes}")
+
+
+class WorkerStrategyPullTest(unittest.TestCase):
+    """streams-strategy-pull: streams.md's worker-contract fence carries a <strategy> block that
+    points the worker at the task's §5 (mirroring advisor.md). It must stay INSIDE the fence."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = (SKILL / "streams.md").read_text(encoding="utf-8")
+
+    def test_strategy_block_present_and_names_section5(self):
+        block = re.search(r"<strategy>(.*?)</strategy>", self.text, re.DOTALL)
+        self.assertIsNotNone(block, "streams.md worker contract missing the <strategy> block")
+        self.assertIn("§5", block.group(1), "the <strategy> block must point at the task's §5")
+        # placed inside the worker contract: between </persona> and <touch_boundary>
+        self.assertLess(self.text.index("</persona>"), self.text.index("<strategy>"))
+        self.assertLess(self.text.index("</strategy>"), self.text.index("<touch_boundary>"))
+
+    def test_strategy_stays_fenced(self):
+        stripped = _FENCE_RE.sub("", self.text)
+        self.assertNotIn("<strategy>", stripped,
+                         "<strategy> leaked OUTSIDE the worker-contract code fence")
 
 
 if __name__ == "__main__":

--- a/add-method/tooling/test_xml_convention.py
+++ b/add-method/tooling/test_xml_convention.py
@@ -188,7 +188,7 @@ class TestXmlConventionPhaseGuides(unittest.TestCase):
 # is ENUMERATED so the over-tagging guard is real, not hollow.
 ENGINE_SUBSET = {"constraints", "reject_codes"}  # STRICT — excludes output_format on purpose
 WORKER_CONTRACT_TAGS = {
-    "objective", "persona", "touch_boundary", "context_files", "expertise", "tools", "return",
+    "objective", "persona", "strategy", "touch_boundary", "context_files", "expertise", "tools", "return",
 }
 ENGINE_FILES = {
     "confidence.md": {


### PR DESCRIPTION
## Why

A trace of **319 real subagent spawns** in the ai-proxy project showed every spawn pulled its implementation strategy from the global CLAUDE.md **Rule-5** template — never from the task's own **§5**. ADD documents `advisor.md` / `streams.md` as the spawn templates, but neither referenced §5, so each spawn re-invented strategy. This closes that doc-vs-reality gap: §5 becomes the single source of truth for strategy + known-problem solutions, and both spawn homes point at it.

## What (two loose tasks, full ADD lane, §3 FROZEN @ v1 each)

**`build-strategy-solutions`**
- `TASK.md.tmpl` §5 → new plain-text `Known-problem fixes:` line (additive; the 3 pre-existing §5 lines stay byte-identical)
- `TASK.fast.md.tmpl` §5 → new condensed `Strategy & known-problem fixes:` line (the fast lane had none)
- `advisor.md` fenced plan-following template → new `<strategy>` block pointing the subagent at §5

**`streams-strategy-pull`** (resolves the build-strategy-solutions spec-delta)
- `streams.md` worker-contract fence → the same `<strategy>` block, so the parallel-spawn home matches the single advisor
- `WORKER_CONTRACT_TAGS` gains `"strategy"`

## Invariants held

- **Engine untouched** — no `add.py` / `add_engine` changes; ENGINE_MD5 / ENGINE_PKG_MD5 unchanged (prose/template + skill only)
- **3-tree byte parity** — canonical · `_bundled` · dogfood identical for every edited file
- **Additive** — no pre-existing §5 line or worker tag removed; `FROZEN_TAGS` census intact
- **Lean fence** — orchestration pool rebaselined `51994 → 52464 → 52731` (ratio 0.75 kept, won ground preserved)

## Tests

Extended `test_scope_decl_template`, `test_advisor_strategy`, `test_streams`, `test_xml_convention` (red → green); `test_skill_lean` rebaselined. **Suite 2109/0 · check 461/0.**

https://claude.ai/code/session_01SPZ4ZNrW727KPKzn94vYgT
