### PR TITLE
chore(deps): bump the 4 GitHub Pages actions (combines #68–#71)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
     name: Build site (mkdocs --strict)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build the site (strict)
         run: mkdocs build --strict
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 


### PR DESCRIPTION
## Bump the 4 GitHub Pages actions (combines #68 · #69 · #70 · #71)

The four dependabot PRs all edit the same file (`.github/workflows/pages.yml`) and were based on a stale `main`. Combined here as their four original commits (dependabot authorship preserved), cherry-picked onto current `main` — one validation, no rebase churn.

| action | from → to | was PR |
|--------|-----------|--------|
| actions/checkout | v5 → v7 | #70 |
| actions/configure-pages | v5 → v6 | #68 |
| actions/upload-pages-artifact | v3 → v5 | #69 |
| actions/deploy-pages | v4 → v5 | #71 |

Each bumped a distinct `uses:` line (no inter-conflict). Each passed its own CI as an individual PR. Closes #68, #69, #70, #71.

https://claude.ai/code/session_01SPZ4ZNrW727KPKzn94vYgT
