### PR TITLE
chore(release): 1.13.0 — adr-at-observe + flow-honesty + Trusted Publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.13.0 — 2026-06-28
+
+- Decision/ADR record harvested at OBSERVE — 1 carried · 0 key decision(s)
+- flow-honesty — make ADD's stated guarantees engine-true or honestly labeled — 15 carried · 0 key decision(s)
+
 ## 1.12.0 — 2026-06-26
 
 - UDD design intake — 0 carried · 0 key decision(s)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 1.13.0 — 2026-06-28
+milestones: adr-at-observe, flow-honesty
+loose tasks: skill-todo-flag, build-strategy-solutions, streams-strategy-pull, strategy-soft-not-hard
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: 2 milestones (adr-at-observe + flow-honesty) + 4 loose tasks since 1.12.0 + npm Trusted Publishing (OIDC) migration; suite 2173/0; ENGINE_MD5 9d73e5abb8f0536c9192234efc7ba053
+
 ## 1.12.0 — 2026-06-26
 milestones: udd-design-intake, multi-milestone-intake, multi-active-polish
 loose tasks: milestone-naming, queued-await-confirm-hint, freeze-actor-stamp, flow-jit-tasks-doc

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -6,6 +6,56 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 
 ## [Unreleased]
 
+## [1.13.0] — 2026-06-28
+
+Two method milestones make ADD's loop more **self-auditing** and more **honest**:
+the observe step now harvests a decision record automatically, and every flow gate
+is either mechanically enforced or plainly disclosed where it is not. Plus the npm
+release pipeline moves to tokenless **Trusted Publishing**. Backward-compatible
+throughout; nothing retro-changes an existing task or milestone record.
+
+### Added (adr-at-observe — a decision record, harvested not hand-written)
+- **`### Decisions (ADR)` harvested at the gate.** On `add.py gate PASS`, the engine
+  harvests a §7 Architecture-Decision-Record block from §1/§3/§5/§6 — one
+  actor-tagged line per decision (`[AI] specify · [human] freeze · [AI] build ·
+  [human] verify`), refilled only while the placeholder stands (never hand-edited).
+- **`add.py audit` checks the ADR at done.** A done task whose §7 ADR block is unfilled
+  is surfaced — presence-only, never a semantic judgment of the decisions themselves.
+- **Strategy write-back.** The §6 GATE RECORD is stamped with the git actor + date, and
+  the §5 "Strategy actually used" line is harvested into the ADR as the `[AI] build` row.
+
+### Added (flow-honesty — every gate engine-true or honestly disclosed)
+- **Two structural holes became real, forceable gates.** A **universal freeze gate**
+  (`contract_not_frozen` fires for every task at tests→build, with a recorded
+  `--skip-freeze` escape) and a **delta-drain release floor**
+  (`release_build_in_flight`, `--force`-able but loud) — the two places the method
+  promised enforcement and now delivers it.
+- **Four honor-system edges became plain disclosures + measure-not-block lints.**
+  `add.py audit` now surfaces `shallow_deep_check`, `risk_unset`, and
+  `refute_unrecorded` (presence-only, never blocking); the guides + book state plainly
+  that a *missed* security finding is invisible to the engine (a human spot-audit is
+  the only backstop under `auto`); reject-code names read honestly
+  (`release_tests_red`→`release_build_in_flight`).
+- **The earned-green refute-read is now a recorded verdict.** Under `auto`, the §6
+  `### Refute-read verdict` block records `EARNED | NOT-EARNED`; the engine measures it
+  is filled but never spawns the read — the resolver still does the judging.
+- **Stale guidance synced to the shipped engine.** The 5-build "scope gate deferred"
+  note is gone (the scope gate enforces today); the auto-PASS precondition list is now
+  identical across `run.md`, `6-verify.md`, and the book.
+
+### Added (loose tasks)
+- **`/add --todo` flag** (`skill-todo-flag`) — capture/list/close backlog todos.
+- **§5 Strategy fed into spawns** (`build-strategy-solutions` · `streams-strategy-pull`)
+  — the planned build order + known-problem fixes flow into subagent prompts.
+- **`<strategy>` softened** (`strategy-soft-not-hard`) — §5 is the *preferred* plan; the
+  builder may self-improve during build and reports the strategy actually used for audit.
+
+### Changed (release infrastructure)
+- **npm Trusted Publishing (OIDC).** `publish.yml` drops the stored npm token (no more
+  ~90-day rotation), publishes via OIDC (`id-token: write`, Node 24 + npm ≥ 11.5.1),
+  and generates provenance automatically (`--provenance` no longer needed). A guard test
+  locks the tokenless shape. PyPI already used OIDC.
+
 ## [1.12.0] — 2026-06-26
 
 Multi-milestone polish release — the intake/roadmap front grows a real **queue**,

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.12.0"
+version = "1.13.0"
 description = "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — install the ADD skill, tooling, and AIDD book into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.12.0"
+__version__ = "1.13.0"

--- a/add-method/tooling/test_release_1_13_0.py
+++ b/add-method/tooling/test_release_1_13_0.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.12.0 release readiness (milestone-naming feature).
+"""Red/green tests for the 1.13.0 release readiness.
 
-Bundles one loose task: `milestone-naming` — new-milestone nudges bare-version
-slugs toward descriptive names + stamps MILESTONE.md `created:` with the full ISO
-timestamp. Backward-compatible (advisory; never blocks).
+Bundles two milestones — adr-at-observe (engine harvests a §7 Decisions/ADR record
+at the gate, audited at done) + flow-honesty (every flow gate engine-true or honestly
+disclosed) — plus 4 loose tasks (skill-todo-flag, build-strategy-solutions,
+streams-strategy-pull, strategy-soft-not-hard) and the npm Trusted Publishing (OIDC)
+release-pipeline migration. Backward-compatible throughout.
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.12.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.13.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_12_0 -v
+    python3 -m unittest test_release_1_13_0 -v
 """
 import hashlib
 import json
@@ -25,17 +27,19 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.12.0"
-PRIOR_VERSIONS = ("1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.3", "1.7.2", "1.7.1",
-                  "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")
+VERSION = "1.13.0"
+PRIOR_VERSIONS = ("1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.3", "1.7.2",
+                  "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0",
+                  "1.1.0", "1.0.0")
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline the release notes must name (the milestone-naming bundle)
-FEATURE_ANCHORS = ("new-milestone", "descriptive", "created:")
+# the headline features the 1.13.0 notes must name (adr-at-observe + flow-honesty +
+# the Trusted Publishing migration)
+FEATURE_ANCHORS = ("ADR", "flow-honesty", "Trusted Publishing")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_12_0_entry(self):
+    def test_changelog_has_1_13_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -44,7 +48,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.12.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.13.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -83,10 +87,25 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    # NOTE: the version-equality asserts (package.json / pyproject / plugin / __version__
-    # all == "1.12.0") migrated FORWARD to test_release_1_13_0.py when the version bumped
-    # off 1.12.0 — the live version is pinned by exactly one release test at a time. The
-    # 1.12.0 changelog-lineage + workflow-hygiene + ship-channel guards below stay valid.
+    def test_versions_agree_at_1_13_0(self):
+        pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
+        py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
+                       (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
+        self.assertEqual((pkg, py), (VERSION, VERSION),
+                         "publish.yml's guard would fail this release closed")
+
+    def test_plugin_version_agrees(self):
+        plugin = json.loads(
+            (PKG / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+        self.assertEqual(plugin, VERSION,
+                         "the Claude Code plugin manifest must match the shipped version")
+
+    def test_runtime_version_agrees(self):
+        init = (PKG / "src" / "add_method" / "__init__.py").read_text(encoding="utf-8")
+        runtime = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', init).group(1)
+        self.assertEqual(runtime, VERSION,
+                         "add_method.__version__ must match the shipped version")
 
     def test_getting_started_mentions_guide_line(self):
         text = (PKG / "GETTING-STARTED.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Release 1.13.0

Bundles everything on `main` since 1.12.0: **2 milestones + 4 loose tasks + the npm Trusted Publishing migration.**

### Contents
- **adr-at-observe** — the observe step harvests a `### Decisions (ADR)` record at the gate (actor-tagged, from §1/§3/§5/§6), audited at done; §6 GATE RECORD + §5 strategy write-back.
- **flow-honesty** — every flow gate is now engine-true or honestly disclosed: two structural holes → forceable gates (universal freeze, delta-drain floor), four honor-system edges → disclosures + measure-not-block lints (`shallow_deep_check` · `risk_unset` · `refute_unrecorded`), the earned-green refute-read is a recorded verdict, stale guidance synced to the shipped engine.
- **4 loose tasks** — `skill-todo-flag`, `build-strategy-solutions`, `streams-strategy-pull`, `strategy-soft-not-hard`.
- **npm Trusted Publishing (OIDC)** — tokenless publish, the first release to use it.

### The cut
- 5 version sources bumped 1.12.0 → **1.13.0** (package.json, pyproject.toml, `__init__.py`, plugin.json, package-lock ×2).
- Rich `## [1.13.0]` entry hand-authored in `add-method/CHANGELOG.md`; `add.py release` recorded the `RELEASES.md` ledger row + root CHANGELOG.
- Forward-pin gate migrated: new `test_release_1_13_0.py` carries the version-equality asserts; `test_release_1_12_0.py` keeps its historical guards.

### Evidence
- Suite **2181/0** · check **445/0** · audit **exit 0** · **0 open SPEC deltas** · ENGINE_MD5 `9d73e5ab`.
- npm tarball acceptance: full `add_engine/` package + `add.py` + CHANGELOG/SECURITY ship (103 files).

### ⚠️ First publish on Trusted Publishing
Merging this PR does **not** publish — the **tag push** (`v1.13.0`) triggers `publish.yml`. This is the first release to authenticate npm via **OIDC trusted publishing** (no token). The trusted-publisher registration on npmjs.com must be in place (done). PyPI already uses OIDC. If the npm OIDC mint doesn't engage, the npm job fails closed (recoverable — diagnose + re-tag); PyPI publishes independently.
