### PR TITLE
Release 1.14.0 — component-polish + installer-polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.14.0 — 2026-06-29
+
+- component-polish — close the component-pillar gaps and harden the cross-repo edges — 14 carried · 0 key decision(s)
+- installer-polish — round out the global-home and installer lane — 7 carried · 0 key decision(s)
+
 ## 1.13.0 — 2026-06-28
 
 - Decision/ADR record harvested at OBSERVE — 1 carried · 0 key decision(s)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 1.14.0 — 2026-06-29
+milestones: component-polish, installer-polish
+loose tasks: none
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: 2 milestones (component-polish + installer-polish); suite 2279/0; engine pins unchanged (installer/validator only); PR #114 merged a8bad226; independent pre-merge review MERGE-SAFE
+
 ## 1.13.0 — 2026-06-28
 milestones: adr-at-observe, flow-honesty
 loose tasks: skill-todo-flag, build-strategy-solutions, streams-strategy-pull, strategy-soft-not-hard

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -6,6 +6,46 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 
 ## [Unreleased]
 
+## [1.14.0] — 2026-06-29
+
+Two milestones round out lanes that shipped partially in earlier releases: the
+**global-home / installer** lane gets its missing inverse + safety, and the
+**component** pillar closes its remaining gaps and hardens its cross-repo edges.
+Installer- and engine-pin-neutral — the ADD engine is byte-identical (ENGINE_MD5
+unchanged); all changes live in the installer twins and the component validator.
+Backward-compatible throughout.
+
+### Added (installer-polish — complete the global lane)
+- **Restore the global home.** `init --from-global-data` (and an `init` that detects a
+  matching `<home>/data/<key>`) rehydrates a project's user-data from the global home on
+  a fresh clone — the non-destructive inverse of the one-way backup. Fill-gaps by default;
+  `--force` writes a `<name>.bak` sidecar before overwriting.
+- **`prune-data` orphan cleanup.** A new `prune-data` command removes home snapshots with
+  no live registry owner — dry-run by default, `--force` to delete. Both installer twins
+  (pip + npm) carry the behavior, byte-for-byte.
+- **`update --global` made safe.** An O_EXCL home lock (`<home>/.update.lock`) serializes
+  concurrent runs **cross-twin** (a pip-held lock blocks an npm run and vice-versa), and
+  every registered path is validated before any write — a relative/traversal entry aborts
+  the whole run loud (`unsafe_registry_path`), a directory without `.add/` is dropped.
+- **Reconcile roll-up.** Every reconcile now reports a file-level `N restored · M refreshed`
+  summary, so a partially-gutted-but-present managed tree's heal is finally visible (it
+  healed silently before). Pure observation — copy semantics are unchanged.
+
+### Added (component-polish — close the pillar gaps + harden the edges)
+- **`add.py components` reader + validator.** A `components.toml` schema-lint surfaces
+  `component_unknown_key` / `component_type_mismatch` / `component_unknown_table` — all
+  measure-not-block warnings at `check`.
+- **Federation hardening.** `federate pull` path-confines the manifest `source` to a
+  sibling-repo allowlist with a fail-closed HARD-STOP (`federation_source_escapes`) before
+  any read; a stale leftover contract snapshot that no longer admits a consumer is surfaced
+  (`producer_contract_stale`, never red).
+- **Registry fill + a worked example.** The component registry round-trips completely, and
+  a full worked example threads the component flow end-to-end in the book.
+
+### Changed
+- Five version sources bump in lockstep to **1.14.0** (`package.json`, `package-lock.json`
+  ×2, `pyproject.toml`, `.claude-plugin/plugin.json`, `add_method.__version__`).
+
 ## [1.13.0] — 2026-06-28
 
 Two method milestones make ADD's loop more **self-auditing** and more **honest**:

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.13.0"
+version = "1.14.0"
 description = "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — install the ADD skill, tooling, and AIDD book into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.13.0"
+__version__ = "1.14.0"

--- a/add-method/tooling/test_release_1_14_0.py
+++ b/add-method/tooling/test_release_1_14_0.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.13.0 release readiness.
+"""Red/green tests for the 1.14.0 release readiness.
 
-Bundles two milestones — adr-at-observe (engine harvests a §7 Decisions/ADR record
-at the gate, audited at done) + flow-honesty (every flow gate engine-true or honestly
-disclosed) — plus 4 loose tasks (skill-todo-flag, build-strategy-solutions,
-streams-strategy-pull, strategy-soft-not-hard) and the npm Trusted Publishing (OIDC)
-release-pipeline migration. Backward-compatible throughout.
+Bundles two milestones — component-polish (close the component-pillar gaps:
+validator, federation-harden, freeze-recency, registry-fill, worked example) +
+installer-polish (round out the global-home/installer lane: --from-global-data
+restore + prune-data, update --global cross-twin lock + path-safety, and the
+reconcile "N restored · M refreshed" roll-up). Installer/engine-pin-neutral —
+ENGINE_MD5 unchanged. Backward-compatible throughout.
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.13.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.14.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_13_0 -v
+    python3 -m unittest test_release_1_14_0 -v
 """
 import hashlib
 import json
@@ -27,19 +28,19 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.13.0"
-PRIOR_VERSIONS = ("1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.3", "1.7.2",
-                  "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0",
-                  "1.1.0", "1.0.0")
+VERSION = "1.14.0"
+PRIOR_VERSIONS = ("1.13.0", "1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.3",
+                  "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0",
+                  "1.2.0", "1.1.0", "1.0.0")
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline features the 1.13.0 notes must name (adr-at-observe + flow-honesty +
-# the Trusted Publishing migration)
-FEATURE_ANCHORS = ("ADR", "flow-honesty", "Trusted Publishing")
+# the headline features the 1.14.0 notes must name (installer-polish global lane +
+# component-polish pillar gaps)
+FEATURE_ANCHORS = ("prune-data", "reconcile", "component")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_13_0_entry(self):
+    def test_changelog_has_1_14_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -48,7 +49,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.13.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.14.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -87,10 +88,25 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    # NOTE: the version-equality asserts (package.json / pyproject / plugin / __version__
-    # all == "1.13.0") migrated FORWARD to test_release_1_14_0.py when the version bumped
-    # off 1.13.0 — the live version is pinned by exactly one release test at a time. The
-    # 1.13.0 changelog-lineage + workflow-hygiene + ship-channel guards below stay valid.
+    def test_versions_agree_at_1_14_0(self):
+        pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
+        py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
+                       (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
+        self.assertEqual((pkg, py), (VERSION, VERSION),
+                         "publish.yml's guard would fail this release closed")
+
+    def test_plugin_version_agrees(self):
+        plugin = json.loads(
+            (PKG / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+        self.assertEqual(plugin, VERSION,
+                         "the Claude Code plugin manifest must match the shipped version")
+
+    def test_runtime_version_agrees(self):
+        init = (PKG / "src" / "add_method" / "__init__.py").read_text(encoding="utf-8")
+        runtime = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', init).group(1)
+        self.assertEqual(runtime, VERSION,
+                         "add_method.__version__ must match the shipped version")
 
     def test_getting_started_mentions_guide_line(self):
         text = (PKG / "GETTING-STARTED.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Release 1.14.0 — component-polish + installer-polish

Cuts **1.14.0**, bundling the two milestones closed since 1.13.0. The ADD engine
is byte-identical (ENGINE_MD5 unchanged) — all changes are installer/validator + ledger.

### Bundled milestones
- **installer-polish** (PR #114, merge `a8bad226`) — complete the global-home/installer lane: `init --from-global-data` restore + `prune-data`, `update --global` cross-twin O_EXCL lock + registry path-safety, file-level reconcile `N restored · M refreshed` roll-up.
- **component-polish** (PR #113) — close the component-pillar gaps + harden cross-repo edges: `add.py components` validator, federation source path-confinement, freeze-recency, registry fill, worked example.

### Release mechanics
- 5 version sources (6 occurrences) bumped in lockstep to 1.14.0.
- Rich `## [1.14.0]` entry hand-authored in `add-method/CHANGELOG.md`; engine wrote the terse root CHANGELOG + the RELEASES.md ledger row (both milestones attributed).
- Forward-pin migrated: 3 version-equality asserts stripped from `test_release_1_13_0.py` → new `test_release_1_14_0.py`.

### Verification
- Full suite **2287/0** · `add.py check` **445/0** · `audit` clean · `release-report`: **0 blockers, 0 waivers**.
- Engine-parity asserts pass (engine trees byte-identical + pinned).

After merge: tag `v1.14.0` triggers `publish.yml` → npm + PyPI via Trusted Publishing (tokenless OIDC), then cut the GitHub release.

https://claude.ai/code/session_01Fe1WvmJkLTVcthNbQPUUtS
