### PR TITLE
chore(release): cut 1.16.0 — install-update-hardening

### DIFF
--- a/.add/milestones/install-update-hardening/MILESTONE.md
+++ b/.add/milestones/install-update-hardening/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: add.py init/update (both --global and project-scope, pip+npm twins) survive a crash or a concurrent run without leaving a half-written .add/ tree or a wedged lock
 rationale: <why this scope — the confirmed intake classification (bucket + reason)>
 stage: mvp · status: active · created: 2026-07-02T14:46:06+00:00
-release: pending
+release: 1.16.0
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
 > exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.16.0 — 2026-07-03
+
+- Install/update hardening — atomic + concurrency-safe writes — 16 carried · 0 key decision(s)
+
 ## 1.15.0 — 2026-07-03
 
 - Seams — 3 carried · 0 key decision(s)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 1.16.0 — 2026-07-03
+milestones: install-update-hardening
+loose tasks: none
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: 1 milestone (install-update-hardening — 4/4 tasks gate=PASS, 1167+ combined adversarial concurrency attempts / 0 anomalies, independent verify + advisor 3-lens on every task, human-reviewed for the risk:high task); PR #129 merged 2eeb008 (66 commits); CI 9/9 green; check 513/0 (65 warn, routine); zero HARD-STOP / RISK-ACCEPTED across 116 tasks
+
 ## 1.15.0 — 2026-07-03
 milestones: seams, context-search, drift-guard, artifact-graph, ground-trust, traceability-ids, persona-teacher-bundle, persona-learning-loop, advisor-gated-autonomy, portable-roster, loop-readability
 loose tasks: scope-exclude-claude, mirror-resync, untrack-add-tooling, installer-gitignore-mirrors, ci-tooling-mirror-gap, phase-agents-lean, gitignore-vendor-path-fix, update-global-gitignore-seed, nested-suite-skip-count-tolerance, report-plan-approve, status-pagination, skill-tree-compaction-audit, add-advisor

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [1.16.0] — 2026-07-03
+
+Closes the **install-update-hardening** milestone: `add.py init`/`update` (both
+`--global` and project-scope, pip + npm twins) now survive a crash or a
+concurrent run without leaving a half-written `.add/` tree or a wedged lock.
+Backward-compatible; nothing removed or renamed on the CLI surface.
+
+### Added (a lock where none existed)
+- **Project-scope install/update lock.** Two concurrent `install`/`update` runs
+  against the same project-scope destination can no longer interleave writes —
+  one waits or fails cleanly (`install_in_progress`). Independent of the
+  existing global lock — separate file, separate default threshold, no shared
+  code — but the same identity-verified reclaim discipline (below).
+- **`--lock-timeout <seconds>`, opt-in** (`init` and `update`, both twins).
+  Unset keeps today's behavior — fail immediately if the lock is held; set it
+  to poll instead, so CI can wait out a held lock. The staleness threshold
+  itself (when a held lock counts as abandoned, not merely held) stays an
+  env-var (`ADD_LOCK_STALE_SECONDS`), not a routine flag.
+
+### Fixed (crash-safety, both twins)
+- **Managed-tree reconcile** (`_clean_replace` / `cleanReplaceTree`) and the
+  **user-data persist/restore path** (`_persist_data` / `_restore_data`) both
+  move to a stage-then-commit idiom — self-heal a leftover scratch sibling,
+  stage into a fresh uniquely-named one, commit via same-parent rename, sweep
+  the old backup. A killed process mid-copy or mid-write no longer leaves a
+  half-written tree; the next run heals it automatically.
+- **Global and project-scope lock reclaim, made identity-verified.** A stale
+  lock used to be reclaimed by unlinking it by *path* — an independent verify
+  pass found this let two racers both believe they held it at once. Reclaim
+  now re-stats the lock immediately before unlinking and proceeds only on an
+  inode match; a per-generation ticket file gates entry to the reclaim itself,
+  so a losing racer never touches the real lock file at all. Confirmed
+  against 1167+ combined adversarial concurrent attempts, 0 anomalies, across
+  both locks.
+
+### Known limitation
+- The reclaim fix's identity check compares inode numbers — sound only if the
+  filesystem never reuses one inside the brief re-stat-to-unlink window.
+  Confirmed on macOS/APFS this cycle; Linux/Windows were not independently
+  re-verified. Disclosed, not blocking — flagged for the next verify pass.
+
+### Changed
+- Five version sources bump in lockstep to **1.16.0** (`package.json`,
+  `package-lock.json` ×2, `pyproject.toml`, `.claude-plugin/plugin.json`,
+  `add_method.__version__`).
+
 ## [1.15.0] — 2026-07-02
 
 Ten milestones — the largest bundle yet — round out ADD's self-knowledge

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — a minimal, state-tracked Claude Code skill that ships the AIDD book as its trust layer.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "1.15.0"
+version = "1.16.0"
 description = "ADD (AI-Driven Development). One skill. Eight steps. Five disciplines. Every feature ships through the loop — install the ADD skill, tooling, and AIDD book into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "1.15.0"
+__version__ = "1.16.0"

--- a/add-method/tooling/test_release_1_16_0.py
+++ b/add-method/tooling/test_release_1_16_0.py
@@ -1,23 +1,21 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 1.15.0 release readiness.
+"""Red/green tests for the 1.16.0 release readiness.
 
-Bundles ten milestones — seams (SEAMS.md shared-contract doc) + context-search
-(keyword-searchable milestone/task index) + drift-guard (symbol-cited §0,
-ground_sha) + artifact-graph (task<->milestone<->release backlinks) +
-ground-trust (GROUND surfaces issues/risks + related-intent links) +
-traceability-ids (M#/R# rule IDs + scenario/test coverage lint) +
-persona-teacher-bundle (vendored agency-agents teacher corpus) +
-persona-learning-loop (project-fit persona learn/apply loop) +
-advisor-gated-autonomy (persisted advisor-guarded auto+parallel run mode) +
-portable-roster (non-Claude tools get the phase-roster via AGENTS.md) — plus
-13 loose tasks. All additive; nothing removed or renamed on the CLI surface.
-ENGINE_MD5/ENGINE_PKG_MD5 both moved this cycle (53 tasks touched code) —
+Bundles one milestone — install-update-hardening (add.py init/update, both
+--global and project-scope, pip+npm twins, survive a crash or a concurrent run
+without leaving a half-written .add/ tree or a wedged lock): a new project-scope
+install/update lock + opt-in --lock-timeout, plus crash-safe stage-then-commit
+for the managed-tree reconcile copy and the user-data persist/restore path, plus
+a TOCTOU race + ticket-leak livelock fix in the existing global lock. No loose
+tasks attributed this cut. Installer-only — the ADD engine (add.py) is
+byte-identical (ENGINE_MD5 unchanged) since this milestone's own ship-by-domain
+review named tooling (_installer.py + cli.js) as the only surface touched;
 parity across the 3 mirror trees is what this suite pins, not a fixed hash.
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 1.15.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 1.16.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
 Run:
-    python3 -m unittest test_release_1_15_0 -v
+    python3 -m unittest test_release_1_16_0 -v
 """
 import hashlib
 import json
@@ -34,19 +32,19 @@ CHANGELOG = PKG / "CHANGELOG.md"
 CI_YML = REPO / ".github" / "workflows" / "ci.yml"
 PUBLISH_YML = REPO / ".github" / "workflows" / "publish.yml"
 
-VERSION = "1.15.0"
-PRIOR_VERSIONS = ("1.14.0", "1.13.0", "1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0",
+VERSION = "1.16.0"
+PRIOR_VERSIONS = ("1.15.0", "1.14.0", "1.13.0", "1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0",
                   "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0",
                   "1.2.0", "1.1.0", "1.0.0")
 from engine_pin import ENGINE_MD5
 CANONICAL_AUDIT = "run: python3 .add/tooling/add.py audit"
-# the headline milestones the 1.15.0 notes must name (add-method/CHANGELOG.md is the
-# hand-authored Keep-a-Changelog; slugs appear verbatim in each "### Added (<slug> — ...)")
-FEATURE_ANCHORS = ("traceability-ids", "persona-learning-loop", "portable-roster")
+# the headline milestone the 1.16.0 notes must name (add-method/CHANGELOG.md is the
+# hand-authored Keep-a-Changelog; the slug appears verbatim in the entry's intro)
+FEATURE_ANCHORS = ("install-update-hardening",)
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_1_15_0_entry(self):
+    def test_changelog_has_1_16_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -55,7 +53,7 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"1.15.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"1.16.0 entry must name: {anchor}")
 
     def test_changelog_ships_in_both_channels(self):
         files = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["files"]
@@ -94,10 +92,25 @@ class WorkflowHygieneTest(unittest.TestCase):
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    # NOTE: the version-equality asserts (package.json / pyproject / plugin / __version__
-    # all == "1.15.0") migrated FORWARD to test_release_1_16_0.py when the version bumped
-    # off 1.15.0 — the live version is pinned by exactly one release test at a time. The
-    # 1.15.0 changelog-lineage + workflow-hygiene + ship-channel guards below stay valid.
+    def test_versions_agree_at_1_16_0(self):
+        pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
+        py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
+                       (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
+        self.assertEqual((pkg, py), (VERSION, VERSION),
+                         "publish.yml's guard would fail this release closed")
+
+    def test_plugin_version_agrees(self):
+        plugin = json.loads(
+            (PKG / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+        self.assertEqual(plugin, VERSION,
+                         "the Claude Code plugin manifest must match the shipped version")
+
+    def test_runtime_version_agrees(self):
+        init = (PKG / "src" / "add_method" / "__init__.py").read_text(encoding="utf-8")
+        runtime = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"', init).group(1)
+        self.assertEqual(runtime, VERSION,
+                         "add_method.__version__ must match the shipped version")
 
     def test_getting_started_mentions_guide_line(self):
         text = (PKG / "GETTING-STARTED.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Cuts 1.16.0, attributing the `install-update-hardening` milestone (4/4 tasks gate=PASS): `add.py init`/`update` (both `--global` and project-scope, pip+npm twins) now survive a crash or a concurrent run without leaving a half-written `.add/` tree or a wedged lock.
- Adds a new project-scope install/update lock (didn't exist before) + opt-in `--lock-timeout`; fixes crash-safety (stage-then-commit) for the managed-tree reconcile + user-data persist/restore paths; makes stale-lock reclaim identity-verified (inode-checked + per-generation ticket-gated) after an independent verify pass found the prior unlink-by-path reclaim let two racers both believe they held the lock.
- Bumps 5 version sources in lockstep; migrates `test_release_1_15_0.py`'s live version-agreement asserts forward into new `test_release_1_16_0.py`, per this repo's established one-file-pins-the-live-version convention.
- Root `CHANGELOG.md`/`RELEASES.md` engine-recorded via `add.py release 1.16.0`; `add-method/CHANGELOG.md` (npm/PyPI-facing) hand-authored and cross-checked against the milestone's own commit messages (not just the milestone doc roll-up) — this caught a factual error in the first draft (`--lock-timeout` was mis-described) and added an honest "Known limitation" disclosure (inode-identity reclaim validated on macOS/APFS only this cycle).
- Version: **1.16.0 (MINOR)**, not a patch — this milestone adds real new capability (the project-scope lock, `--lock-timeout`), not just fixes, per this repo's own semver rule (breaking→MAJOR, feature→MINOR, fix-only→PATCH).

## Test plan
- [x] `test_release_1_16_0.py` — 11/11 green
- [x] `test_release_1_15_0.py` (migrated forward) + `test_release_1_16_0.py` together — 19/19 green
- [x] `test_packaging.py` — 8/8 green
- [x] Full tooling suite (`npm test` equivalent) — green (exit 0) before commit
- [x] `add.py check` — 513 passed, 0 failed (65 routine warnings)
- [x] 0 open HARD-STOP, 0 open RISK-ACCEPTED waivers project-wide
- [ ] Human: confirm before tag + publish (npm/PyPI) — not done yet, separate checkpoint