### PR TITLE
chore(method): six-phase-loop close (accepted-partial re-measure) + call-residuals draft

### DIFF
--- a/.add/milestones/call-residuals/MILESTONE.md
+++ b/.add/milestones/call-residuals/MILESTONE.md
@@ -1,0 +1,34 @@
+# MILESTONE: Call Residuals
+
+goal: Close the measured WM1 call-count gap (20.7 -> <=12) by killing the four message-layer residuals the six-phase re-measure anatomized: double init · post-freeze re-cross repairs · status re-reads · the --help habit — zero enforcement-path changes
+rationale: sub-milestone — human decision 2026-07-14 'Close + draft follow-on milestone' at six-phase-loop close; the re-measure proved the calls bar is reachable (~11-12) through ergonomics, not phase surgery (benchmark/results/2026-07-sixphase-remeasure.md)
+stage: mvp · status: active · created: 2026-07-14T04:33:38+00:00
+release: pending
+relations: <cross-MILESTONE edges — add header lines `depends-on:` / `extends:` / `relates-to:` with milestone slugs (comma-sep); omit if none. Non-blocking except depends-on; validated by `add.py check`>
+
+> SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
+> exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,
+> written just-in-time. Update this doc whenever a task reveals a milestone gap.
+
+## Ground (current assets this builds on)
+- six-phase-loop MERGED (PRs #146/#149/#148): 6-phase lifecycle, compound ticks, bundle-disclosed guides, build-entry spec echo; WM1 re-measure sixphase-r{1,2,3}: fid 0.98x3 / 0 regr / $3.17 mean / calls 20.7 UNMET vs <=12.
+- Waste anatomy per rep (the four levers, ~8-10 calls): double init+lock (r1: init x2 lock x2, r3: init x2) - re-cross scope repairs (r2 x3, r3 x1) - status re-reads (3-4/rep) - exactly one --help/rep.
+- Precedent: skip-error-ergonomics proved message-layer-only tasks cut -24% turns/-34% cost with zero enforcement changes.
+
+## Scope
+IN: init idempotence messaging (existing project -> loud resume pointer, no re-init) - scope first-draft quality at freeze (kill the post-freeze re-cross class) - status/orientation diet (resume without re-reads) - --help habit kill (quick-ref in the error/skill surface).
+OUT: any gate/freeze/tamper/scope ENFORCEMENT change - phase-list changes - roster changes - benchmark harness changes.
+
+## Tasks (breadth-first)
+- [ ] init-idempotent-nudge   depends-on: none — `init` on an already-initialized project prints the resume pointer (status/active task) and exits 0 WITHOUT re-seeding; status opens with "project exists — do NOT init" when state.json is present (kills double-init, the +2-4 calls/rep lever)
+- [ ] scope-first-draft       depends-on: none — the freeze-time scope echo escalates from propose-to-stdout to a ready-to-paste §5 Scope line whenever declared tokens fail to cover §3 Touches (still propose-not-impose; target: post-freeze re-cross repairs -> 0)
+- [ ] status-orientation-diet depends-on: none — one status read carries the full resume context (phase - next verb - active file), so re-orientation re-reads stop; audit the 3-4x/rep re-read transcripts for what was missing
+- [ ] help-habit-kill         depends-on: none — the one --help/rep: unknown/misused subcommand errors restate usage inline (the skip-error-ergonomics recipe), and the skill quick-ref covers the verbs agents actually reach for
+
+## Exit criteria (observable)
+- [ ] init on an existing project is a no-op with a loud resume pointer — test-pinned
+- [ ] scope echo emits a paste-ready Scope line on non-covering declarations — test-pinned
+- [ ] a single status read carries phase + next verb + resume file — test-pinned
+- [ ] misuse errors restate usage inline; no doc says "run --help" — test-pinned
+- [ ] floors untouched: full fence green, no enforcement-path diff, ENGINE_MD5 re-pinned
+- [ ] (paid, human-gated) WM1 re-measure: calls <= 12 mean, fidelity >= 0.97 held, zero double-init and zero post-freeze re-cross in transcripts

--- a/.add/milestones/six-phase-loop/MILESTONE.md
+++ b/.add/milestones/six-phase-loop/MILESTONE.md
@@ -50,7 +50,7 @@ OUT: gate SEMANTICS (one recorded outcome, security HARD-STOP, tamper/scope guar
 - [x] each of the 3 bundle agents carries per-phase persona preset lines   (<- persona-presets)   (verify: test_persona_presets.py — preset census, routing-first survives, never-lowers-a-gate)
 - [x] the build-entry echo renders Must/Reject + contract summary; bare non-build ticks byte-identical — test-pinned   (<- build-entry-spec-echo)   (verify: test_build_entry_spec_echo.py 9 tests; self-proved live on the task's own re-cross)
 - [x] floors untouched: full fence green, ENGINE_MD5 re-pinned, 3-tree parity, gate semantics byte-identical   (verify: fence 3554/3554 OK; ENGINE_MD5 bf89b033 @ build-entry-spec-echo; twin-parity tests green; zero tests weakened across 6 tasks)
-- [ ] (paid, human-gated) WM1 re-measure after merge: fidelity >= 0.97 held, calls <= 12
+- [x] (paid, human-gated) WM1 re-measure after merge: fidelity >= 0.97 held, calls <= 12   (verify: benchmark/results/2026-07-sixphase-remeasure.md — fidelity MET 0.98x3/0 regr/oracle 1.0; calls UNMET 20.7 mean, HUMAN-ACCEPTED-PARTIAL at close 2026-07-14 by Tin Dang — residuals are message-layer (double-init - re-cross - status re-reads - help), moved to the follow-on milestone)
 
 ## Risks
 - The expectations-first migration class: phase-index vs §-section off-by-one (named trap in every merge task) · ~3500 fixtures pin phase sequences — merges are the two biggest test-ripple tasks this repo has attempted since flow-reorder · gate tamper tripwire fires if migration touches frozen §3s (recover via re-cross --by, precedent recorded).

--- a/.add/milestones/six-phase-loop/RETRO.md
+++ b/.add/milestones/six-phase-loop/RETRO.md
@@ -1,0 +1,40 @@
+════════════════════════════════════════════════════════════════════════
+ six-phase-loop · Six-phase loop with bundle-owned subagents
+════════════════════════════════════════════════════════════════════════
+ VERDICT   DONE
+ TASKS     6/6 done           CRITERIA  8/8 met
+ GATES     6 PASS             WAIVERS   none
+
+ goal  Merge specify+scenarios and verify+observe (8->6 phases),
+       disclose phase guides into the lean roster's bundle agents so the
+       orchestrator loads only SKILL.md, add per-phase persona presets +
+       a build-entry spec echo
+ closed by Tin Dang <tindang.ht97@gmail.com>
+
+ TASK                        PHASE     GATE TESTS PROGRESS
+ ───────────────────────────────────────────────────────────────────────
+ phase-merge-specify         done      PASS 8†    ●●●●●●
+ phase-merge-verify          done      PASS 13†   ●●●●●●
+ guide-recut                 done      PASS 8†    ●●●●●●
+ bundle-disclosure           done      PASS 6†    ●●●●●●
+ persona-presets             done      PASS 4†    ●●●●●●
+ build-entry-spec-echo       done      PASS 9†    ●●●●●●
+ legend  ● reached  ◉ current  ○ pending   spec→…→done
+ † counted at the §4-declared path
+
+ GATED BY
+   phase-merge-specify      PASS Tin Dang <tindang.ht97@gmail.com>
+   phase-merge-verify       PASS Tin Dang <tindang.ht97@gmail.com>
+   guide-recut              PASS Tin Dang <tindang.ht97@gmail.com>
+   bundle-disclosure        PASS Tin Dang <tindang.ht97@gmail.com>
+   persona-presets          PASS Tin Dang <tindang.ht97@gmail.com>
+   build-entry-spec-echo    PASS Tin Dang <tindang.ht97@gmail.com>
+
+ EXIT CRITERIA  ●●●●●●●●●● 8/8 met
+
+ LEARNINGS      none
+
+ SPEC DELTAS    27 open deltas — resolve: new-task --from-delta / drop-delta
+
+ DECIDE NEXT  consolidate learnings + archive-milestone six-phase-loop
+════════════════════════════════════════════════════════════════════════

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "build-entry-spec-echo",
+  "active_task": null,
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -9329,7 +9329,7 @@
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-07-13T19:25:16+00:00",
+  "updated": "2026-07-14T04:33:38+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -9723,9 +9723,9 @@
       "title": "Six-phase loop with bundle-owned subagents",
       "goal": "Merge specify+scenarios and verify+observe (8->6 phases), disclose phase guides into the lean roster's bundle agents so the orchestrator loads only SKILL.md, add per-phase persona presets + a build-entry spec echo",
       "stage": "mvp",
-      "status": "active",
+      "status": "done",
       "created": "2026-07-13T17:03:37+00:00",
-      "updated": "2026-07-13T17:10:12+00:00",
+      "updated": "2026-07-14T04:33:21+00:00",
       "confirmed": true,
       "confirmed_at": "2026-07-13T17:10:12+00:00",
       "confirmed_by": "tindang",
@@ -9734,10 +9734,27 @@
         "name": "Tin Dang",
         "email": "tindang.ht97@gmail.com",
         "source": "git"
+      },
+      "done_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
       }
+    },
+    "call-residuals": {
+      "title": "Call Residuals",
+      "goal": "",
+      "stage": "mvp",
+      "status": "active",
+      "created": "2026-07-14T04:33:38+00:00",
+      "updated": "2026-07-14T04:33:38+00:00",
+      "confirmed": false,
+      "confirmed_at": null,
+      "confirmed_by": null,
+      "await_confirm": true
     }
   },
-  "active_milestone": "six-phase-loop",
+  "active_milestone": "call-residuals",
   "archived": [
     {
       "slug": "v5",
@@ -10576,7 +10593,8 @@
     "plan-legibility",
     "ceremony-to-effort",
     "call-floor",
-    "six-phase-loop"
+    "six-phase-loop",
+    "call-residuals"
   ],
   "active_tasks": {
     "flow-simplification": "phase-review",

--- a/benchmark/results/2026-07-sixphase-remeasure.md
+++ b/benchmark/results/2026-07-sixphase-remeasure.md
@@ -1,0 +1,47 @@
+# six-phase-loop WM1 re-measure — 2026-07-14
+
+3 reps · `add` arm · pinned meter (`claude-sonnet-5 --effort medium`) · engine =
+six-phase-loop merged into main (`8360b06` resolved pin; PRs #146/#149/#148),
+installed editable by the arm's own setup. Archived: `benchmark/runs/sixphase-r{1,2,3}`.
+Method: same transcript anatomy as the ceremony re-measure (assistant-message turns;
+`add.py <subcommand>` invocations in Bash tool_use).
+
+## Per rep
+
+| rep | turns | add.py calls | --help | cost | fidelity | regressions |
+|-----|------:|-------------:|-------:|------:|---------:|------------:|
+| r1  | 119   | 19           | 1      | $3.05 | 0.98     | 0 |
+| r2  | 138   | 22           | 1      | $3.02 | 0.98     | 0 |
+| r3  | 137   | 21           | 1      | $3.44 | 0.98     | 0 |
+| **mean** | **131** | **20.7** | **1.0** | **$3.17** | **0.98** | **0** |
+
+Prior round (ceremony, same meter): 134 turns · 18.7 calls · $3.51 · fid 0.98 · 0 regr.
+
+## Verdict vs the milestone exit bar
+
+- fidelity ≥ 0.97 held → **MET** (0.98 ×3, oracle pass 1.0, zero regressions)
+- calls ≤ 12 → **UNMET** (mean 20.7; ceremony was 18.7 — flat within rep noise)
+- cost −10% vs ceremony ($3.17 vs $3.51) — the cheapest honest ADD round measured
+- turns −2% (131 vs 134)
+
+## Anatomy — why the phase merge didn't move the call count
+
+The merge did what it claims mechanically: crossings are 5-6 `advance`s (was 7-8
+pre-merge), one freeze, one gate. But the call budget is dominated by residuals
+ORTHOGONAL to phase count, the same four levers the ceremony report named:
+
+1. **double init** — r1 and r3 ran `init` twice (+`lock` ×2 in r1) although the
+   arm's setup already initialized; status still doesn't say "do NOT init".
+2. **re-cross repairs** — r2 ×3, r3 ×1: scope declarations repaired post-freeze.
+   (The scope echo surfaces the resolution; a mis-drafted line still costs a
+   re-cross round-trip.)
+3. **status re-reads** — 3-4/rep, orientation re-anchoring.
+4. **--help habit** — exactly 1/rep, stubborn.
+
+Sum of those ≈ 8-10 calls/rep — removing them alone would land ~11-12, i.e. the
+bar is reachable but through the message/ergonomics layer, not more phase surgery.
+
+## Decision
+
+Recorded at milestone close (six-phase-loop): fidelity criterion MET; calls
+criterion UNMET on this meter — disposition per the human's close decision.


### PR DESCRIPTION
Records the human close decision for six-phase-loop: WM1 re-measure fidelity MET (0.98 ×3, 0 regr), calls UNMET (20.7 vs ≤12) HUMAN-ACCEPTED-PARTIAL — anatomy + full record in `benchmark/results/2026-07-sixphase-remeasure.md`. Milestone → done (RETRO.md). Drafts the follow-on **call-residuals** milestone (await-confirm) with the four message-layer levers targeting the ~11-12 call landing. Bookkeeping only — no engine, guide, or test changes.