### PR TITLE
chore(release): expand unpublished 1.18.0 — 11 milestones + installer fix attributed

### DIFF
--- a/.add/milestones/add-bench-v2/MILESTONE.md
+++ b/.add/milestones/add-bench-v2/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: measure ADD's actual value proposition — regression safety, gaming resistance, resumability, direction-mining, security floors, traceability — on the pinned meter, deterministically scored, and report cost-per-TRUSTED-feature alongside v1's raw cost; if a competing flow also holds the floors, report that honestly
 rationale: sub-milestone — v1 (add-bench) only measured simple-greenfield WM1 cost, spec-kit's optimal case (~3.3× cheaper, confirmed fair, `benchmark/results/2026-07-sonnet-campaign.md`); none of the trust dimensions ADD's ceremony pays for have ever been run on the fixed meter, and the v1 LLM fidelity judge is proven untrustworthy. Design confirmed by human 2026-07-10 (`benchmark/v2/DESIGN.md`, commit 26b2084).
 stage: mvp · status: active · created: 2026-07-10T02:03:19+00:00
-release: pending
+release: 1.18.0
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
 > exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,

--- a/.add/milestones/add-bench/MILESTONE.md
+++ b/.add/milestones/add-bench/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: a reproducible, automated benchmark under `benchmark/` proving (or falsifying) ADD's long-term-project claim — five method arms (ADD · vanilla Claude Code · plan-mode-first · GSD · GitHub spec-kit) each build the same longitudinal greenfield workload (task/booking REST API + CLI, 3 sequential milestones) headlessly, and the harness auto-scores regression rate, spec fidelity, tokens/cost, context-rot slope, and time-to-first-edit into one arm-vs-arm pilot report
 rationale: new-major — an automated benchmark harness is a new product theme no active milestone's goal covers (all prior milestones ship the method/engine/book; only archived book chapters *reference* GSD/spec-kit). Confirmed at intake 2026-07-07.
 stage: mvp · status: active · created: 2026-07-07T09:14:41+00:00
-release: pending
+release: 1.18.0
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
 > exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,

--- a/.add/milestones/expectations-first/MILESTONE.md
+++ b/.add/milestones/expectations-first/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: Reorder the task flow to expectations-first — specify/scenarios become light projections of a milestone-level Ground (gathered once) + the request; grounding, the frozen contract, and build strategy unify into one 'plan' phase carrying the single human freeze. Fewer stops, no re-grounding per task, grounding floor preserved.
 rationale: sub-milestone (method redesign of the core lifecycle). Origin: human analysis 2026-07-12 — the current `ground → specify` order is inverted (grounding serves the HOW, not the WHAT; the WHAT flows down from the milestone). Replaces the abandoned `plan-phase-merge` branch, which only merged ground→specify and mis-modelled where grounding belongs.
 stage: mvp · status: active · created: 2026-07-12T08:16:14+00:00
-release: pending
+release: 1.18.0
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
 > exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`.

--- a/.add/milestones/plan-legibility/MILESTONE.md
+++ b/.add/milestones/plan-legibility/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: Make the plan and its relationships legible to the human: the freeze report surfaces the full §3 build-strategy plan-of-action (approve HOW, not just WHAT), and every task carries a structured, synced Relations surface (depends-on · extends · relates-to) at task and milestone altitude, with a validate/sync guard.
 rationale: sub-milestone (human-confirmed 2026-07-13) — a legibility follow-on to expectations-first: the plan phase now unifies ground+contract+build-strategy, but the AI's build plan-of-action is NOT surfaced at the one freeze (the human approves WHAT, not HOW), and task relations are scattered (milestone `depends-on`, §3 Related-intent, SEAMS pointers) with no sync. Sequenced BEFORE expectations-first's T4 (book-align), per the human.
 stage: mvp · status: active · created: 2026-07-13T05:13:25+00:00
-release: pending
+release: 1.18.0
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
 > exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,

--- a/.add/milestones/quality-floors/MILESTONE.md
+++ b/.add/milestones/quality-floors/MILESTONE.md
@@ -2,7 +2,7 @@
 
 goal: convert the WV1 wm2 miss (own tests spoke a friendlier input dialect than the spec's own examples → aware/naive datetime crash shipped green) into narrow, ~zero-turn floors — the lean lane keeps its −27–33% cost while the failure CLASS is closed; quality is bought with mechanical floors, never with re-added ceremony
 stage: mvp · status: active · created: 2026-07-10T17:12:27+00:00 · lane: tiny
-release: pending
+release: 1.18.0
 
 > Tiny plan — small scope, one approval. Keep it to a handful of lines; if it
 > outgrows this shape, recreate without --tiny (the full SDD scaffold).

--- a/.add/milestones/risk-proportional-ceremony/MILESTONE.md
+++ b/.add/milestones/risk-proportional-ceremony/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: cut ADD's big-milestone cost premium (1.8x dollars / 2x wall-clock vs spec-kit) toward ~1.3x by scaling ceremony to task risk — never by lowering the trust floor (frozen contract, red suite, recorded gate hold in every lane)
 rationale: sub-milestone (user-signaled after the add-bench WM4-6 verdict): the benchmark proved the premium is turn fragmentation + suite-run churn + done-phase ceremony on big milestones — not the spec phases (~3%) — and that ceremony pays only where risk lives; scale it to risk.
 stage: mvp · status: active · created: 2026-07-08T08:28:21+00:00
-release: pending
+release: 1.18.0
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
 > exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,

--- a/.add/milestones/six-phase-loop/MILESTONE.md
+++ b/.add/milestones/six-phase-loop/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: Merge specify+scenarios and verify+observe (8->6 phases), disclose phase guides into the lean roster's bundle agents so the orchestrator loads only SKILL.md, add per-phase persona presets + a build-entry spec echo
 rationale: sub-milestone — the user's compress-steps + expert-subagent-per-step request, interview-confirmed 2026-07-14 (TRUE 8->6 merge · disclosure into bundle agents · presets · spec echo)
 stage: mvp · status: active · created: 2026-07-13T17:03:37+00:00
-release: pending
+release: 1.18.0
 relations: <cross-MILESTONE edges — add header lines `depends-on:` / `extends:` / `relates-to:` with milestone slugs (comma-sep); omit if none. Non-blocking except depends-on; validated by `add.py check`>
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and

--- a/.add/milestones/three-phase-flow/MILESTONE.md
+++ b/.add/milestones/three-phase-flow/MILESTONE.md
@@ -3,7 +3,7 @@
 goal: let the AI drive a clear, small/medium, or benchmark task through ADD's 8 phases as 3 agent-owned bundles — auto-verifying the DIRECTION gate and skipping only the optional ceremony (scenarios · observe) — while the frozen-contract · red-suite · recorded-gate · security-HARD-STOP floor holds in every mode
 rationale: sub-milestone of the lean / risk-proportional-ceremony line (user-signaled 2026-07-09). EXTENDS `fast-lane` (the existing collapse-never-skip minimal lane — make it faster by skipping the non-important steps for oneshot/small/medium tasks) and `advisor-gated-autonomy` (which only lets `mechanical` sensitivity be advisor-gated — this raises the AI gate to the DIRECTION/contract boundary with a security/data/architecture→human floor). OVERLAPS `flag-first-freeze` (the freeze + autonomy dial). The benchmark measured the big-milestone premium as turn-fragmentation + done-phase ceremony, not the spec phases; this cuts the human-wait and optional ceremony where risk is low, never the floor.
 stage: mvp · status: active · created: 2026-07-08T17:51:23+00:00
-release: pending
+release: 1.18.0
 
 > SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
 > exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Changelog
 
-## 1.18.0 — 2026-07-07
+## 1.18.0 — 2026-07-14
 
-- Drain the 4 open SPEC deltas — 0 carried · 0 key decision(s)
 - Faceted §5 build strategy — 0 carried · 0 key decision(s)
+- Drain the 4 open SPEC deltas — 0 carried · 0 key decision(s)
+- Add Bench — 8 carried · 0 key decision(s)
+- Add Lean Loop — 0 carried · 0 key decision(s)
+- Expectations-first flow: plan phase — 0 carried · 0 key decision(s)
+- Plan legibility — surface the build plan at the freeze + structured task relations — 0 carried · 0 key decision(s)
+- Six-phase loop with bundle-owned subagents — 0 carried · 0 key decision(s)
+- Add Bench V2 — 10 carried · 0 key decision(s)
+- Three Phase Flow — 1 carried · 0 key decision(s)
+- Risk Proportional Ceremony — 2 carried · 0 key decision(s)
+- Quality floors for lean ADD — 0 carried · 0 key decision(s)
 
 ## 1.17.0 — 2026-07-06
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,11 +1,11 @@
 # Releases
 
-## 1.18.0 — 2026-07-07
-milestones: delta-drain, build-strategy-facets
-loose tasks: none
+## 1.18.0 — 2026-07-14
+milestones: build-strategy-facets, delta-drain, add-bench, add-lean-loop, expectations-first, plan-legibility, six-phase-loop, add-bench-v2, three-phase-flow, risk-proportional-ceremony, quality-floors
+loose tasks: prune-benchmark-deadweight
 waivers: reclaim-ticket-race, js-reclaim-lock-heartbeat
 actor: Tin Dang <tindang.ht97@gmail.com> (git)
-evidence: test_release_1_18_0.py 11/11 green · add.py check green · milestones build-strategy-facets(#139) + delta-drain(#140) merged to main
+evidence: expanded cut (1.17.0-amend precedent): 11 milestones — six-phase-loop(#148/#149 stack) + expectations-first/plan-legibility/quality-floors(#145) + add-bench/add-bench-v2(#142) + three-phase-flow/risk-proportional-ceremony + add-lean-loop + build-strategy-facets(#139)/delta-drain(#140) — plus loose installer-shared-namespace-guard(#151); ceremony-to-effort + call-floor features included, milestones open on measurement criteria; 10 open SPEC deltas ride forced (fold review pending, human-owned); fence 3570 OK · release tests green · WM1 re-measure fid 0.98x3/0 regr
 
 ## 1.17.0 — 2026-07-07
 milestones: persona-domain-fit, method-ergonomics, dynamic-personas, self-improving-loop

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,15 +4,55 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
-## [1.18.0] — 2026-07-07
+## [1.18.0] — 2026-07-14
 
-Minor: two milestones — **build-strategy-facets** (§5 build strategy becomes
-four domain-generic facet lines with fast-lane collapse, plus per-facet ADR
-harvest) and **delta-drain** (all 4 open SPEC deltas resolved into shipped
-behavior, leaving zero open SPEC deltas). All additive; no gate weakened,
-nothing removed or renamed.
+Minor: eleven milestones, expanded from the original July-7 two-milestone cut
+(unpublished — the 1.17.0-amend precedent) to attribute everything merged
+since. Headline: **six-phase-loop** — the lifecycle merges 8 phases into 6
+(specify absorbs scenarios; verify absorbs observe), phase guides disclose
+into the roster's bundle subagents, and the tick into build re-renders the
+frozen spec. Also: **expectations-first** (plan phase; ONE freeze),
+**plan-legibility**, **quality-floors**, **risk-proportional-ceremony**,
+**three-phase-flow**, **add-bench** + **add-bench-v2** (the trust benchmark
+that measured it all), **add-lean-loop**, plus the original
+**build-strategy-facets** and **delta-drain**. The ceremony-to-effort and
+call-floor features (compound ticks · scope echo · kickoff truth · skill
+orient split) ship here too; their milestones remain open on measurement
+criteria. No gate weakened; a security finding still HARD-STOPs.
+
+### Changed (the headline)
+- **The loop is six phases**: `specify → plan → tests → build → verify → done`.
+  Scenarios live inside SPECIFY (§2 unchanged as a section); the observe duties
+  live inside VERIFY (§7 unchanged). Legacy phase tokens (`ground`, `contract`,
+  `scenarios`, `observe`) normalize on read — in-flight boards migrate loud and
+  safe; the skip grammar is retired (nothing is skippable; vestigial `skips:`
+  headers are noted at gate, never fatal) (six-phase-loop).
+- **Guides re-cut to 6 files**; delegating spawns a bundle agent that loads its
+  own phase guides — the orchestrator reads only SKILL.md; the inline lane stays
+  first-class (six-phase-loop).
+- The specification bundle approves at ONE freeze on the plan phase
+  (expectations-first); the freeze report renders the BUILD PLAN block and the
+  resolved scope echo (plan-legibility, ceremony-to-effort).
 
 ### Added
+- **Build-entry spec echo** — the tests→build tick prints the §1 Must/Reject
+  rules + the frozen §3 contract head, so the builder starts from the spec on
+  the screen, not from memory; fail-open, both entry paths (six-phase-loop).
+- **Per-phase persona presets** — teacher-grade expert stances per owned phase
+  in the roster agents; project-persona routing stays first; a preset never
+  lowers a gate (six-phase-loop).
+- **Compound ticks** — `freeze --cross` lands in tests; `gate` records from
+  build (one call fewer per crossing); init prints the resume pointer
+  (call-floor).
+- **Quality floors** — spec-dialect warn at build entry · fast-lane
+  `Boundary:` freeze-refusal · §6 DIALECT check line (quality-floors).
+- **The trust benchmark** — arms × workload-milestones harness with
+  deterministic oracles, tamper/regression meters, and the
+  cost-per-trusted-feature verdict (add-bench, add-bench-v2).
+- **AI-plan-verify gate + phase bundles** (three-phase-flow) · message-layer
+  error ergonomics, −24% turns at equal rigor (risk-proportional-ceremony).
+
+### Added (from the original July-7 cut)
 - **Faceted §5 build strategy** — four domain-generic facet lines drafted at
   the tests→build cross: `Approach` (domain strategy) · `Data strategy` ·
   `Pattern` · `Optimization stance`; the fast lane collapses them to one line
@@ -30,6 +70,12 @@ nothing removed or renamed.
 ### Changed
 - §5 build strategy guidance, phase guides, and the TASK.md/TASK.fast.md
   templates teach and carry the facet block (build-strategy-facets).
+
+### Fixed
+- **Installer data loss** — `.claude/agents` is a shared namespace: init/update
+  now land only ADD's own roster files per-file (atomic), removal is
+  explicit-tombstone-only — the user's own subagents survive every install and
+  update (loose task installer-shared-namespace-guard, PR #151).
 
 ### Disclosed waivers (non-security, signed)
 - `reclaim-ticket-race` — lock-reclaim TOCTOU flake; owner Tin Dang, expires 2026-08-04.


### PR DESCRIPTION
Expands the unpublished 1.18.0 (1.12.0/1.17.0 amend precedent): rich changelog headline = six-phase loop; one complete RELEASES.md row (11 milestones, waivers disclosed, 10 open SPEC deltas ride --force pending the human fold review). Release tests 25/25, check 807/0. After merge: ready to tag v1.18.0.