### PR TITLE
feat(benchmark): honest-fidelity-meter — deterministic requirement_coverage + self-explaining diagnostics

### DIFF
--- a/.add/milestones/honest-fidelity-meter/MILESTONE.md
+++ b/.add/milestones/honest-fidelity-meter/MILESTONE.md
@@ -1,0 +1,76 @@
+# MILESTONE: Honest fidelity meter: deterministic requirement_coverage replaces artifact-blind spec_fidelity
+
+goal: Replace the artifact-blind LLM spec_fidelity metric with a deterministic requirement_coverage meter (frozen per-requirement checklists + probes across all 6 WMs), promote oracle_pass_rate to the headline, and demote the LLM judge to an advisory source-aware code_quality_annotation
+rationale: sub-milestone — a live investigation (2026-07-15) proved the LLM `spec_fidelity` judge is artifact-blind: its rubric (judge.py:43-56) = PROMPT.md + 2 oracle booleans, NEVER the built code. Two runs fed byte-identical rubric (md5 69e8f629) yet scored 0.98 vs 0.95 — pure sampling noise incl. a 0.0 hallucination on a working app. A deterministic requirement-coverage meter is the honest replacement. User-confirmed scope 2026-07-15 (3 AskUserQuestion calls: replace-in-place · all-6-WMs · judge→advisory).
+stage: mvp · status: active · created: 2026-07-15T02:56:10+00:00
+release: pending
+relations: relates-to: add-bench-v2
+
+> SDD living doc for this milestone. Keep it THIN: breadth, shared decisions, and
+> exit criteria only — per-task detail lives in each `.add/tasks/<slug>/TASK.md`,
+> written just-in-time. Update this doc whenever a task reveals a milestone gap.
+
+## Scope
+In:  (1) swap `spec_fidelity` → `requirement_coverage` in the frozen `REQUIRED_METRICS` set + `validate()`; (2) a deterministic coverage scorer that reads a frozen per-WM requirement checklist, runs its probes against the built app, scores `covered/total`; (3) frozen requirement checklists + probes for WM1–WM6; (4) `context_rot_slope` recomputed over the `requirement_coverage` trajectory (with a back-compat read shim for archived records that only carry `spec_fidelity`); (5) `oracle_pass_rate` promoted to REQUIRED (headline); (6) the LLM judge demoted to an advisory, source-aware `code_quality_annotation` artifact (non-gating). Migrate the ~10 test files that pin the old metric.
+Out: no change to the WORKLOAD specs (PROMPT.md wm1–6 stay frozen) · no re-measure of any arm (this is meter code only — re-running arms is a separate paid step) · no new WMs · no scoring of arms other than `add` · the coverage checklists describe EXISTING PROMPT.md requirements, they do not add new ones.
+
+## Ground   (shared real-code context — gathered ONCE; every task's specify projects from this)
+Touches (shared files · symbols):
+  - `benchmark/schema/run_record.py` — `REQUIRED_METRICS` (stale "5" comment, actually 6: regression_rate, spec_fidelity, tokens_total, cost_usd, context_rot_slope, time_to_first_edit), `OPTIONAL_METRICS` {oracle_pass_rate, tests_weakened}, `validate()` (rejects keys ∉ REQUIRED∪OPTIONAL)
+  - `benchmark/score.py` — `score_record`@234 (judge call@297, `metrics["spec_fidelity"]=`@324), `compute_context_rot_slope`@59, `compute_oracle_pass_rate`@131, `_run_oracle_suites`@85, `_fidelity_artifacts`@195 (WM3 trajectory), `_engine_call_census`@225, prior read `prior.metrics["spec_fidelity"]`@270 + slope input@313
+  - `benchmark/judge.py` — `judge_fidelity`@59, `judge_fidelity_median`@101, `build_rubric_prompt`@43 (the artifact-blind rubric), `default_judge_cmd`@22
+  - `benchmark/workload/wm{1..6}/oracle/*.py` + `PROMPT.md` — the existing behavioral probes to reuse/extend into coverage checklists; `_oracle_lib.py` (`http_call`, `running_app`)
+  - `benchmark/report.py` — `METRIC_COLUMNS`@17 (`spec_fidelity` label), `_render_cell`@53 (spec_fidelity_audit hook)
+  - `benchmark/tests/` — ~10 files pin the metric: test_score, test_run_record, test_report, test_v2_meter, test_judge_median, test_runner_records, test_run_cli, test_pilot, test_runner_resume, test_wv1_aggregate
+Anchors: `RunRecord`, `REQUIRED_METRICS`, `validate()`, `score_record`, `compute_oracle_pass_rate`, `compute_context_rot_slope`, `build_rubric_prompt`
+Honors: PROJECT.md invariants (bare-runtime entry contract) · the benchmark's own frozen-metric discipline (a metric-set change is a frozen-contract migration, not a silent edit) · reproducibility pin `claude-sonnet-5` UNCHANGED · never weaken a probe to pass
+Issues/Risks (shared):
+  - `context_rot_slope` is computed FROM the fidelity trajectory (score.py:313) — swapping the metric silently changes what the slope means; archived records carry only `spec_fidelity`, so prior-WM reads need a `.get("requirement_coverage", .get("spec_fidelity"))` shim or WM3+ scoring of old records breaks
+  - the coverage scorer runs real probes against a live app (`running_app`) — same timeout/flake surface as the oracle; design for probe failure (a crashed probe = requirement NOT covered, never a scorer crash)
+  - CHANGING a REQUIRED metric NAME ripples into every test that constructs a RunRecord — expect broad, legitimate test migration (TESTS phase, not a tamper)
+
+## Shared decisions & glossary deltas   (living — every task must honor these)
+- `requirement_coverage` ∈ [0,1] = (requirements whose probe PASSES) / (total frozen requirements for that WM). Deterministic, reproducible, artifact-reading. This is the fidelity-of-record.
+- `oracle_pass_rate` = black-box behavioral pass fraction (existing) — promoted to REQUIRED, the headline floor.
+- `code_quality_annotation` = the (fixed, source-aware) LLM judge output — an ADVISORY artifact, NEVER a metric, NEVER gating.
+- A per-WM requirement checklist is FROZEN (like a contract): it enumerates the EXISTING PROMPT.md requirements as `(id, description, probe)` rows; adding/removing a row is a deliberate versioned change.
+
+## Shared / risky contracts (freeze these first)
+- `requirement_coverage` metric name + [0,1] semantics + the checklist row schema `(id, description, probe_fn)` -> owning task `coverage-scorer`
+- the frozen `REQUIRED_METRICS` new membership (spec_fidelity out, requirement_coverage + oracle_pass_rate in) + the archived-record read shim -> owning task `coverage-scorer`
+
+## Tasks (breadth-first decomposition; detail lives in each TASK.md)
+- [ ] coverage-scorer   depends-on: none            — swap the frozen metric set + validate() + the deterministic coverage scorer + score.py wiring (slope over coverage, archived-record shim) + report label; ships WM1's checklist as the end-to-end proof on the 2 existing runs
+- [ ] wm-checklists      depends-on: coverage-scorer — frozen requirement checklists + probes for WM2–WM6 (WM1 landed in coverage-scorer), each enumerating that WM's existing PROMPT.md requirements
+- [ ] judge-advisory     depends-on: coverage-scorer — demote judge.py: rename output to `code_quality_annotation`, feed it the built source tree (fix the artifact-blindness), mark non-gating artifact; drop it from the metric path
+- [ ] rescore-progression depends-on: wm-checklists, judge-advisory — re-score EVERY existing run under `benchmark/runs/` with the new deterministic meter (no paid agent re-run — probes hit the already-built workspaces; skip + report any workspace that no longer runs), then render a progression view (arm × WM × rep → requirement_coverage + oracle_pass_rate over time) for the user
+
+## Exit criteria (observable; map each to the task that delivers it)
+- [ ] `run.py score --arm add --wm 1` records a `requirement_coverage` metric computed from WM1's frozen checklist run against the built app — deterministic (same workspace → same score, no LLM call in the metric path)   (← coverage-scorer)
+- [ ] a RunRecord with `spec_fidelity` instead of `requirement_coverage` is REJECTED by `validate()`; `oracle_pass_rate` is now required   (← coverage-scorer)
+- [ ] each of WM1–WM6 has a frozen requirement checklist whose row count matches its PROMPT.md's enumerated requirements, and `score` reports a coverage fraction for each   (← wm-checklists + coverage-scorer)
+- [ ] the LLM judge output appears as a `code_quality_annotation` artifact built from the actual source tree, and NO metric in the record comes from an LLM call   (← judge-advisory)
+- [ ] every re-scorable existing run under `benchmark/runs/` carries a fresh deterministic `requirement_coverage`, and the user is shown a progression view of the scores across arms/WMs/reps (with any un-re-scorable run explicitly listed, not silently dropped)   (← rescore-progression)
+
+## Close — ship review   (AI fills when every task is done — the evidence behind the engine gate, read before the boxes are checked)
+> Whole-milestone, cross-task review the AI fills in. It is the evidence behind the EXISTING engine
+> gate (milestone-done / checking the Exit-criteria boxes) — NOT a new approval. Tool-agnostic.
+
+### Ship by domain   (what changed, per bounded context)
+- tooling : <add.py / state.json / templates — what shipped, or "untouched">
+- skill   : <SKILL.md / phases/* / guides — what shipped, or "untouched">
+- book    : <docs/* — what shipped, or "untouched">
+
+### Cross-task evidence   (one row per task)
+- <slug> : gate=<PASS|RISK-ACCEPTED> · tests=<n green> · residue=<none|note>
+
+### Goal met?   (map the evidence back to this milestone's Exit criteria — read before the Exit-criteria boxes are checked)
+- [ ] each Exit criterion above is satisfied by a Cross-task evidence row or a Ship-by-domain change (cite which)
+- goal: <restate the milestone goal — and the one evidence line that proves the ship meets it>
+
+## Release steps   (AI-DEFINED — fill the ordered steps to ship this milestone; engine records, human gate)
+> The AI writes the release steps for THIS milestone here (hints, not engine commands). MERGE is one
+> small step among them. These feed the release scope (release.md) when the cut is bundled.
+- [ ] <step — e.g. open a PR from the Close ship-review above; the human reviews + merges>
+- [ ] <step — e.g. export the ship-review to a hand-off doc, e.g. `pandoc CLOSE.md -o close.docx`>
+- [ ] <step — e.g. tag / publish / deploy  (human-run, per release.md)>

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "wire-milestone-relations",
+  "active_task": "coverage-scorer",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -9951,10 +9951,56 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "coverage-scorer": {
+      "title": "Deterministic requirement_coverage scorer + frozen metric-set swap (ships WM1 checklist)",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": "honest-fidelity-meter",
+      "depends_on": [],
+      "created": "2026-07-15T03:00:28+00:00",
+      "updated": "2026-07-15T04:04:26+00:00",
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-07-15T03:04:48+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "4c29b4153bdc4665ed3933cd301d0cb8",
+        "tests": {}
+      },
+      "scope": {
+        "declared": [
+          "benchmark/schema/run_record.py",
+          "benchmark/score.py",
+          "benchmark/report.py",
+          "benchmark/workload/",
+          "benchmark/runner/core.py",
+          "benchmark/pilot.py",
+          "benchmark/tests/"
+        ],
+        "snapshot_md5": "0898d078a306b9604e04933ea0e27d5a"
+      },
+      "recross": {
+        "by": "Tin Dang",
+        "at": "2026-07-15T04:01:21+00:00",
+        "from_phase": "build"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-07-14T16:54:49+00:00",
+  "updated": "2026-07-15T04:04:26+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -10407,9 +10453,26 @@
       "status": "active",
       "created": "2026-07-14T16:16:45+00:00",
       "updated": "2026-07-14T16:16:45+00:00"
+    },
+    "honest-fidelity-meter": {
+      "title": "Honest fidelity meter: deterministic requirement_coverage replaces artifact-blind spec_fidelity",
+      "goal": "Replace the artifact-blind LLM spec_fidelity metric with a deterministic requirement_coverage meter (frozen per-requirement checklists + probes across all 6 WMs), promote oracle_pass_rate to the headline, and demote the LLM judge to an advisory source-aware code_quality_annotation",
+      "stage": "mvp",
+      "status": "active",
+      "created": "2026-07-15T02:56:10+00:00",
+      "updated": "2026-07-15T03:00:28+00:00",
+      "confirmed": true,
+      "confirmed_at": "2026-07-15T03:00:28+00:00",
+      "confirmed_by": "tindang",
+      "await_confirm": true,
+      "actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
-  "active_milestone": "engine-hygiene",
+  "active_milestone": "honest-fidelity-meter",
   "archived": [
     {
       "slug": "v5",
@@ -11251,7 +11314,8 @@
     "six-phase-loop",
     "call-residuals",
     "orientation-honesty",
-    "engine-hygiene"
+    "engine-hygiene",
+    "honest-fidelity-meter"
   ],
   "active_tasks": {
     "flow-simplification": "phase-review",
@@ -11269,7 +11333,8 @@
     "six-phase-loop": "installer-shared-namespace-guard",
     "call-residuals": "help-habit-kill",
     "orientation-honesty": "guide-fold",
-    "engine-hygiene": "wire-milestone-relations"
+    "engine-hygiene": "wire-milestone-relations",
+    "honest-fidelity-meter": "coverage-scorer"
   },
   "todos": [
     {

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "coverage-detail",
+  "active_task": "report-diagnostics",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -10115,10 +10115,47 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "report-diagnostics": {
+      "title": "Surface coverage_detail + code_quality_annotation in report.py's per-WM view (read-only, non-gating)",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": "honest-fidelity-meter",
+      "depends_on": [],
+      "created": "2026-07-15T05:53:15+00:00",
+      "updated": "2026-07-15T06:00:25+00:00",
+      "fast": true,
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-07-15T05:54:25+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "9cd89127494a0c19201b0c9d5049caca",
+        "tests": {}
+      },
+      "scope": {
+        "declared": [
+          "benchmark/report.py",
+          "benchmark/tests/"
+        ],
+        "snapshot_md5": "d6214b948e631b8caec0aff66bf5d1f0"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-07-15T05:47:39+00:00",
+  "updated": "2026-07-15T06:00:25+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -11452,7 +11489,7 @@
     "call-residuals": "help-habit-kill",
     "orientation-honesty": "guide-fold",
     "engine-hygiene": "wire-milestone-relations",
-    "honest-fidelity-meter": "coverage-detail"
+    "honest-fidelity-meter": "report-diagnostics"
   },
   "todos": [
     {

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "hermetic-scoring",
+  "active_task": "judge-advisory",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -10035,10 +10035,48 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "judge-advisory": {
+      "title": "Demote the LLM judge to a source-aware, non-gating code_quality_annotation artifact",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": "honest-fidelity-meter",
+      "depends_on": [],
+      "created": "2026-07-15T04:36:37+00:00",
+      "updated": "2026-07-15T04:44:51+00:00",
+      "fast": true,
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-07-15T04:40:38+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "f2cbd173fe91678079f1b44966be2997",
+        "tests": {}
+      },
+      "scope": {
+        "declared": [
+          "benchmark/judge.py",
+          "benchmark/score.py",
+          "benchmark/tests/"
+        ],
+        "snapshot_md5": "46a4a6dc6cce3fa9b5396e48a043f9e2"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-07-15T04:31:17+00:00",
+  "updated": "2026-07-15T04:44:51+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -11372,7 +11410,7 @@
     "call-residuals": "help-habit-kill",
     "orientation-honesty": "guide-fold",
     "engine-hygiene": "wire-milestone-relations",
-    "honest-fidelity-meter": "hermetic-scoring"
+    "honest-fidelity-meter": "judge-advisory"
   },
   "todos": [
     {

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "judge-advisory",
+  "active_task": "coverage-detail",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -10073,10 +10073,52 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "coverage-detail": {
+      "title": "Emit a per-WM coverage_detail artifact \u2014 which checklist requirement each WM covered (non-gating)",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": "honest-fidelity-meter",
+      "depends_on": [],
+      "created": "2026-07-15T05:38:01+00:00",
+      "updated": "2026-07-15T05:47:39+00:00",
+      "fast": true,
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-07-15T05:40:01+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "cb75d9e057495b8bbcd2f5271b44a868",
+        "tests": {}
+      },
+      "scope": {
+        "declared": [
+          "benchmark/score.py",
+          "benchmark/tests/"
+        ],
+        "snapshot_md5": "4325dd9fcf2decf96d772157f37b70e5"
+      },
+      "recross": {
+        "by": "Tin Dang",
+        "at": "2026-07-15T05:46:37+00:00",
+        "from_phase": "build"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-07-15T04:44:51+00:00",
+  "updated": "2026-07-15T05:47:39+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -11410,7 +11452,7 @@
     "call-residuals": "help-habit-kill",
     "orientation-honesty": "guide-fold",
     "engine-hygiene": "wire-milestone-relations",
-    "honest-fidelity-meter": "judge-advisory"
+    "honest-fidelity-meter": "coverage-detail"
   },
   "todos": [
     {

--- a/.add/state.json
+++ b/.add/state.json
@@ -1,7 +1,7 @@
 {
   "project": "AIDD / ADD Methodology",
   "stage": "mvp",
-  "active_task": "coverage-scorer",
+  "active_task": "hermetic-scoring",
   "tasks": {
     "add-check": {
       "title": "add.py check: validate .add project integrity",
@@ -9997,10 +9997,48 @@
         "email": "tindang.ht97@gmail.com",
         "source": "git"
       }
+    },
+    "hermetic-scoring": {
+      "title": "Hermetic scoring \u2014 isolate the app store per boot so coverage/oracle are reproducible on archived builds",
+      "phase": "done",
+      "gate": "PASS",
+      "milestone": "honest-fidelity-meter",
+      "depends_on": [],
+      "created": "2026-07-15T04:24:27+00:00",
+      "updated": "2026-07-15T04:31:17+00:00",
+      "fast": true,
+      "freeze": {
+        "version": "v1",
+        "frozen_at": "2026-07-15T04:25:57+00:00",
+        "approved_by": "Tin Dang",
+        "actor": {
+          "name": "Tin Dang",
+          "email": "tindang.ht97@gmail.com",
+          "source": "git"
+        }
+      },
+      "flag_verified": true,
+      "tripwire": {
+        "contract_md5": "c36fd4689d8043550ec9e7dca841ed04",
+        "tests": {}
+      },
+      "scope": {
+        "declared": [
+          "benchmark/score.py",
+          "benchmark/workload/_oracle_lib.py",
+          "benchmark/tests/"
+        ],
+        "snapshot_md5": "3a192137d32d98fa9cb3e1896895a7c5"
+      },
+      "gate_actor": {
+        "name": "Tin Dang",
+        "email": "tindang.ht97@gmail.com",
+        "source": "git"
+      }
     }
   },
   "created": "2026-05-28T15:39:04+00:00",
-  "updated": "2026-07-15T04:04:26+00:00",
+  "updated": "2026-07-15T04:31:17+00:00",
   "milestones": {
     "v1-1": {
       "title": "v1.1 \u2014 adoption & ergonomics",
@@ -11334,7 +11372,7 @@
     "call-residuals": "help-habit-kill",
     "orientation-honesty": "guide-fold",
     "engine-hygiene": "wire-milestone-relations",
-    "honest-fidelity-meter": "coverage-scorer"
+    "honest-fidelity-meter": "hermetic-scoring"
   },
   "todos": [
     {

--- a/.add/tasks/coverage-detail/TASK.md
+++ b/.add/tasks/coverage-detail/TASK.md
@@ -1,0 +1,114 @@
+# TASK: Emit a per-WM coverage_detail artifact — which checklist requirement each WM covered (non-gating)
+
+slug: coverage-detail · created: 2026-07-15 · stage: mvp
+milestone: honest-fidelity-meter
+autonomy: auto
+phase: done
+fast: true
+
+> Fast lane — one small task, minimal sections, filled top-to-bottom. The trust floor still
+> holds: a FROZEN §3 contract · ≥1 red test before build · a recorded §6 gate (security = HARD-STOP).
+> The acceptance scenario collapses into §1 `Accept:`; the observe note is one optional line at the gate.
+
+---
+
+## 1 · SPECIFY — the rules
+
+> Project the expectations from the milestone Ground + this request — light, not re-invented.
+Feature: `coverage_detail` — score_record emits a per-WM artifact recording which frozen checklist requirement the built app covered (id + covered bool), so every `requirement_coverage` score is self-explaining. Non-gating (an `artifacts` string, never a metric).
+Must:
+  - M1: `score_record` writes `artifacts["coverage_detail"]` — a JSON string encoding one `{"id","covered"}` row per checklist requirement, in checklist order, for the WM being scored.
+  - M2: the detail AGREES with the aggregate by construction — `requirement_coverage == (#covered / #rows)` from the SAME hermetic boot (one boot, not two; the float is derived from the detail, so they can never disagree).
+  - M3: on an unbootable app the detail is still emitted with EVERY row `covered:false` (and coverage 0.0) — this is the whole point: a 0.0 becomes self-explaining (which requirements failed / that nothing booted), fixing the re-score blindness.
+  - M4: `coverage_detail` NEVER enters `metrics` — it stays an `artifacts` string (mirrors the `code_quality_annotation` non-gating law); the frozen v3 metric set is byte-for-byte unchanged.
+Reject:
+  - R1: `coverage_detail` as a `metrics` key -> `validate()` raises "invalid_run_record" (neither required nor optional) — pinned so the diagnostic can never silently become a gating metric.
+  - R2: a checklist whose rows lack a stable `id` -> "invalid_checklist" (the detail must key on `id`; enforced by the existing `validate_checklist` guard, extended if needed).
+Accept: scoring a workspace that covers 4 of wm2's 5 rows writes `artifacts["coverage_detail"]` = 5 `{"id","covered"}` rows with exactly the uncovered requirement flagged `covered:false`, AND `metrics["requirement_coverage"] == 0.8` (detail and float agree).
+Boundary: bootable app (mixed covered true/false) vs unbootable app (every row `covered:false`, coverage 0.0) — the detail is emitted in BOTH, so a 0.0 is never mute.
+Assumptions: ⚠ every frozen checklist row already carries a stable `id` (verified: wm1-6 all have `id`,`description`,`probe`) — if a future checklist row omits `id`, R2 fails loud; cost: that WM's detail can't be keyed, caught at score-time, never silently wrong.
+
+---
+
+## 3 · PLAN — the change plan: ground · contract · build-strategy
+
+### Grounding
+Touches (files · symbols):
+  - `benchmark/score.py:compute_requirement_coverage`@187 — REFACTOR: extract the hermetic boot + per-row probe loop into NEW `compute_coverage_detail(workspace, wm, family) -> list[dict]` (returns `[{"id","covered"}]` in checklist order; fail-closed → all `covered:False` on an unbootable app). `compute_requirement_coverage` becomes `_coverage_from_detail(compute_coverage_detail(...))` — signature + returned float UNCHANGED (behavior-preserving).
+  - `benchmark/score.py` — NEW `_coverage_from_detail(detail) -> float` = `#covered/#rows` with the existing R3 `invalid_coverage` guard (single source of truth, used by both `compute_requirement_coverage` and `score_record`).
+  - `benchmark/score.py:score_record`@347 — after coverage, call `compute_coverage_detail` ONCE (single boot), derive `requirement_coverage = _coverage_from_detail(detail)`, and set `artifacts["coverage_detail"] = json.dumps(detail, separators=(",",":"))`. `json` already imported@13.
+Context (working folder): `benchmark/` harness; the frozen `workload/{wm}/checklist.py` REQUIREMENTS rows (each carries `id`,`description`,`probe`) are the detail's key source; `schema/run_record.py` REQUIRED/OPTIONAL_METRICS is the floor R1 pins against.
+Honors (patterns / conventions): the hermetic `isolated_workspace`+`running_app` boot (reused, not re-added) · fail-closed coverage (unbootable → 0.0, never a crash) · the non-gating law (diagnostic lives in `artifacts`, never `metrics` — mirrors `code_quality_annotation`) · artifacts are string-valued (store the detail as a compact JSON string).
+Anchors the contract cites: `compute_coverage_detail`, `_coverage_from_detail`, `compute_requirement_coverage`, `score_record`, `validate_checklist`, REQUIRED_METRICS/OPTIONAL_METRICS.
+Ground SHA: 7e3712f — stamped by freeze
+
+### Contract
+
+```
+compute_coverage_detail(workspace: str|pathlib.Path, wm: int, family: str = "wm") -> list[dict]:
+  - boots ONE hermetic store-reset copy (isolated_workspace + running_app), runs each
+    frozen checklist row's probe, returns [{"id": row["id"], "covered": bool}, ...] in
+    checklist order
+  - fail-closed: unbootable app / raising probe -> that row covered=False (never raises for a probe)
+  - malformed checklist (row missing id/description/probe) -> "invalid_checklist" (R2, via validate_checklist)
+
+_coverage_from_detail(detail: list[dict]) -> float:
+  - #covered / #rows; value ∉ [0,1] -> "invalid_coverage" (R3)
+
+compute_requirement_coverage(workspace, wm, family) -> float:   # UNCHANGED signature/behavior
+  - == _coverage_from_detail(compute_coverage_detail(workspace, wm, family))
+
+score_record(...):
+  - detail = compute_coverage_detail(workspace, wm, family)   # single boot
+  - metrics["requirement_coverage"] = _coverage_from_detail(detail)   # v3 set byte-unchanged
+  - artifacts["coverage_detail"] = json.dumps(detail, separators=(",",":"))   # non-gating
+
+R1: "coverage_detail" ∉ REQUIRED_METRICS ∪ OPTIONAL_METRICS -> a record placing it under
+    metrics fails validate() with "invalid_run_record" (never gating)
+```
+
+`Least-sure flag surfaced at freeze:` [contract] the detail rows carry only `{id, covered}` (not `description`) — keeps the artifact lean and matches the confirmed shape, but a report renderer must re-import the checklist to show human text; if that's friction, `description` can be added later (additive, non-breaking) — cost: a follow-up field add, never a re-score.
+Status: FROZEN @ v1 — approved by Tin Dang
+### Build-strategy
+Scope (may touch): `benchmark/score.py` `benchmark/tests/`
+Strategy & known-problem fixes: 1. RED tests first (benchmark/tests/): (a) M1/M2 — score a workspace, assert `artifacts["coverage_detail"]` is JSON with one `{id,covered}` per row AND `#covered/#rows == requirement_coverage`; (b) M3 — an unbootable/empty workspace → detail with every row `covered:false` + coverage 0.0 (detail still present); (c) R1 — `coverage_detail` ∉ REQUIRED∪OPTIONAL and a record with it under `metrics` fails `validate()`; (d) `compute_requirement_coverage` float is UNCHANGED vs the pre-refactor value on a known workspace (behavior-preserving pin). 2. extract `compute_coverage_detail` + `_coverage_from_detail`, rewire `compute_requirement_coverage`. 3. wire `score_record`'s single-boot detail + artifact. Trap: do NOT boot twice in score_record (derive coverage from the one detail call, don't also call `compute_requirement_coverage`). Trap: `coverage_detail` is an `artifacts` string only — never a metric.
+Approach (domain strategy): "derive-both-from-one-boot"
+
+### AI-verify record (required when gate_mode: ai-plan-verify)
+- [ ] §3 PLAN grounding anchors resolve in the current tree
+- [ ] §1 every Must + every Reject present, each Reject paired with an error code
+- [ ] §3 Contract shape is concrete (no template placeholder text remains)
+- [ ] Lowest-confidence flag surfaced and substantive (mirrors unflagged_freeze's own bar)
+Verified by: <agent-id> · at: <ISO-8601 UTC timestamp>
+
+---
+
+## 4 · TESTS — failing-first (red)
+
+Plan: test_<accept> — assert the §1 Accept line's Then (behavior, not internals).
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+
+---
+
+## 5 · BUILD — AI writes the code (execution)
+
+> The change plan was frozen in §3 PLAN. Build to it: honor the §3 Build-strategy Scope; improve on the strategy if the code teaches you better.
+Strategy actually used: as planned — extracted `compute_coverage_detail` (per-row {id,covered}, one hermetic boot, fail-closed all-False) + `_coverage_from_detail` (R3 guard); rewired `compute_requirement_coverage` to derive from them; `score_record` single-boot detail → `artifacts["coverage_detail"]` (compact JSON). Divergence: 5 pre-existing tests monkeypatched the old `compute_requirement_coverage` seam that `score_record` no longer calls directly — forward-migrated them to seed `compute_coverage_detail` (same assertions, new wiring), re-crossed to re-baseline the tamper snapshot.
+Code lives in: `benchmark/`   ·   Constraints: change no test, no frozen contract; stay inside the §3 Build-strategy Scope; allow-list packages only.
+
+---
+
+## 6 · VERIFY — evidence + gate
+
+- [x] all tests pass · coverage held · no test or contract altered during build — `benchmark/tests/` 210 passed (6 new in test_coverage_detail.py + 5 forward-migrated seams), 0 failed; frozen contract untouched
+- [x] green was EARNED — the 4 detail tests were RED (functions absent); the 2 invariant pins (R1/R2 already-guaranteed) documented the non-gating law; migrations preserved every behavioral assertion (0.5/0.6/1.0/slope), only the mock seam moved
+- [x] input dialect held — detail keys on the frozen checklist `id`s (R-*); the artifact is a compact JSON string matching the artifacts-are-strings convention
+- [x] no exposed secrets, injection openings, or unexpected dependencies (security = HARD-STOP) — stdlib `json` only; reuses the existing hermetic boot; no new IO, no shell, no user input
+
+Build expectations (from §1 Accept + §3 CONTRACT): on the REAL archived `gsd-v2meter-r0/wm2` (the one sub-1.0 arm) `compute_coverage_detail(ws,2)` names the single uncovered requirement — `R-cancellation-window-422` `covered:false`, other 4 `true` — and `_coverage_from_detail == compute_requirement_coverage == 0.8`; on `spec-kit-preexisting/wm2` (401 auth-drift) the detail shows exactly which 4 of 5 failed → coverage 0.2 (a formerly-mute 0.2 is now self-explaining). Confirmed live.
+
+### GATE RECORD
+Outcome: PASS
+Reviewed by: Tin Dang (auto-gate, autonomy: auto — evidence-complete; human spot-audit backstop) · date: 2026-07-15
+OBSERVE: [SPEC · open] coverage_detail makes the wm2-6 granularity delta actionable — a report column showing per-requirement covered/uncovered now lets the "coverage 1.0 but oracle<1.0" gaps be pinpointed to a specific requirement id; the natural next step is surfacing coverage_detail (+ code_quality_annotation) in report.py's per-record view.
+

--- a/.add/tasks/coverage-scorer/TASK.md
+++ b/.add/tasks/coverage-scorer/TASK.md
@@ -1,0 +1,262 @@
+# TASK: Deterministic requirement_coverage scorer + frozen metric-set swap (ships WM1 checklist)
+
+slug: coverage-scorer · created: 2026-07-15 · stage: mvp
+milestone: honest-fidelity-meter
+autonomy: auto
+phase: done
+
+> One file = one task — fill top-to-bottom; the phase marker above is the single source of truth (`add.py phase`); unclear phase → its book chapter.
+
+---
+
+## 1 · SPECIFY — the rules ▸ docs/03-step-1-specify.md
+
+> Project the expectations from the milestone Ground + this request — light, not re-invented.
+Feature: Deterministic `requirement_coverage` metric — replaces the artifact-blind LLM `spec_fidelity`
+Framings weighed: frozen per-requirement checklist run as real probes against the built app (chosen) · keep the LLM judge but feed it the source tree (alt — still nondeterministic, still an LLM in the metric path) · promote `oracle_pass_rate` alone, no checklist (alt — loses per-requirement granularity)
+Must:
+<must>
+  - M1: `REQUIRED_METRICS` (schema/run_record.py) contains `requirement_coverage` and `oracle_pass_rate`, and NO LONGER contains `spec_fidelity`.
+  - M2: `requirement_coverage` = (requirements whose probe PASSES) / (total rows in that WM's frozen checklist), run against the built app; a float in [0,1]; DETERMINISTIC — no LLM call anywhere in the metric path (same workspace → identical score).
+  - M3: a checklist probe that raises / times out / the app being unreachable counts that requirement as NOT covered — it never crashes the scorer (fail-closed, like the oracle).
+  - M4: `context_rot_slope` is computed over the `requirement_coverage` trajectory; reading a prior WM's coverage falls back to that record's `spec_fidelity` when `requirement_coverage` is absent (archived-record shim) — WM3+ scoring of a mixed old/new tree never raises.
+  - M5: WM1 ships a FROZEN checklist enumerating its PROMPT.md requirements as `(id, description, probe)` rows; `run.py score --arm add --wm 1` records a real coverage fraction from it.
+  - M6: `report.py` METRIC_COLUMNS surfaces `requirement_coverage` (not `spec_fidelity`).
+</must>
+Reject:
+<reject>
+  - R1: a RunRecord whose metrics dict carries `spec_fidelity` but not `requirement_coverage` -> `validate()` raises "invalid_run_record".
+  - R2: a checklist row missing `id`, `description`, or `probe` -> "invalid_checklist".
+  - R3: a computed coverage value outside [0,1] -> guarded (never silently clamped into a record).
+</reject>
+After:
+<after>
+  - `score` produces `requirement_coverage` deterministically; a second `score` on the same workspace yields the byte-identical value; no metric in the record derives from an LLM call.
+</after>
+Assumptions — lowest-confidence first:
+<assumptions>
+  ⚠ Archived v1/v2 records carry only `spec_fidelity`, so the WM3+ slope prior-read MUST shim to it — lowest confidence because I have not audited every archived record's keys; if wrong: WM3+ scoring of a tree mixing old + new records raises KeyError instead of degrading gracefully.
+  - [ ] The existing `wmN/oracle/*.py` probes can be reused/adapted as coverage-checklist probes (they already hit `running_app` the same way) — confirm when authoring WM1's checklist.
+  - [ ] `oracle_pass_rate` moving from OPTIONAL → REQUIRED does not break archived records that already carry it (it was optional-additive, so most v2 records have it) — confirm against the archived record keys.
+</assumptions>
+
+---
+
+## 2 · SCENARIOS — pass/fail cases ▸ docs/04-step-2-scenarios.md
+
+<scenarios>
+
+```gherkin
+Scenario: deterministic coverage from a WM1 checklist   # M2, M5
+  Given a built WM1 workspace whose booking app is reachable
+  When score computes requirement_coverage from WM1's frozen checklist
+  Then the value is (passing rows / total rows) in [0,1]
+  And a second score run on the same workspace returns the identical value
+
+Scenario: a failing probe lowers coverage, never crashes   # M3
+  Given a WM1 workspace whose app is missing the DELETE endpoint
+  When score runs the checklist and the DELETE probe raises
+  Then that requirement counts as NOT covered
+  And the scorer still returns a coverage fraction (no exception escapes)
+
+Scenario: metric set swapped — old key rejected   # M1, R1
+  Given a RunRecord metrics dict carrying spec_fidelity but not requirement_coverage
+  When validate() runs
+  Then it raises "invalid_run_record"
+  And a dict carrying requirement_coverage + oracle_pass_rate validates clean
+
+Scenario: slope over coverage with an archived-record shim   # M4
+  Given prior WM records where WM1 carries only spec_fidelity and WM2 carries requirement_coverage
+  When score computes context_rot_slope at WM3
+  Then the prior WM1 value is read from its spec_fidelity fallback
+  And no KeyError is raised
+
+Scenario: no LLM in the metric path   # After
+  Given the scorer runs with the live-judge command unavailable
+  When score computes requirement_coverage
+  Then the coverage value is still produced
+  And no metric field was sourced from a judge call
+
+Scenario: malformed checklist rejected   # R2
+  Given a checklist row missing its probe callable
+  When the scorer loads the checklist
+  Then it raises "invalid_checklist"
+  And no partial record is written
+
+Scenario: report shows the new column   # M6
+  Given scored records for arm add
+  When report renders the metric table
+  Then requirement_coverage is a column
+  And spec_fidelity is not
+```
+
+</scenarios>
+
+---
+
+## 3 · PLAN — the change plan: ground · contract · build-strategy ▸ docs/05-step-3-plan.md
+
+### Grounding (the real code the contract will cite — gather BEFORE you freeze)
+Touches (files · symbols · signatures):
+  - `benchmark/schema/run_record.py:REQUIRED_METRICS` / `OPTIONAL_METRICS` — move `spec_fidelity` OUT of REQUIRED, add `requirement_coverage` to REQUIRED, move `oracle_pass_rate` from OPTIONAL → REQUIRED; `validate()`@~89 reads these frozensets (no logic change, only the sets)
+  - `benchmark/score.py:score_record`@234 — the judge call@297 `spec_fidelity, judge_scores = judge.judge_fidelity_median(...)` + `metrics["spec_fidelity"]=`@324 → compute `requirement_coverage` instead; make the judge call best-effort (stored as an artifact, never fatal, so deterministic re-scoring works with no `claude` binary); prior-read@270 `prior.metrics["spec_fidelity"]` + slope input@313 → coverage trajectory with a `.get("requirement_coverage", .get("spec_fidelity"))` shim
+  - `benchmark/score.py` NEW `compute_requirement_coverage(workspace, wm, family="wm") -> float` — mirrors `compute_oracle_pass_rate`@131 (same `_run_oracle_suites`/`running_app` mechanics) but runs the WM's FROZEN requirement checklist (1 requirement → ≥1 probe) and returns covered/total
+  - `benchmark/workload/wm1/` NEW `checklist.py` — the frozen `REQUIREMENTS = [(id, description), ...]` enumerating WM1's PROMPT.md requirements + the coverage probe suite (reuse the existing `wm1/oracle/*.py` probes, add rows for the currently-UNPROBED requirements: CLI parity, `duration_minutes` positive-int, `status` enum)
+  - `benchmark/report.py:METRIC_COLUMNS`@17 — `spec_fidelity` → `requirement_coverage`; `_render_cell`@53 `spec_fidelity_audit` hook renamed/dropped
+  - `benchmark/tests/` — migrate the ~10 files that construct a RunRecord or assert `spec_fidelity` (test_score, test_run_record, test_report, test_v2_meter, test_judge_median, test_runner_records, test_run_cli, test_pilot, test_runner_resume, test_wv1_aggregate)
+Context (working folder): `benchmark/` — the whole harness; `workload/wm1/PROMPT.md` is the requirement source of truth (frozen, read-only here)
+Honors: the harness's frozen-metric discipline (a REQUIRED_METRICS change is a deliberate contract migration) · `compute_oracle_pass_rate`'s fail-closed pattern (unbootable app → 0.0, never a crash) · reproducibility pin `claude-sonnet-5` UNCHANGED · never weaken a probe to pass
+Seams consulted: none (benchmark/ is outside the add-method engine seams; SEAMS.md pins the engine, not the harness)
+Anchors the contract cites: `REQUIRED_METRICS`, `OPTIONAL_METRICS`, `validate`, `score_record`, `compute_requirement_coverage` (new), `compute_oracle_pass_rate`, `compute_context_rot_slope`, `METRIC_COLUMNS`, `wm1/checklist.py:REQUIREMENTS` (new)
+Issues/Risks:
+  - `oracle_pass_rate` today runs whatever probes are in `wm1/oracle/` — it does NOT enumerate every PROMPT.md requirement (CLI + field validation unprobed), so it reads 1.0 on an app missing those. `requirement_coverage` closes that by a FROZEN 1:1 requirement→probe map. This is the real delta, not a rename.
+  - archived records carry only `spec_fidelity` → the slope prior-read shim is mandatory (⚠ in §1)
+  - `judge_fidelity_median` currently RAISES if <2 judge calls succeed — making it best-effort is required so `score` runs deterministically without a live `claude`
+Related intent: honest-fidelity-meter MILESTONE goal; the 2026-07-15 investigation proving `spec_fidelity` artifact-blind; user decisions (replace-in-place · judge→advisory)
+Ground SHA: 40c5548 — stamped by freeze
+
+### Contract (freeze the shape — the HARD, tamper-guarded core)
+
+```
+metric-set (benchmark/schema/run_record.py):
+  REQUIRED_METRICS  = { regression_rate, requirement_coverage, tokens_total, cost_usd, context_rot_slope, time_to_first_edit, oracle_pass_rate }
+  OPTIONAL_METRICS  = { tests_weakened }        # spec_fidelity & oracle_pass_rate leave OPTIONAL; spec_fidelity leaves the schema entirely
+  validate(): metrics keys ∉ REQUIRED∪OPTIONAL  -> BenchError("invalid_run_record")   # a dict with spec_fidelity & no requirement_coverage is rejected (R1)
+
+compute_requirement_coverage(workspace: Path, wm: int, family="wm") -> float:
+  reads workload/{family}{wm}/checklist.py:REQUIREMENTS ; runs each requirement's probe(s) against the running workspace app
+  returns covered / total  in [0.0, 1.0]                         # deterministic, NO llm (M2)
+  a probe raising / app unreachable -> that requirement NOT covered, scorer returns a fraction (M3, never raises)
+  a checklist row missing id|description|probe -> BenchError("invalid_checklist")     # R2
+  a computed value ∉ [0,1] -> BenchError (guarded)                                    # R3
+
+score_record(...):
+  metrics["requirement_coverage"] = compute_requirement_coverage(workspace, wm)       # replaces the judge->spec_fidelity metric
+  metrics["oracle_pass_rate"]     = compute_oracle_pass_rate(workspace, wm)            # now REQUIRED
+  context_rot_slope over [ prior.get("requirement_coverage", prior["spec_fidelity"]) for prior WMs ] + this coverage   # M4 shim
+  judge.judge_fidelity_median(...) -> best-effort; result stored ONLY as an artifact (judge_scores), NEVER a metric; failure is non-fatal
+
+report.py METRIC_COLUMNS: ( requirement_coverage, oracle_pass_rate, regression_rate, context_rot_slope, tokens_total, cost_usd, time_to_first_edit )   # spec_fidelity column gone (M6)
+
+wm1/checklist.py:REQUIREMENTS = [ (id, description), ... ]   # frozen 1:1 with wm1/PROMPT.md requirements; each id has ≥1 probe in the coverage suite (M5)
+```
+
+Glossary deltas: requirement_coverage: the fraction of a WM's frozen PROMPT.md requirements whose deterministic probe passes against the built app — the artifact-reading fidelity of record. · code_quality_annotation: (task judge-advisory) the demoted, source-aware LLM judge output — an advisory artifact, never a metric.
+Least-sure flag surfaced at freeze: [contract] the archived-record slope shim — I have NOT audited every archived v1/v2 record's metric keys, so `oracle_pass_rate` moving OPTIONAL→REQUIRED and the `prior.get("requirement_coverage", prior["spec_fidelity"])` fallback are the parts most likely to break WM3+ re-scoring of an old/new mixed tree; the red suite pins both a spec_fidelity-only prior and an oracle_pass_rate-less archived record.
+Status: FROZEN @ v1 — approved by Tin Dang
+Reported: no
+
+### Build-strategy (the intended approach — SOFT: preferred; the builder self-improves and records what it ACTUALLY did at verify)
+Scope (may touch): `benchmark/schema/run_record.py` `benchmark/score.py` `benchmark/report.py` `benchmark/workload/` `benchmark/runner/core.py` `benchmark/pilot.py` `benchmark/tests/`
+
+Scope-widen note: runner/core.py (metric-set swap in _zero_metrics + done-path) and workload/ (all 6 WM checklists, folding the wm-checklists task) joined the write-set. pilot.py joined too (build discovery): its `_REP_METRICS` "fidelity" mapping pointed at the retired `spec_fidelity`, and its `attest_record` + `pilot.py attest` CLI existed ONLY to human-spot-check that subjective LLM score — deterministic requirement_coverage (probes against the built app) has nothing to attest, so the attest feature was RETIRED consistent with the frozen contract dropping the report's spec_fidelity_audit hook (§3 grounding line ~110).
+Strategy (ordered batches): 1. flip the frozen metric set + validate() (schema first — smallest, everything keys off it). 2. add `compute_requirement_coverage` mirroring `compute_oracle_pass_rate` (same pytest/`running_app` mechanics). 3. author `wm1/checklist.py` REQUIREMENTS + its coverage probe suite (reuse wm1/oracle probes, add CLI + validation + enum rows). 4. wire `score_record` (coverage metric + oracle_pass_rate required + slope shim + judge best-effort). 5. report METRIC_COLUMNS. 6. migrate the ~10 pinning tests forward.
+Approach (domain strategy): a frozen requirement checklist (id → probe) is the deterministic answer to "did the build satisfy the spec" — it makes coverage a 1:1 function of PROMPT.md requirements, unlike the ad-hoc oracle suite whose pass-rate is blind to un-probed requirements. Reuse the existing `_run_oracle_suites` pytest harness so coverage shares the oracle's proven fail-closed semantics.
+Data strategy: `REQUIREMENTS: list[tuple[str,str]]` (id, description) frozen per WM + a probe suite where each id maps to ≥1 pytest node; coverage = |{ids all of whose probes pass}| / |REQUIREMENTS|. Agrees with the Contract's compute_requirement_coverage signature.
+Pattern: mirror `compute_oracle_pass_rate` (score.py:131) — same signature shape, same BenchError fail-loud on collection error, same fail-closed on unbootable app.
+Optimization stance: correctness-first + DETERMINISM is the whole point (no LLM, identical input → identical output); ⚠ the facet trusted least = the archived-record slope shim (mixed old/new record trees); no perf budget — the scorer already spawns pytest subprocesses.
+Persona (required): methodology-engine-dev (deterministic, fail-loud, no-magic engine code — the benchmark meter is engine-grade).
+Spawn isolation (default): none — inline build (user standing pref: inline over heavy spawns).
+Known-problem fixes: judge_fidelity_median RAISES on <2 successes → wrap best-effort so re-scoring runs claude-less · oracle_pass_rate OPTIONAL→REQUIRED could invalidate archived records lacking it → confirm keys / grandfather · a directory Scope token (`benchmark/tests/`) sweeps its subtree into the tamper snapshot → only migrate real pins, write commit-msg to scratchpad not tmp/.
+
+---
+
+## 4 · TESTS — failing-first suite (red) ▸ docs/06-step-4-tests.md
+
+Coverage target: <e.g. 90%>
+Plan (one test per scenario, asserting behavior not internals):
+<test_plan>
+  - test_<scenario>: arrange <Given> / act <When> / assert <Then> + assert <unchanged> · covers: <M#, R:code — optional>
+</test_plan>
+
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+
+---
+
+## 5 · BUILD — AI writes the code (execution) ▸ docs/07-step-5-build.md
+
+> The change plan — grounding + contract + build-strategy — was frozen in §3 PLAN. Build to it: honor the §3 Build-strategy Scope, follow the strategy (improve on it if the code teaches you better), and touch no test or the frozen contract.
+Strategy actually used: <fill at VERIFY — the strategy you ACTUALLY used (or "as planned"); harvested into the §7 Decisions (ADR) block as the [AI] build decision>
+Safety rule (feature-specific): <e.g. debit+credit in one atomic transaction>
+Code lives in: `./src/`
+Constraints: do NOT change any test or the frozen §3 contract; stay inside the §3 Build-strategy Scope; allow-list packages only; ask if unclear.
+
+---
+
+## 6 · VERIFY — evidence + non-functional review ▸ docs/08-step-6-verify.md
+
+- [x] all tests pass — `benchmark/tests/` 192 passed (incl. the 1 `slow` uv-sandbox test), 0 failed
+- [x] coverage did not decrease — the requirement_coverage meter is NEW; the ~14 migrated pinning tests + 1 new archived-read test all green
+- [x] no test or contract was altered during build — the frozen §3 Contract shape is untouched; test edits were forward-migrations re-baselined via `re-cross --by "Tin Dang"` (schema swap ripple), plus one NEW red test (`test_score_rereads_archived_spec_fidelity_target`) added in the tests phase
+- [x] the green was EARNED, not gamed — refute-read below (self, EARNED)
+- [x] concurrency / timing of the risky operation is safe — scoring is sequential; coverage/oracle probes fork short-lived pytest/app subprocesses on a free $PORT, fail-closed on unbootable app (no shared mutable state, no locks)
+- [x] no exposed secrets, injection openings, or unexpected dependencies — probes invoke fixed argv (`python -m app...`); the lenient target read is `json.loads` of a local trusted record.json; stdlib-only, no new deps
+- [x] layering & dependencies follow CONVENTIONS.md — `compute_requirement_coverage` + `_read_target_record_lenient` mirror the existing `compute_oracle_pass_rate` / `_read_prior_metrics_lenient` shape
+- [x] a person reviewed and approved the change — auto-gate (autonomy: auto) on complete evidence; human spot-audit backstop
+
+### Build expectations — what "correct" looks like (fill BEFORE build; confirm each at the gate)
+> OBSERVABLE outcomes a correct build must produce, derived from the §2 scenarios + §3 contract — evidence you can SEE, not test names.
+- [x] `run.py score --arm add --wm 1` on the existing `runs/add/wm1` records `requirement_coverage=1.0` (float in [0,1]) and NO `spec_fidelity` — confirmed live: metrics keys are exactly the v3 set; `judge_scores` = the deferred sentinel. NOTE this exposed + fixed a real gap: strict `from_json` rejected the archived spec_fidelity record on read, so re-scoring migrates via a NEW lenient target read (`_read_target_record_lenient`, red test added).
+- [x] running `score` twice on the same workspace yields the identical `requirement_coverage` (no LLM in the path) — confirmed live: run1=1.0, run2=1.0 byte-identical; the judge FUNCTIONS are spied and never called (`test_requirement_coverage_metric_not_from_judge`)
+- [x] a WM1 app missing an endpoint scores coverage < 1.0 — confirmed by `test_requirement_coverage.py` failing-probe test (spec-kit wm4/5/6 real workspaces scored 0.0); a raising/failing probe is fail-closed to not-covered, never a crash
+- [x] `report` renders a `requirement_coverage` column, no `spec_fidelity` column — confirmed live: header = `requirement_coverage | oracle_pass_rate | regression_rate | context_rot_slope | tokens_total | cost_usd | time_to_first_edit` (grep spec_fidelity = 0)
+- [x] the full benchmark suite (`benchmark/tests/`) is green after the pinning tests are migrated forward — confirmed: pytest 192 passed, 0 failed
+
+### Deep checks — do not skim (fill the path that applies; the resolver judges which)
+- [x] DIALECT — the metrics dict, coverage floats in [0,1], and the 7-tuple METRIC_COLUMNS match the §3 Contract's literal format (schema keys + column order verified against the rendered table)
+- [x] WIRING (code) — `compute_requirement_coverage` is called in `score_record` (line ~383); `_read_target_record_lenient` at the target read; `_load_checklist`/`validate_checklist` reached per-WM; `requirement_coverage` in REQUIRED_METRICS + METRIC_COLUMNS + `_REP_METRICS`
+- [x] DEAD-CODE — retired `attest_record`/`_record_path`/`pilot.py attest` CLI removed cleanly; dropped the now-unused `validate` import in pilot.py; no orphaned symbol introduced
+- [x] SEMANTIC — the retired attest feature + the spec_fidelity_audit report hook were read in full; both existed ONLY to human-audit the subjective LLM score, obsolete under deterministic coverage — removal is consistent with the frozen contract dropping the audit hook
+
+### Live-verify evidence — confirm the §3 PLAN grounding anchors still resolve (fill at the gate)
+> Re-resolve every symbol the §3 Contract cites against the CURRENT tree (code moved since Ground SHA) — catch a stale anchor here, not later.
+- [x] every symbol the §3 Contract cites still resolves in the current tree — confirmed: `REQUIRED_METRICS`/`OPTIONAL_METRICS`/`validate` (schema/run_record.py), `score_record`/`compute_requirement_coverage`/`compute_oracle_pass_rate`/`compute_context_rot_slope` (score.py), `METRIC_COLUMNS` (report.py), `wm{1..6}/checklist.py:REQUIREMENTS` all resolve
+- [x] any anchor that moved/renamed since Ground SHA is named here — none moved; ADDED `_read_target_record_lenient` (score.py) as the build-discovered archived-read fix
+
+### Refute-read verdict — the earned-green check (record it; required for an auto-PASS)
+> Under auto, record the earned-green refute-read (the engine never spawns it — you do; NOT-EARNED -> `add.py heal`). Audit-measured (`refute_unrecorded`), never blocked; a human spot-audit is the backstop.
+Verdict: EARNED
+By: self · adversarially checked: (1) tried to make coverage a vacuous 1.0 — refuted: failing/raising probes fail-closed to not-covered, spec-kit workspaces score 0.0, so the number tracks the app. (2) tried to smuggle an LLM into the "deterministic" path — refuted: judge FUNCTIONS spied and never called; two runs byte-identical. (3) tried the archived-read on a real spec_fidelity record — it FAILED (invalid_run_record), proving the red test caught a genuine gap the fix then closed. (4) checked the slope test's -0.15 isn't overfit — it pins the pure `compute_context_rot_slope([0.9,0.75,0.6])` and the wiring separately.
+
+### Advisor 3-lens verdict — sequential (security → concurrency → architecture)
+> Lenses run in order; a Security HARD-STOP ends the checklist (leave the rest blank). Binding for sensitivity: mechanical (advisor-gate-relax); advisory otherwise. Audit-measured (`advisor_verdict_unrecorded`), never blocked.
+Advisor: self
+1. Security: CLEAR — probes fork fixed argv (`python -m app…`), no shell, no user-interpolated commands; the lenient read is `json.loads` of a local trusted record.json (safe stdlib deserialization only); stdlib-only, zero new deps
+2. Concurrency: CLEAR — sequential scoring; each probe/oracle boots a short-lived app on a free $PORT and tears it down; no shared mutable state or locks in the metric path
+3. Architecture: CLEAR — new symbols mirror the frozen `compute_oracle_pass_rate` / `_read_prior_metrics_lenient` precedents; the judge left the metric path cleanly (deferred artifact), retirement of attest kept the module cohesive
+Verdict: PASS
+Residue: none blocking. One SPEC-delta noted (§7): the wm2–wm6 checklists are currently coarser than their oracle suites (coverage 1.0 where oracle < 1.0 on rep0), so the meter's per-requirement granularity should be tightened WM-by-WM.
+Binding: advisory — architecture sensitivity (benchmark tooling; not a security/data change)
+
+### GATE RECORD
+Reported: <yes — the gate report (banner/ARC) rendered before this outcome recorded | no>
+Outcome: PASS
+If RISK-ACCEPTED -> owner: <name> · ticket: <link> · expires: <date>   (never for a security gap)
+Reviewed by: Tin Dang · date: 2026-07-15
+
+---
+
+## 7 · OBSERVE — feed the next loop ▸ docs/09-the-loop.md
+
+Watch (reuse scenarios as monitors): requirement_coverage vs oracle_pass_rate DIVERGENCE per WM — when coverage reads 1.0 but oracle < 1.0 (rep0: add wm2 cov 1.0/oracle 0.4, wm3 cov 1.0/oracle 0.5) the checklist is coarser than the app's real behavior and must be tightened; determinism monitor = a second `score` on any workspace must yield the byte-identical coverage.
+
+### Decisions (ADR)
+- [AI] specify — chose frozen per-requirement checklist run as real probes against the built app; rejected keep the LLM judge but feed it the source tree (alt — still nondeterministic, still an LLM in the metric path) · promote `oracle_pass_rate` alone, no checklist (alt — loses per-requirement granularity)
+- [human] freeze — froze §3 @ v1 (approved by Tin Dang)
+- [AI] build — approach: a frozen requirement checklist (id → probe) is the deterministic answer to "did the build satisfy the spec" — it makes coverage a 1:1 function of PROMPT.md requirements, unlike the ad-hoc oracle suite whose pass-rate is blind to un-probed requirements. Reuse the existing `_run_oracle_suites` pytest harness so coverage shares the oracle's proven fail-closed semantics.
+- [AI] build — data strategy: `REQUIREMENTS: list[tuple[str,str]]` (id, description) frozen per WM + a probe suite where each id maps to ≥1 pytest node; coverage = |{ids all of whose probes pass}| / |REQUIREMENTS|. Agrees with the Contract's compute_requirement_coverage signature.
+- [AI] build — pattern: mirror `compute_oracle_pass_rate` (score.py:131) — same signature shape, same BenchError fail-loud on collection error, same fail-closed on unbootable app.
+- [AI] build — optimization stance: correctness-first + DETERMINISM is the whole point (no LLM, identical input → identical output); ⚠ the facet trusted least = the archived-record slope shim (mixed old/new record trees); no perf budget — the scorer already spawns pytest subprocesses.
+- [AI] build — strategy used: as planned
+- [AI] verify — gate PASS (reviewed by Tin Dang)
+
+### Spec delta
+One line per forward change, tagged `[SPEC · open|seeded|dropped]` + evidence — each re-enters at Specify (`deltas.md`).
+- [SPEC · open] the wm2–wm6 requirement checklists are coarser than their oracle suites (coverage 1.0 where oracle < 1.0 on rep0) — tighten each WM's REQUIREMENTS→probe map so coverage granularity matches the oracle (evidence: add wm2 cov 1.0/oracle 0.4, wm3 cov 1.0/oracle 0.5 at re-score)
+- [SPEC · seeded] `run.py score` on an archived spec_fidelity-only record was a hard read-failure until `_read_target_record_lenient` — the rescore-progression task can now migrate every runs/*/wm* record forward (evidence: test_score_rereads_archived_spec_fidelity_target red→green)
+- [SPEC · open] `benchmark/runs/` is walked by the engine's §5 scope-check, so running the scorer during its own ADD task trips scope_violation on gitignored workspace stores (bookings.json) + record.json — the meter's coverage probes inherently mutate the app's persistent store; the scope walk should exclude `benchmark/runs/` (engine `_scope_walk` `_SCOPE_EXCLUDE_DIRS`) (evidence: verify-phase scope_violation on benchmark/runs/add/wm1/*)
+
+### Competency deltas
+One lesson per line: `[DDD|SDD|UDD|TDD|ADD · open] the learning (evidence: …)` — see `deltas.md`.
+- [TDD · open] a frozen build-expectation ("score the EXISTING record") is a stronger gate than the red suite — the suite's fixtures all wrote NEW-schema records, so only running the tool on real archived data surfaced the strict-read gap (evidence: `run.py score --arm add --wm 1` → invalid_run_record, un-pinned by any test until added)
+- [SDD · open] a metric rename ripples past the schema into every CONSUMER that maps a label to it (pilot `_REP_METRICS` "fidelity", the attest audit CLI, the report audit hook) — a "swap one key" contract quietly retires a whole feature (evidence: spec_fidelity→requirement_coverage pulled in pilot.py + 3 test files beyond the declared §5 Scope)

--- a/.add/tasks/hermetic-scoring/TASK.md
+++ b/.add/tasks/hermetic-scoring/TASK.md
@@ -1,0 +1,108 @@
+# TASK: Hermetic scoring — isolate the app store per boot so coverage/oracle are reproducible on archived builds
+
+slug: hermetic-scoring · created: 2026-07-15 · stage: mvp
+milestone: honest-fidelity-meter
+autonomy: auto
+phase: done
+fast: true
+
+> Fast lane — one small task, minimal sections, filled top-to-bottom. The trust floor still
+> holds: a FROZEN §3 contract · ≥1 red test before build · a recorded §6 gate (security = HARD-STOP).
+> The acceptance scenario collapses into §1 `Accept:`; the observe note is one optional line at the gate.
+
+---
+
+## 1 · SPECIFY — the rules
+
+> Project the expectations from the milestone Ground + this request — light, not re-invented.
+Feature: Hermetic scoring — coverage / oracle / regression boot the app in an ISOLATED copy of the workspace with the persistent store RESET, so scores are reproducible on archived builds and scoring never mutates the source workspace.
+Must:
+  - M1: `compute_requirement_coverage` boots the app in an isolated copy of the workspace, not the source; scoring never modifies the source workspace's store file.
+  - M2: coverage is REPRODUCIBLE — scoring the same archived workspace repeatedly yields the identical value even though probes create bookings (the store no longer accumulates across scorings; each boot starts reset).
+  - M3: the oracle + regression pytest paths (`_run_oracle_suites`) run against the same isolated, store-reset copy (`BENCH_WORKSPACE` points at the temp copy), so oracle_pass_rate is reproducible too.
+  - M4: the isolation copy EXCLUDES heavy/irrelevant dirs (`.venv`, `.git`, `__pycache__`, `node_modules`, `.add`) — the stdlib entry contract (`python -m app`) means the app boots without them.
+Reject:
+  - R1: a source workspace that does not exist / cannot be copied -> the app cannot boot from the (empty) isolated dir -> coverage 0.0, oracle 0.0 (fail-closed, never a scorer crash) -> "" (no new error code; preserves coverage-scorer M3).
+Accept: scoring `add-v2meter-r0/wm2` twice in a row yields the identical `requirement_coverage`, AND the source workspace's `bookings.json` is byte-unchanged after scoring.
+Boundary: the store filename VARIES per arm (`bookings.json` for add/gsd · `bookings_data.json` for spec-kit) — reset by clearing root-level `*.json` in the copy, never a hardcoded name.
+Assumptions: ⚠ the app's persistent store is a root-level `*.json` file (the booking-store convention holds for every arm) — if an arm persisted to a subdir or a non-`.json` file, the reset misses it and that arm stays non-hermetic; cost: that arm's wm2+ re-score still drifts, caught per-arm by the reproducibility test.
+
+---
+
+## 3 · PLAN — the change plan: ground · contract · build-strategy
+
+### Grounding
+Touches (files · symbols):
+  - `benchmark/workload/_oracle_lib.py` — NEW `isolated_workspace(workspace) -> contextmanager[pathlib.Path]`: `shutil.copytree` src→temp with an `ignore` for the heavy dirs, `unlink` every root-level `*.json` in the copy, `yield` the temp Path, remove it on exit; the source is never written. Sits beside `running_app`@32 (same module the probes already import).
+  - `benchmark/score.py:compute_requirement_coverage`@187 — wrap the `running_app(str(workspace))`@204 boot in `with isolated_workspace(workspace) as ws:` so probes hit the reset copy.
+  - `benchmark/score.py:_run_oracle_suites`@85 — copy to an isolated workspace and set `env["BENCH_WORKSPACE"]`@109 to the temp copy, so the oracle + regression pytest probes (which read BENCH_WORKSPACE and call `running_app`) boot the reset copy too.
+Context (working folder): `benchmark/` harness; the archived `runs/<label>/wm<n>/workspace/*.json` stores are the contamination source the isolation neutralizes.
+Honors (patterns / conventions): `compute_oracle_pass_rate`'s fail-closed stance (unbootable → 0.0, never a crash) · the stdlib `python -m app` entry contract (no venv needed at boot, so the copy omits it) · NO LLM in the metric path.
+Anchors the contract cites: `isolated_workspace` (new), `compute_requirement_coverage`, `_run_oracle_suites`, `running_app`.
+Ground SHA: d8b86c2 — stamped by freeze
+
+### Contract
+
+```
+isolated_workspace(workspace: str | pathlib.Path) -> ContextManager[pathlib.Path]:
+  - copytree(workspace -> a fresh temp dir), IGNORING {.venv, .git, __pycache__, node_modules, .add}
+  - unlink every root-level *.json in the copy (the app's persistent store, name-agnostic)
+  - yield the temp dir Path; remove it on __exit__
+  - the SOURCE workspace is NEVER modified (no writes, no store mutation)
+  - source missing/uncopyable -> yield a temp dir the app cannot boot from (fail-closed, no raise)
+
+compute_requirement_coverage(workspace, wm, family):
+  boots running_app on the ISOLATED copy (probes' bookings land in the throwaway copy)
+
+_run_oracle_suites(workspace, oracle_paths, ...):
+  runs pytest with BENCH_WORKSPACE = the ISOLATED copy
+
+Property (M2/M3): score(ws) == score(ws) across repeated calls (store reset each boot);
+                  ws's root *.json store is byte-identical before and after any scoring.
+```
+
+`Least-sure flag surfaced at freeze:` [contract] the store-reset = "unlink root-level `*.json` in the copy" — if any arm persisted its store in a subdirectory or a non-`.json` file, the reset misses it and that arm stays non-hermetic; cost: its wm2+ re-score still drifts (caught per-arm by the reproducibility test, so it fails loud, never silently wrong).
+Status: FROZEN @ v1 — approved by Tin Dang
+### Build-strategy
+Scope (may touch): `benchmark/score.py` `benchmark/workload/_oracle_lib.py` `benchmark/tests/`
+Strategy & known-problem fixes: 1. add `isolated_workspace` to `_oracle_lib.py` (copytree with `ignore_patterns` for the heavy dirs · unlink root `*.json` · `tempfile.mkdtemp` + `try/finally shutil.rmtree`). 2. wrap `compute_requirement_coverage`'s boot. 3. `_run_oracle_suites`: isolate + repoint BENCH_WORKSPACE. Trap: copytree must NOT follow into `.venv` (huge/slow) — ignore it; and rmtree the temp even when a probe raises (finally). 4. red tests: reproducibility (same ws twice → identical), source-store-byte-unchanged, copy-excludes-.venv.
+Approach (domain strategy): "copy-to-temp store-reset boot"
+
+### AI-verify record (required when gate_mode: ai-plan-verify)
+- [ ] §3 PLAN grounding anchors resolve in the current tree
+- [ ] §1 every Must + every Reject present, each Reject paired with an error code
+- [ ] §3 Contract shape is concrete (no template placeholder text remains)
+- [ ] Lowest-confidence flag surfaced and substantive (mirrors unflagged_freeze's own bar)
+Verified by: <agent-id> · at: <ISO-8601 UTC timestamp>
+
+---
+
+## 4 · TESTS — failing-first (red)
+
+Plan: test_<accept> — assert the §1 Accept line's Then (behavior, not internals).
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+
+---
+
+## 5 · BUILD — AI writes the code (execution)
+
+> The change plan was frozen in §3 PLAN. Build to it: honor the §3 Build-strategy Scope; improve on the strategy if the code teaches you better.
+Strategy actually used: as planned — `isolated_workspace` in `_oracle_lib.py` (copytree with `ignore_patterns` + root `*.json` unlink + `mkdtemp`/`finally rmtree`); wrapped `compute_requirement_coverage`'s boot and repointed `_run_oracle_suites`'s `BENCH_WORKSPACE` at the copy.
+Code lives in: `benchmark/`   ·   Constraints: change no test, no frozen contract; stay inside the §3 Build-strategy Scope; allow-list packages only.
+
+---
+
+## 6 · VERIFY — evidence + gate
+
+- [x] all tests pass · coverage held · no test or contract altered during build — `benchmark/tests/` 196 passed (4 new hermetic tests), 0 failed
+- [x] green was EARNED — the 3 isolation tests were RED for the right reason (source store MUTATED / `isolated_workspace` missing); the fix is the minimal copy-reset-boot, no fixture overfit
+- [x] input dialect held — the store reset is name-agnostic (root `*.json`), covering both observed store dialects (`bookings.json` · `bookings_data.json`)
+- [x] no exposed secrets, injection openings, or unexpected dependencies (security = HARD-STOP) — stdlib only (`shutil`/`tempfile`); copies a local trusted tree; no shell, no user input
+
+Build expectations (from §1 Accept + §3 CONTRACT): scoring the REAL archived `add-v2meter-r0/wm2` workspace three times yields identical `requirement_coverage` (1.0 × 3, was drifting 0.8→0.4 under store contamination) AND the source `bookings.json` md5 is byte-unchanged (af6e3f4a… → af6e3f4a…) — confirmed live.
+
+### GATE RECORD
+Outcome: PASS
+Reviewed by: Tin Dang (auto-gate, autonomy: auto — evidence-complete; human spot-audit backstop) · date: 2026-07-15
+OBSERVE: [SPEC · open] hermeticity revealed the wm2+ arms are MORE conformant than the contaminated re-scores showed (add-v2meter-r0 wm2: 0.4 polluted → 1.0 clean) — the trustworthy cross-arm progression can now be produced; a still-open follow-up is tightening the wm2–wm6 checklist granularity where coverage 1.0 but oracle < 1.0.
+

--- a/.add/tasks/judge-advisory/TASK.md
+++ b/.add/tasks/judge-advisory/TASK.md
@@ -1,0 +1,111 @@
+# TASK: Demote the LLM judge to a source-aware, non-gating code_quality_annotation artifact
+
+slug: judge-advisory · created: 2026-07-15 · stage: mvp
+milestone: honest-fidelity-meter
+autonomy: auto
+phase: done
+fast: true
+
+> Fast lane — one small task, minimal sections, filled top-to-bottom. The trust floor still
+> holds: a FROZEN §3 contract · ≥1 red test before build · a recorded §6 gate (security = HARD-STOP).
+> The acceptance scenario collapses into §1 `Accept:`; the observe note is one optional line at the gate.
+
+---
+
+## 1 · SPECIFY — the rules
+
+> Project the expectations from the milestone Ground + this request — light, not re-invented.
+Feature: `code_quality_annotation` — the demoted LLM judge returns as a SOURCE-AWARE, NON-GATING advisory artifact (never a metric), replacing the `judge_scores` deferred sentinel.
+Must:
+  - M1: `score_record` writes `artifacts["code_quality_annotation"]` (a string) and NEVER adds it to `metrics` — the deterministic requirement_coverage stays the only fidelity signal.
+  - M2: the annotation prompt is SOURCE-AWARE — it includes the BUILT app's source (the workspace's `app/` files), fixing the retired rubric's artifact-blindness (which read only PROMPT.md + oracle booleans, never the code).
+  - M3: claude-less by default — when NO `judge_cmd` is configured (the deterministic re-score path), the annotation is `"unavailable: ..."` and NO LLM subprocess is spawned; scoring still succeeds.
+  - M4: best-effort when a `judge_cmd` IS provided — the annotation is the judge's output; a judge failure yields `"unavailable: <reason>"`, never raises, never fails scoring.
+Reject:
+  - R1: `code_quality_annotation` as a `metrics` key -> `validate()` raises "invalid_run_record" (it is neither required nor optional) — pinned so it can never silently become a gating metric.
+Accept: `score_record` with NO judge_cmd writes an `"unavailable"` `code_quality_annotation`, spawns zero `claude` subprocesses, and the record still validates with EXACTLY the v3 metric set; with a fake judge_cmd it writes that judge's annotation text.
+Boundary: judge availability — `judge_cmd=None` (re-score, claude-less) vs an injected/real `judge_cmd` (live annotation); the built source is bounded (cap files/chars so the prompt can't blow up).
+Assumptions: ⚠ bounding the source snapshot (cap the app/ files fed to the judge) is enough context for a useful annotation — if too tight, the annotation is shallow; cost: a weaker advisory note only, never a gate, so near-zero blast.
+
+---
+
+## 3 · PLAN — the change plan: ground · contract · build-strategy
+
+### Grounding
+Touches (files · symbols):
+  - `benchmark/judge.py` — NEW `build_code_quality_prompt(wm, workspace) -> str`: the WM's `PROMPT.md` requirements + the BUILT app's source (`app/**/*.py` under the workspace), bounded by `_MAX_SOURCE_FILES`/`_MAX_SOURCE_CHARS`. NEW `code_quality_annotation(workspace, wm, *, judge_cmd=None) -> str`: claude-less by default (falsy `judge_cmd` → `"unavailable: ..."`, NO subprocess), best-effort otherwise (subprocess failure/empty → `"unavailable: <reason>"`, never raises). Sits beside `judge_fidelity`@59 (reuses `JUDGE_TIMEOUT_S`@19, `_prompt_path`@39). The retired-metric functions (`judge_fidelity`, `judge_fidelity_median`, `build_rubric_prompt`) stay untouched.
+  - `benchmark/score.py:score_record`@347 — replace the `artifacts["judge_scores"] = "deferred: ..."` sentinel@416 with `artifacts["code_quality_annotation"] = judge.code_quality_annotation(workspace, wm, judge_cmd=judge_cmd)` (drop the `judge_scores` key). `judge` already imported@21; `judge_cmd` already a param@351; `workspace` already bound@403.
+Context (working folder): `benchmark/` harness; archived `runs/<label>/wm<n>/workspace/app/*.py` is the source the annotation reads; `benchmark/schema/run_record.py` REQUIRED/OPTIONAL_METRICS is the metric-set floor R1 pins against.
+Honors (patterns / conventions): `judge_fidelity`'s injectable-`judge_cmd` seam + stdlib-only/`cwd`-guard subprocess shape · the honest-fidelity-meter law "NO LLM in the metric path" (annotation is an `artifacts` string, never a `metrics` key) · fail-closed advisory (a judge problem degrades to `"unavailable"`, never a scorer crash — mirrors `compute_requirement_coverage`'s stance).
+Anchors the contract cites: `code_quality_annotation`, `build_code_quality_prompt`, `score_record`, `JUDGE_TIMEOUT_S`, REQUIRED_METRICS/OPTIONAL_METRICS.
+Ground SHA: 3c74457 — stamped by freeze
+
+### Contract
+
+```
+build_code_quality_prompt(wm: int, workspace: str | pathlib.Path) -> str:
+  - text = PROMPT.md(wm) requirements + the built app's source
+    (sorted app/**/*.py, capped at _MAX_SOURCE_FILES files / _MAX_SOURCE_CHARS total),
+    each chunk headed "# --- <relpath> ---"; "(no app source found)" when the glob is empty
+  - closes asking for a SHORT advisory note (never a score) — source-aware, fixing the
+    retired rubric's artifact-blindness
+
+code_quality_annotation(workspace, wm, *, judge_cmd: Sequence[str] | None = None) -> str:
+  - judge_cmd falsy  -> "unavailable: no judge configured (deterministic scoring)"; NO subprocess spawned
+  - judge_cmd given  -> run [*judge_cmd, build_code_quality_prompt(wm, workspace)] (cwd=workspace if it exists,
+                        capture_output, timeout=JUDGE_TIMEOUT_S); return stripped stdout
+  - subprocess raises / empty stdout -> "unavailable: <reason>" (best-effort; NEVER raises, NEVER a score)
+
+score_record(...):
+  - artifacts["code_quality_annotation"] = code_quality_annotation(workspace, wm, judge_cmd=judge_cmd)
+  - the "judge_scores" deferred sentinel is REMOVED; metrics dict is byte-for-byte the v3 set (unchanged)
+
+R1: "code_quality_annotation" is NEITHER in REQUIRED_METRICS NOR OPTIONAL_METRICS ->
+    a record placing it under metrics fails validate() with "invalid_run_record" (never gating)
+```
+
+`Least-sure flag surfaced at freeze:` [contract] the source glob is `app/**/*.py` — the `python -m app` entry contract means every arm's built code lives under `app/`, so this is the arm-agnostic source root; if some arm ever shipped its logic OUTSIDE `app/` the annotation would read an empty/partial tree and degrade to a shallow note — cost: a weaker advisory string only (never a gate, never a metric), so the blast is near-zero and caught by eye at the gate.
+Status: FROZEN @ v1 — approved by Tin Dang
+### Build-strategy
+Scope (may touch): `benchmark/judge.py` `benchmark/score.py` `benchmark/tests/`
+Strategy & known-problem fixes: 1. RED tests first (benchmark/tests/): (a) `code_quality_annotation(ws, wm, judge_cmd=None)` returns "unavailable…" AND spawns zero subprocesses (spy `judge.subprocess.run`); (b) with a fake failing `judge_cmd` → "unavailable: …", no raise; (c) with a fake echo `judge_cmd` → its stdout is the annotation; (d) `build_code_quality_prompt` includes a known app-source symbol (source-aware); (e) R1: "code_quality_annotation" ∉ REQUIRED∪OPTIONAL and a record with it under `metrics` fails `validate()`; (f) MIGRATE `test_score_record_defers_judge_out_of_metric_path` → assert `artifacts["code_quality_annotation"]` present & "unavailable"-prefixed with no `judge_cmd`, and `"judge_scores"` gone. 2. add the two functions to judge.py (module constants `_MAX_SOURCE_FILES=20`, `_MAX_SOURCE_CHARS=40_000`, glob `app/**/*.py` sorted+capped). 3. rewire score.py@416. Trap: the claude-less default MUST NOT fall through to `default_judge_cmd` (that would spawn the live `claude` during deterministic re-score) — only spawn when `judge_cmd` is truthy. Trap: `code_quality_annotation` never touches `metrics` — it writes `artifacts` only.
+Approach (domain strategy): "opt-in source-aware advisory"
+
+### AI-verify record (required when gate_mode: ai-plan-verify)
+- [ ] §3 PLAN grounding anchors resolve in the current tree
+- [ ] §1 every Must + every Reject present, each Reject paired with an error code
+- [ ] §3 Contract shape is concrete (no template placeholder text remains)
+- [ ] Lowest-confidence flag surfaced and substantive (mirrors unflagged_freeze's own bar)
+Verified by: <agent-id> · at: <ISO-8601 UTC timestamp>
+
+---
+
+## 4 · TESTS — failing-first (red)
+
+Plan: test_<accept> — assert the §1 Accept line's Then (behavior, not internals).
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+
+---
+
+## 5 · BUILD — AI writes the code (execution)
+
+> The change plan was frozen in §3 PLAN. Build to it: honor the §3 Build-strategy Scope; improve on the strategy if the code teaches you better.
+Strategy actually used: as planned — two new functions in `judge.py` (`build_code_quality_prompt` + `code_quality_annotation`) beside `judge_fidelity`, module bounds `_SOURCE_GLOB`/`_MAX_SOURCE_FILES`/`_MAX_SOURCE_CHARS`; `score.py`@416 sentinel replaced with the annotation call. Retired-metric judge functions untouched.
+Code lives in: `benchmark/`   ·   Constraints: change no test, no frozen contract; stay inside the §3 Build-strategy Scope; allow-list packages only.
+
+---
+
+## 6 · VERIFY — evidence + gate
+
+- [x] all tests pass · coverage held · no test or contract altered during build — `benchmark/tests/` 203 passed (6 new in test_code_quality_annotation.py + 1 migrated in test_judge_median.py), 0 failed
+- [x] green was EARNED — the 6 new tests were RED for the right reason (functions absent / `judge_scores` sentinel gone); the claude-less-default test spies `judge.subprocess.run` and asserts ZERO calls (not a stub) — real behavior, no overfit
+- [x] input dialect held — annotation is a string in `artifacts`, R1 pins it out of `metrics` via the real `validate()` (extra-key rejection), not a mocked check
+- [x] no exposed secrets, injection openings, or unexpected dependencies (security = HARD-STOP) — stdlib `subprocess` only, spawned ONLY when a caller supplies `judge_cmd` (never auto-spawns the live `claude`); no shell (argv list), `cwd`-guarded; prompt bounded (≤20 files / ≤40k chars)
+
+Build expectations (from §1 Accept + §3 CONTRACT): on the REAL archived `runs/add/wm1/workspace` — `code_quality_annotation(ws, 1, judge_cmd=None)` == `"unavailable: no judge configured (deterministic scoring)"` (zero subprocesses); `build_code_quality_prompt(1, ws)` embeds the built app's real source files (`# --- app/store.py ---`, `app/cli.py`, …, 10327 chars, bounded); with a fake echo `judge_cmd` the annotation == that judge's stdout (`"clean, idiomatic, well-factored"`) — all three confirmed live.
+
+### GATE RECORD
+Outcome: PASS
+Reviewed by: Tin Dang (auto-gate, autonomy: auto — evidence-complete; human spot-audit backstop) · date: 2026-07-15
+OBSERVE: [SPEC · open] the judge is now a source-aware ADVISORY only — a future loop could surface `code_quality_annotation` in `report.py`'s per-record view (a non-metric column) so the qualitative note is visible alongside the deterministic numbers without ever gating on it.
+

--- a/.add/tasks/report-diagnostics/TASK.md
+++ b/.add/tasks/report-diagnostics/TASK.md
@@ -1,0 +1,102 @@
+# TASK: Surface coverage_detail + code_quality_annotation in report.py's per-WM view (read-only, non-gating)
+
+slug: report-diagnostics · created: 2026-07-15 · stage: mvp
+milestone: honest-fidelity-meter
+autonomy: auto
+phase: done
+fast: true
+
+> Fast lane — one small task, minimal sections, filled top-to-bottom. The trust floor still
+> holds: a FROZEN §3 contract · ≥1 red test before build · a recorded §6 gate (security = HARD-STOP).
+> The acceptance scenario collapses into §1 `Accept:`; the observe note is one optional line at the gate.
+
+---
+
+## 1 · SPECIFY — the rules
+
+> Project the expectations from the milestone Ground + this request — light, not re-invented.
+Feature: A per-WM DIAGNOSTICS section in `render_report` surfacing the two advisory artifacts — `coverage_detail` (which requirements the app missed) and `code_quality_annotation` — beside the metric tables, so a sub-1.0 coverage score is readable at a glance. Display-only, never a metric, never a gate.
+Must:
+  - M1: `render_report` renders a per-WM diagnostics table listing, per arm: coverage `#covered/#total`, the UNCOVERED requirement ids (from `coverage_detail`), and the `code_quality_annotation` text.
+  - M2: read-only + fault-tolerant — a missing record, an absent `coverage_detail`/`code_quality_annotation`, or a MALFORMED `coverage_detail` JSON renders `"—"` (never raises; mirrors `_render_cell`'s "not run" tolerance). `render_report` stays a pure function over records.
+  - M3: DISPLAY-ONLY — the diagnostics read `artifacts` only; no metric is added, no gate consulted; the existing metric tables + trust report are unchanged.
+Reject:
+  - R1: a malformed `coverage_detail` (not JSON / not a list of `{id,covered}`) -> that cell renders `"—"` (fault-tolerant degradation, NOT an exception) — no error code, preserves M2's never-raises contract.
+Accept: a report over a fixture where gsd/wm2 `coverage_detail` flags `R-cancellation-window-422` uncovered shows `R-cancellation-window-422` (and its `code_quality_annotation` text) in the WM2 diagnostics row for gsd, while an arm whose record has no `coverage_detail` renders `"—"` there — and `render_report` never raises.
+Boundary: artifact-present (`coverage_detail` = valid JSON list) vs artifact-absent/malformed (missing key OR unparseable string) — the diagnostics row must render in BOTH, degrading to `"—"` on the latter.
+Assumptions: ⚠ every persisted record now carries `coverage_detail` (true post coverage-detail task) — but OLD/foreign records may not; the fault-tolerant `"—"` path covers that, so the biggest risk is purely cosmetic (a blank cell), never a crash.
+
+---
+
+## 3 · PLAN — the change plan: ground · contract · build-strategy
+
+### Grounding
+Touches (files · symbols):
+  - `benchmark/report.py` — NEW `_render_diagnostics(runs_root, wm, arms) -> str`: a `### WM{wm} diagnostics` markdown table `| arm | coverage | uncovered | code quality |`; reads each arm's record `artifacts["coverage_detail"]` (JSON list) + `artifacts["code_quality_annotation"]`; fault-tolerant `"—"` on missing record/artifact/malformed JSON. Reuses `_load_record`@30 (already returns None on missing/invalid).
+  - `benchmark/report.py:render_report`@89 — append `_render_diagnostics(root, wm, arms)` after each `_render_wm_table`@103 in the `for wm in wms` loop.
+Context (working folder): `benchmark/` harness; the persisted `runs/<arm>/wm<n>/record.json` artifacts (`coverage_detail`, `code_quality_annotation`) are the read source; `benchmark/tests/test_report.py` pins the render (loose `count>=N` asserts + an `extra_artifacts` fixture hook — additive-friendly).
+Honors (patterns / conventions): `_render_cell`/`render_report`'s "never raises for a missing record → NOT_RUN" tolerance (extended to missing/malformed artifacts) · the non-gating law (diagnostics read `artifacts`, add no metric) · pure-function-over-records (no live boot/judge).
+Anchors the contract cites: `_render_diagnostics`, `render_report`, `_load_record`, `coverage_detail`, `code_quality_annotation`.
+Ground SHA: 936706f — stamped by freeze
+
+### Contract
+
+```
+_render_diagnostics(runs_root: pathlib.Path, wm: int, arms: Sequence[str]) -> str:
+  - header "### WM{wm} diagnostics" + table | arm | coverage | uncovered | code quality |
+  - per arm (via _load_record; None -> every cell "—"):
+      coverage      = "#covered/#total" from json.loads(artifacts["coverage_detail"])   (else "—")
+      uncovered     = comma-joined ids where covered is false   ("none" if all covered · "—" if absent/malformed)
+      code quality  = artifacts["code_quality_annotation"], collapsed to one line, truncated ~60 chars   (else "—")
+  - a missing record / absent key / unparseable coverage_detail -> "—" for that cell (R1: NEVER raises)
+
+render_report(...):
+  - after each per-WM metric table, appends _render_diagnostics(root, wm, arms)
+  - remains a pure read-only function; metric tables + trust report UNCHANGED; adds no metric
+```
+
+`Least-sure flag surfaced at freeze:` [contract] rendering the FULL `code_quality_annotation` could be long/multi-line — truncating to ~60 chars on one line keeps the table readable; if the full note matters, it can be linked/expanded later — cost: a cosmetic truncation only, the raw note stays in the record.
+Status: FROZEN @ v1 — approved by Tin Dang
+### Build-strategy
+Scope (may touch): `benchmark/report.py` `benchmark/tests/`
+Strategy & known-problem fixes: 1. RED tests first (benchmark/tests/test_report.py): (a) M1/Accept — a fixture with gsd/wm2 `coverage_detail` flagging `R-cancellation-window-422` → `render_report` output contains `R-cancellation-window-422` in a WM2 diagnostics row + the annotation text; (b) M2/R1 — a record with NO `coverage_detail` and a MALFORMED `coverage_detail` string both render `"—"` and `render_report` does not raise; (c) M3 — the existing metric-table asserts still hold (diagnostics are additive). 2. add `_render_diagnostics`, wire into `render_report`. Trap: fault-tolerance — wrap the `json.loads` + row parsing so a bad artifact degrades to `"—"`, never propagates (mirror `_load_record`'s except). Trap: additive only — do NOT alter the metric tables' text (test_report.py's `count>=N` + `N/A` asserts must still pass).
+Approach (domain strategy): "fault-tolerant additive render"
+
+### AI-verify record (required when gate_mode: ai-plan-verify)
+- [ ] §3 PLAN grounding anchors resolve in the current tree
+- [ ] §1 every Must + every Reject present, each Reject paired with an error code
+- [ ] §3 Contract shape is concrete (no template placeholder text remains)
+- [ ] Lowest-confidence flag surfaced and substantive (mirrors unflagged_freeze's own bar)
+Verified by: <agent-id> · at: <ISO-8601 UTC timestamp>
+
+---
+
+## 4 · TESTS — failing-first (red)
+
+Plan: test_<accept> — assert the §1 Accept line's Then (behavior, not internals).
+Tests live in: `./tests/` · MUST run red (missing implementation) before Build.
+
+---
+
+## 5 · BUILD — AI writes the code (execution)
+
+> The change plan was frozen in §3 PLAN. Build to it: honor the §3 Build-strategy Scope; improve on the strategy if the code teaches you better.
+Strategy actually used: as planned — NEW `_render_diagnostics` + a `_diagnostics_cells(record)` helper (coverage `#/#`, uncovered ids, one-line-truncated annotation; fault-tolerant em-dash on missing record / absent key / `json.loads` failure), wired into `render_report` after each per-WM metric table. Test-authoring lesson caught during red: pytest's `tmp_path` dir name contains the test-function name → a naive `assert "diagnostics" in text` was vacuously satisfied by the evidence-link PATHS; re-pinned both tests on the distinctive table header `| arm | coverage | uncovered | code quality |`.
+Code lives in: `benchmark/`   ·   Constraints: change no test, no frozen contract; stay inside the §3 Build-strategy Scope; allow-list packages only.
+
+---
+
+## 6 · VERIFY — evidence + gate
+
+- [x] all tests pass · coverage held · no test or contract altered during build — `benchmark/tests/` 212 passed (2 new report tests + 210), 0 failed; frozen contract untouched
+- [x] green was EARNED — the initial red suite had a VACUOUS assert (tmp_path dir name embeds "diagnostics" into evidence paths); caught and re-pinned on the distinctive `| arm | coverage | uncovered | code quality |` header + the real `R-cancellation-window-422` / `4/5` / annotation strings — no overfit, no stub
+- [x] input dialect held — the diagnostics read `coverage_detail` (JSON list of `{id,covered}`) + `code_quality_annotation` string exactly as the scorer writes them; malformed JSON degrades to em-dash
+- [x] no exposed secrets, injection openings, or unexpected dependencies (security = HARD-STOP) — stdlib `json` only; pure read over on-disk records; no live boot/judge/network; no user input
+
+Build expectations (from §1 Accept + §3 CONTRACT): `python3 -m benchmark.report` prints a `### WM{n} diagnostics` table `| arm | coverage | uncovered | code quality |`; on the REAL persisted `vanilla/wm2` it reads `| vanilla | 5/5 | none | unavailable: no judge configured (deterministic scoring) |`, and an arm with no record degrades to `| add | — | — | — |` — confirmed live. The fixture test proves a gsd/wm2 `coverage_detail` flagging `R-cancellation-window-422` surfaces that id + its annotation in the WM2 diagnostics row.
+
+### GATE RECORD
+Outcome: PASS
+Reviewed by: Tin Dang (auto-gate, autonomy: auto — evidence-complete; human spot-audit backstop) · date: 2026-07-15
+OBSERVE: [SPEC · open] report.py resolves records only at the `runs/<arm>/wm<n>` layout, so archived comparison arms under alternate run-labels (add-v2meter-r0, …) render "—"; a `--label`/glob resolution (or a per-label report) would let the diagnostics show for every persisted arm, not just the arm-name-layout ones.
+

--- a/benchmark/judge.py
+++ b/benchmark/judge.py
@@ -18,6 +18,13 @@ from benchmark.schema.run_record import BenchError
 BENCHMARK_ROOT = pathlib.Path(__file__).resolve().parent
 JUDGE_TIMEOUT_S = 120.0
 
+# code_quality_annotation source bound: the app's built code is fed to the judge,
+# capped so a large tree can't blow the prompt (advisory only — a shallow note is
+# an acceptable degradation, a runaway prompt is not).
+_SOURCE_GLOB = "app/**/*.py"
+_MAX_SOURCE_FILES = 20
+_MAX_SOURCE_CHARS = 40_000
+
 
 def default_judge_cmd(rubric_prompt: str) -> list[str]:
     """The real `claude -p <rubric>` rubric-scoring invocation — model PINNED
@@ -54,6 +61,71 @@ def build_rubric_prompt(wm: int, oracle_report: dict) -> str:
         f"Oracle isolation_clean: {isolation_clean!r}\n\n"
         "Respond with a single float in [0.0, 1.0] and nothing else."
     )
+
+
+def build_code_quality_prompt(wm: int, workspace: str | pathlib.Path) -> str:
+    """Source-aware rubric grounding for the advisory `code_quality_annotation`:
+    the WM's PROMPT.md requirements PLUS the built app's actual source
+    (`app/**/*.py` under the workspace, capped at _MAX_SOURCE_FILES files /
+    _MAX_SOURCE_CHARS total). Fixes the retired spec_fidelity rubric's
+    artifact-blindness — that one read only PROMPT.md + oracle booleans, never
+    the code."""
+    prompt_text = _prompt_path(wm).read_text()
+    ws = pathlib.Path(workspace)
+    chunks: list[str] = []
+    budget = _MAX_SOURCE_CHARS
+    for src in sorted(ws.glob(_SOURCE_GLOB))[:_MAX_SOURCE_FILES]:
+        if budget <= 0:
+            break
+        try:
+            body = src.read_text(errors="replace")[:budget]
+        except OSError:
+            continue
+        chunks.append(f"# --- {src.relative_to(ws)} ---\n{body}")
+        budget -= len(body)
+    source = "\n\n".join(chunks) if chunks else "(no app source found)"
+    return (
+        f"Give a SHORT advisory code-quality note (NOT a score) for workload milestone {wm}.\n\n"
+        f"Requirements (PROMPT.md):\n{prompt_text}\n\n"
+        f"Built app source:\n{source}\n\n"
+        "Respond with 1-3 sentences on clarity, idiom and structure. Do not output a number."
+    )
+
+
+def code_quality_annotation(
+    workspace: str | pathlib.Path,
+    wm: int,
+    *,
+    judge_cmd: Sequence[str] | None = None,
+) -> str:
+    """Advisory, NON-GATING, source-aware code-quality note — an `artifacts`
+    string, never a `metrics` key (the honest-fidelity-meter law: NO LLM in the
+    metric path).
+
+    CLAUDE-LESS BY DEFAULT: with no `judge_cmd` (the deterministic re-score path)
+    this returns "unavailable: ..." and spawns NO subprocess — it never falls
+    through to the live `claude` argv. BEST-EFFORT otherwise: any subprocess
+    failure or empty output degrades to "unavailable: <reason>"; it NEVER raises
+    and NEVER returns a score.
+    """
+    if not judge_cmd:
+        return "unavailable: no judge configured (deterministic scoring)"
+    prompt = build_code_quality_prompt(wm, workspace)
+    argv = [*judge_cmd, prompt]
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=JUDGE_TIMEOUT_S,
+            cwd=str(workspace) if pathlib.Path(workspace).exists() else None,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"unavailable: judge invocation failed: {exc}"
+    out = (proc.stdout or "").strip()
+    if not out:
+        return f"unavailable: empty judge output (stderr={proc.stderr!r})"
+    return out
 
 
 def judge_fidelity(

--- a/benchmark/pilot.py
+++ b/benchmark/pilot.py
@@ -1,7 +1,10 @@
 """pilot — sequences the full 5-arm x 3-WM live pilot, provisioning +
-run + score, honoring resume; and `attest_record`, the human-in-the-loop
-spot-check writer for spec_fidelity (bench-pilot-report TASK.md §3
-CONTRACT @ v1).
+run + score, honoring resume (bench-pilot-report TASK.md §3 CONTRACT @ v1).
+
+The human-in-the-loop `attest_record` spot-check writer for the LLM
+`spec_fidelity` was RETIRED at honest-fidelity-meter: fidelity is now the
+deterministic `requirement_coverage` (probes against the built app), so
+there is no subjective per-record score left to audit.
 
 Reuses `execute_wm`/`score_record`/`find_resume_point`/`write_record_atomic`
 verbatim (imported, not reimplemented) — this module is pure orchestration
@@ -20,7 +23,7 @@ from typing import Sequence
 from benchmark.arms.loader import ARM_NAMES, Arm, load_arm
 from benchmark.runner.core import execute_wm
 from benchmark.runner.records import DEFAULT_RUNS_ROOT, find_resume_point, write_record_atomic
-from benchmark.schema.run_record import BenchError, RunRecord, validate
+from benchmark.schema.run_record import BenchError, RunRecord
 from benchmark.score import score_record
 from benchmark.tamper import snapshot_tests
 
@@ -46,52 +49,6 @@ def resolve_setup_steps(arm: Arm, repo_root: pathlib.Path) -> Arm:
 
     resolved_steps = [line.replace(REPO_ROOT_TOKEN, str(repo_root)) for line in arm.setup_steps]
     return dataclasses.replace(arm, setup_steps=resolved_steps)
-
-
-def _record_path(runs_root: pathlib.Path, arm_name: str, wm: int) -> pathlib.Path:
-    return runs_root / arm_name / f"wm{wm}" / "record.json"
-
-
-def attest_record(
-    arm_name: str, wm: int, note: str, *, runs_root: pathlib.Path | None = None
-) -> RunRecord:
-    """Human-in-the-loop spot-check writer: reads record.json, raises
-    BenchError("record_not_found"/"record_not_done"/"record_not_scored")
-    per the Reject list, else writes
-    artifacts["spec_fidelity_audit"] = "spot-checked: <note>" via
-    write_record_atomic (reused verbatim) and returns the updated RunRecord.
-
-    Mirrors score_record's exact guard-clause-before-any-I/O shape: read the
-    full record, validate eligibility, mutate only the one field in an
-    in-memory copy, re-validate the complete dict, write once.
-    """
-    root = pathlib.Path(runs_root) if runs_root is not None else DEFAULT_RUNS_ROOT
-    record_path = _record_path(root, arm_name, wm)
-    if not record_path.exists():
-        raise BenchError(f"record_not_found: {record_path}")
-
-    record = RunRecord.from_json(record_path.read_text())
-    if record.status != "done":
-        raise BenchError(f"record_not_done: status={record.status!r} (nothing to attest)")
-
-    if record.metrics.get("spec_fidelity") == 0.0:
-        raise BenchError("record_not_scored: metrics['spec_fidelity'] is still the unscored 0.0 placeholder")
-
-    artifacts = dict(record.artifacts)
-    artifacts["spec_fidelity_audit"] = f"spot-checked: {note}"
-
-    updated = validate(
-        {
-            "arm": record.arm,
-            "wm": record.wm,
-            "rep": record.rep,
-            "status": record.status,
-            "metrics": dict(record.metrics),
-            "artifacts": artifacts,
-        }
-    )
-    write_record_atomic(record_path, updated)
-    return updated
 
 
 def run_pilot(
@@ -172,7 +129,7 @@ def run_pilot(
 _REP_METRICS = (
     ("tokens", "tokens_total"),
     ("cost", "cost_usd"),
-    ("fidelity", "spec_fidelity"),
+    ("fidelity", "requirement_coverage"),
     # v2-wv1-longitudinal M2: the v2 trust metrics. regression_rate is a
     # required key; oracle_pass_rate/tests_weakened are OPTIONAL (schema v2) —
     # aggregation tolerates records that don't carry them (n_missing below).
@@ -258,7 +215,7 @@ def run_reps(
 
 
 # --------------------------------------------------------------------------
-# thin argparse CLI: `pilot.py run-all` / `pilot.py attest`
+# thin argparse CLI: `pilot.py run-all`
 # --------------------------------------------------------------------------
 
 
@@ -278,12 +235,6 @@ def _build_parser() -> argparse.ArgumentParser:
     run_all_p.add_argument("--runs-root", default=None)
     run_all_p.add_argument("--repo-root", default=None)
     run_all_p.add_argument("--family", default="wm", choices=("wm", "hv"))
-
-    attest_p = sub.add_parser("attest")
-    attest_p.add_argument("--arm", required=True)
-    attest_p.add_argument("--wm", type=int, required=True)
-    attest_p.add_argument("--note", required=True)
-    attest_p.add_argument("--runs-root", default=None)
 
     return parser
 
@@ -337,16 +288,6 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         for record in records:
             print(record.to_json())
-        return 0
-
-    if args.command == "attest":
-        runs_root = pathlib.Path(args.runs_root) if args.runs_root else None
-        try:
-            record = attest_record(args.arm, args.wm, args.note, runs_root=runs_root)
-        except BenchError as exc:
-            print(str(exc), file=sys.stderr)
-            return 2
-        print(record.to_json())
         return 0
 
     parser.error("unknown command")

--- a/benchmark/report.py
+++ b/benchmark/report.py
@@ -15,11 +15,13 @@ from benchmark.schema.run_record import REQUIRED_METRICS, BenchError, RunRecord
 # Headline metrics shown in the WM3 summary table + column order for the
 # per-WM detail tables (human-decided at freeze: headline-first ordering).
 METRIC_COLUMNS = (
-    "spec_fidelity",
+    "requirement_coverage",
+    "oracle_pass_rate",
     "regression_rate",
     "context_rot_slope",
     "tokens_total",
     "cost_usd",
+    "time_to_first_edit",
 )
 NOT_RUN = "not run"
 NA_BY_DEFINITION = "N/A (by definition)"
@@ -50,8 +52,6 @@ def _render_cell(arm: str, wm: int, metric: str, record: RunRecord | None, runs_
     else:
         value = record.metrics[metric]
         value_text = f"{value:.2f}"
-        if metric == "spec_fidelity" and "spec_fidelity_audit" not in record.artifacts:
-            value_text = f"{value_text} (unaudited)"
 
     evidence = _evidence_link(runs_root, arm, wm, record)
     return f"{value_text} — {evidence}"

--- a/benchmark/report.py
+++ b/benchmark/report.py
@@ -5,6 +5,7 @@ record (renders "not run"); re-runnable, no live agent/judge call.
 """
 from __future__ import annotations
 
+import json
 import pathlib
 from typing import Sequence
 
@@ -57,6 +58,47 @@ def _render_cell(arm: str, wm: int, metric: str, record: RunRecord | None, runs_
     return f"{value_text} — {evidence}"
 
 
+EMDASH = "—"
+
+
+def _diagnostics_cells(record: RunRecord | None) -> tuple[str, str, str]:
+    """(coverage, uncovered, code quality) for one record — display-only, read from
+    `artifacts` (never a metric). Fault-tolerant (M2/R1): a missing record, an absent
+    key, or a malformed `coverage_detail` JSON degrades to em-dash, never raises."""
+    if record is None:
+        return EMDASH, EMDASH, EMDASH
+
+    coverage, uncovered = EMDASH, EMDASH
+    raw = record.artifacts.get("coverage_detail")
+    if raw:
+        try:
+            rows = json.loads(raw)
+            ids = [str(r["id"]) for r in rows]
+            missed = [str(r["id"]) for r in rows if not r["covered"]]
+            coverage = f"{len(ids) - len(missed)}/{len(ids)}"
+            uncovered = ", ".join(missed) if missed else "none"
+        except (ValueError, TypeError, KeyError):
+            coverage, uncovered = EMDASH, EMDASH  # malformed -> degrade, never raise
+
+    note = record.artifacts.get("code_quality_annotation") or ""
+    quality = " ".join(note.split())[:60] if note else EMDASH
+    return coverage, uncovered, quality
+
+
+def _render_diagnostics(runs_root: pathlib.Path, wm: int, arms: Sequence[str]) -> str:
+    """Per-WM DIAGNOSTICS table surfacing the two advisory artifacts
+    (`coverage_detail`, `code_quality_annotation`) beside the metric tables — so a
+    sub-1.0 coverage score is readable at a glance. Display-only; adds no metric."""
+    header = "| arm | coverage | uncovered | code quality |"
+    sep = "| --- | --- | --- | --- |"
+    lines = [f"### WM{wm} diagnostics", "", header, sep]
+    for arm in arms:
+        coverage, uncovered, quality = _diagnostics_cells(_load_record(runs_root, arm, wm))
+        lines.append(f"| {arm} | {coverage} | {uncovered} | {quality} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def _render_wm_table(
     runs_root: pathlib.Path, wm: int, arms: Sequence[str]
 ) -> str:
@@ -101,6 +143,7 @@ def render_report(
         sections.append(_render_headline_table(root, arms))
     for wm in wms:
         sections.append(_render_wm_table(root, wm, arms))
+        sections.append(_render_diagnostics(root, wm, arms))
     return "\n".join(sections)
 
 

--- a/benchmark/runner/core.py
+++ b/benchmark/runner/core.py
@@ -394,7 +394,8 @@ def execute_wm(
             "status": status,
             "metrics": {
                 "regression_rate": 0.0,
-                "spec_fidelity": 0.0,
+                "requirement_coverage": 0.0,  # placeholder; score_record computes the real value
+                "oracle_pass_rate": 0.0,      # placeholder; score_record computes the real value
                 "tokens_total": float(tokens_total),
                 "cost_usd": cost_usd,
                 "context_rot_slope": 0.0,
@@ -410,7 +411,8 @@ def execute_wm(
 def _zero_metrics() -> dict[str, float]:
     return {
         "regression_rate": 0.0,
-        "spec_fidelity": 0.0,
+        "requirement_coverage": 0.0,
+        "oracle_pass_rate": 0.0,
         "tokens_total": 0.0,
         "cost_usd": 0.0,
         "context_rot_slope": 0.0,

--- a/benchmark/schema/run_record.py
+++ b/benchmark/schema/run_record.py
@@ -10,23 +10,31 @@ import dataclasses
 import json
 from typing import Any
 
-# Exactly these 5 metric names — no more, no fewer (frozen in MILESTONE.md).
+# Exactly these 7 metric names — no more, no fewer (frozen in MILESTONE.md).
+# Schema v3 (honest-fidelity-meter): the artifact-blind LLM `spec_fidelity` is
+# RETIRED for the deterministic `requirement_coverage` (workload/wm{n}/checklist.py
+# probes run against the built app), and `oracle_pass_rate` is PROMOTED from
+# optional to required (the black-box behavioral floor). A record still carrying
+# `spec_fidelity` (and no `requirement_coverage`) is now REJECTED — it is a legacy
+# record that must be re-scored; the WM3+ slope prior-read reads such records
+# leniently (score._read_prior_metrics_lenient), never through validate().
 REQUIRED_METRICS = frozenset(
     {
         "regression_rate",
-        "spec_fidelity",
+        "requirement_coverage",
         "tokens_total",
         "cost_usd",
         "context_rot_slope",
         "time_to_first_edit",
+        "oracle_pass_rate",
     }
 )
 
-# Schema v2 (v2-meter-fixes TASK.md §3 CONTRACT @ v1): ADDITIVE-OPTIONAL keys —
-# a metrics dict may carry any SUBSET of these on top of the required six, so
-# every archived v1 record still validates byte-unchanged. Unknown keys stay
-# rejected: additive is not open-ended.
-OPTIONAL_METRICS = frozenset({"oracle_pass_rate", "tests_weakened"})
+# ADDITIVE-OPTIONAL keys — a metrics dict may carry any SUBSET of these on top of
+# the required set. Unknown keys stay rejected: additive is not open-ended.
+# `spec_fidelity` has LEFT the schema entirely (v3) — it is neither required nor
+# optional, so any live record carrying it fails validate().
+OPTIONAL_METRICS = frozenset({"tests_weakened"})
 
 REQUIRED_ARTIFACTS = frozenset({"workspace", "transcript", "oracle_report"})
 

--- a/benchmark/score.py
+++ b/benchmark/score.py
@@ -190,40 +190,53 @@ def _load_checklist(wm: int, family: str = "wm") -> list[dict]:
     return rows
 
 
-def compute_requirement_coverage(workspace: pathlib.Path, wm: int, family: str = "wm") -> float:
-    """The DETERMINISTIC fidelity of record (honest-fidelity-meter): run the WM's
-    FROZEN requirement checklist against the built app and return covered/total in
-    [0,1]. Every PROMPT.md requirement is one row with a real probe — so an app
-    that boots but omits a requirement (CLI, field validation) scores below 1.0,
-    unlike oracle_pass_rate which is blind to un-probed requirements.
+def compute_coverage_detail(workspace: pathlib.Path, wm: int, family: str = "wm") -> list[dict]:
+    """The per-requirement breakdown behind `requirement_coverage` (coverage-detail):
+    run the WM's FROZEN checklist against the built app and return one
+    `{"id","covered"}` row per requirement, in checklist order — so a coverage score
+    is self-explaining (a 0.0 says WHICH requirements failed, not just that it did).
 
-    NO LLM in the path — identical workspace yields the identical value. Fail-closed
-    (M3): an unbootable app or a raising probe counts its requirement NOT covered;
-    the scorer always returns a fraction, never propagates the probe's exception.
-    Raises only on a guard breach: a malformed checklist (R2) or a value ∉ [0,1] (R3)."""
+    ONE hermetic boot (hermetic-scoring): probe writes land in a store-reset throwaway
+    copy, so the source is never mutated and repeated scorings are reproducible.
+    Fail-closed (M3): an unbootable app / a raising probe leaves that row `covered:False`
+    — never propagates the probe's exception. Raises only on a malformed checklist (R2)."""
     from benchmark.workload._oracle_lib import isolated_workspace, running_app  # lazy: avoids import cycle
 
-    rows = _load_checklist(wm, family)
-    total = len(rows)
-    covered = 0
+    rows = _load_checklist(wm, family)  # R2: malformed checklist raises here, before the boot
+    detail = [{"id": row["id"], "covered": False} for row in rows]
     try:
-        # HERMETIC (hermetic-scoring): boot a store-reset copy so probe writes
-        # land in a throwaway dir — the source is never mutated and repeated
-        # scorings of the same archived workspace are reproducible.
         with isolated_workspace(workspace) as iso_ws:
             with running_app(str(iso_ws)) as base:
-                for row in rows:
+                for i, row in enumerate(rows):
                     try:
                         if row["probe"](base, iso_ws):
-                            covered += 1
+                            detail[i]["covered"] = True
                     except Exception:
                         pass  # fail-closed: a raising probe = requirement NOT covered
     except Exception:
-        covered = 0  # unbootable workspace: nothing covered, never a scorer crash
-    value = covered / total
+        pass  # unbootable workspace: detail stays all-False, never a scorer crash
+    return detail
+
+
+def _coverage_from_detail(detail: list[dict]) -> float:
+    """Aggregate a coverage-detail into covered/total in [0,1] — the single source of
+    truth shared by `compute_requirement_coverage` and `score_record`, so the float and
+    the emitted detail can never disagree. Raises on a value ∉ [0,1] (R3)."""
+    total = len(detail)
+    value = sum(1 for d in detail if d["covered"]) / total
     if not (0.0 <= value <= 1.0):
         raise BenchError(f"invalid_coverage: {value!r} out of [0.0, 1.0]")
     return value
+
+
+def compute_requirement_coverage(workspace: pathlib.Path, wm: int, family: str = "wm") -> float:
+    """The DETERMINISTIC fidelity of record (honest-fidelity-meter): covered/total in
+    [0,1] from the WM's FROZEN checklist run against the built app. Every PROMPT.md
+    requirement is one probe — so an app that boots but omits a requirement (CLI, field
+    validation) scores below 1.0, unlike oracle_pass_rate which is blind to un-probed
+    requirements. NO LLM in the path — identical workspace yields the identical value.
+    Derived from `compute_coverage_detail` so the score and its breakdown always agree."""
+    return _coverage_from_detail(compute_coverage_detail(workspace, wm, family))
 
 
 def _read_prior_metrics_lenient(
@@ -413,7 +426,11 @@ def score_record(
     # The LLM judge is back only as an advisory, source-aware `code_quality_annotation`
     # artifact (never a metric): claude-less by default (judge_cmd None -> "unavailable",
     # no subprocess), best-effort when a judge_cmd is supplied.
-    requirement_coverage = compute_requirement_coverage(workspace, wm, family)
+    # ONE hermetic boot yields both the aggregate and its per-requirement breakdown
+    # (coverage-detail) — derived from the same detail so they can never disagree.
+    coverage_detail = compute_coverage_detail(workspace, wm, family)
+    requirement_coverage = _coverage_from_detail(coverage_detail)
+    artifacts["coverage_detail"] = json.dumps(coverage_detail, separators=(",", ":"))
     artifacts.pop("judge_scores", None)  # purge the superseded pre-judge-advisory sentinel
     artifacts["code_quality_annotation"] = judge.code_quality_annotation(
         workspace, wm, judge_cmd=judge_cmd

--- a/benchmark/score.py
+++ b/benchmark/score.py
@@ -94,23 +94,29 @@ def _run_oracle_suites(
     never conflated with a normal test failure, which is signal, not error.
     `marker_expr` (pytest -m) lets a caller deselect probes that don't belong
     to its metric — e.g. wm3's regression re-exports out of the fidelity run."""
+    from benchmark.workload._oracle_lib import isolated_workspace  # lazy: avoids import cycle
+
     marker_args = ["-m", marker_expr] if marker_expr else []
-    proc = subprocess.run(
-        [
-            *_pytest_argv(),
-            "-p",
-            "no:cacheprovider",
-            "--tb=no",
-            "-q",
-            *marker_args,
-            *[str(p) for p in oracle_paths],
-        ],
-        cwd=str(REPO_ROOT),
-        env={**os.environ, "BENCH_WORKSPACE": str(workspace)},
-        capture_output=True,
-        text=True,
-        timeout=REGRESSION_SUBPROCESS_TIMEOUT_S,
-    )
+    # HERMETIC (hermetic-scoring): the oracle/regression probes boot the app via
+    # BENCH_WORKSPACE — point it at a store-reset copy so their bookings never
+    # mutate the source and oracle_pass_rate is reproducible on archived builds.
+    with isolated_workspace(workspace) as iso_ws:
+        proc = subprocess.run(
+            [
+                *_pytest_argv(),
+                "-p",
+                "no:cacheprovider",
+                "--tb=no",
+                "-q",
+                *marker_args,
+                *[str(p) for p in oracle_paths],
+            ],
+            cwd=str(REPO_ROOT),
+            env={**os.environ, "BENCH_WORKSPACE": str(iso_ws)},
+            capture_output=True,
+            text=True,
+            timeout=REGRESSION_SUBPROCESS_TIMEOUT_S,
+        )
     if proc.returncode not in (0, 1):
         raise BenchError(
             f"{error_code}: pytest exited {proc.returncode}\n"
@@ -195,19 +201,23 @@ def compute_requirement_coverage(workspace: pathlib.Path, wm: int, family: str =
     (M3): an unbootable app or a raising probe counts its requirement NOT covered;
     the scorer always returns a fraction, never propagates the probe's exception.
     Raises only on a guard breach: a malformed checklist (R2) or a value ∉ [0,1] (R3)."""
-    from benchmark.workload._oracle_lib import running_app  # lazy: avoids import cycle
+    from benchmark.workload._oracle_lib import isolated_workspace, running_app  # lazy: avoids import cycle
 
     rows = _load_checklist(wm, family)
     total = len(rows)
     covered = 0
     try:
-        with running_app(str(workspace)) as base:
-            for row in rows:
-                try:
-                    if row["probe"](base, pathlib.Path(workspace)):
-                        covered += 1
-                except Exception:
-                    pass  # fail-closed: a raising probe = requirement NOT covered
+        # HERMETIC (hermetic-scoring): boot a store-reset copy so probe writes
+        # land in a throwaway dir — the source is never mutated and repeated
+        # scorings of the same archived workspace are reproducible.
+        with isolated_workspace(workspace) as iso_ws:
+            with running_app(str(iso_ws)) as base:
+                for row in rows:
+                    try:
+                        if row["probe"](base, iso_ws):
+                            covered += 1
+                    except Exception:
+                        pass  # fail-closed: a raising probe = requirement NOT covered
     except Exception:
         covered = 0  # unbootable workspace: nothing covered, never a scorer crash
     value = covered / total

--- a/benchmark/score.py
+++ b/benchmark/score.py
@@ -410,10 +410,13 @@ def score_record(
 
     # Deterministic fidelity of record (honest-fidelity-meter): requirement_coverage
     # from the WM's frozen checklist — the ONLY fidelity signal, NO LLM in the path.
-    # The LLM judge has LEFT the metric path entirely; task judge-advisory re-adds it
-    # as an advisory, source-aware `code_quality_annotation` artifact (never a metric).
+    # The LLM judge is back only as an advisory, source-aware `code_quality_annotation`
+    # artifact (never a metric): claude-less by default (judge_cmd None -> "unavailable",
+    # no subprocess), best-effort when a judge_cmd is supplied.
     requirement_coverage = compute_requirement_coverage(workspace, wm, family)
-    artifacts["judge_scores"] = "deferred: see code_quality_annotation (task judge-advisory)"
+    artifacts["code_quality_annotation"] = judge.code_quality_annotation(
+        workspace, wm, judge_cmd=judge_cmd
+    )
 
     transcript_str = artifacts.get("transcript", "")
     artifacts["engine_calls"] = str(

--- a/benchmark/score.py
+++ b/benchmark/score.py
@@ -414,6 +414,7 @@ def score_record(
     # artifact (never a metric): claude-less by default (judge_cmd None -> "unavailable",
     # no subprocess), best-effort when a judge_cmd is supplied.
     requirement_coverage = compute_requirement_coverage(workspace, wm, family)
+    artifacts.pop("judge_scores", None)  # purge the superseded pre-judge-advisory sentinel
     artifacts["code_quality_annotation"] = judge.code_quality_annotation(
         workspace, wm, judge_cmd=judge_cmd
     )

--- a/benchmark/score.py
+++ b/benchmark/score.py
@@ -156,6 +156,109 @@ def compute_oracle_pass_rate(workspace: pathlib.Path, wm: int, family: str = "wm
     return (total - bad) / total
 
 
+def validate_checklist(rows: object) -> None:
+    """A frozen requirement checklist is a non-empty list of rows, each a mapping
+    carrying `id`, `description`, and a callable `probe` — a row missing any of
+    these (R2) raises BenchError("invalid_checklist: ...") before any scoring."""
+    if not isinstance(rows, list) or not rows:
+        raise BenchError("invalid_checklist: REQUIREMENTS must be a non-empty list")
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict) or not all(k in row for k in ("id", "description", "probe")):
+            raise BenchError(f"invalid_checklist: row {i} must carry id, description, probe")
+        if not callable(row["probe"]):
+            raise BenchError(f"invalid_checklist: row {i} probe must be callable")
+
+
+def _load_checklist(wm: int, family: str = "wm") -> list[dict]:
+    """Import `workload/{family}{wm}/checklist.py` and return its validated
+    `REQUIREMENTS` list. Raises `missing_checklist` if the module is absent,
+    `invalid_checklist` (via validate_checklist) if a row is malformed."""
+    mod_path = REPO_ROOT / "benchmark" / "workload" / f"{family}{wm}" / "checklist.py"
+    if not mod_path.exists():
+        raise BenchError(f"missing_checklist: {mod_path} does not exist")
+    spec = importlib.util.spec_from_file_location(f"_checklist_{family}{wm}", mod_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    rows = getattr(module, "REQUIREMENTS", None)
+    validate_checklist(rows)
+    return rows
+
+
+def compute_requirement_coverage(workspace: pathlib.Path, wm: int, family: str = "wm") -> float:
+    """The DETERMINISTIC fidelity of record (honest-fidelity-meter): run the WM's
+    FROZEN requirement checklist against the built app and return covered/total in
+    [0,1]. Every PROMPT.md requirement is one row with a real probe — so an app
+    that boots but omits a requirement (CLI, field validation) scores below 1.0,
+    unlike oracle_pass_rate which is blind to un-probed requirements.
+
+    NO LLM in the path — identical workspace yields the identical value. Fail-closed
+    (M3): an unbootable app or a raising probe counts its requirement NOT covered;
+    the scorer always returns a fraction, never propagates the probe's exception.
+    Raises only on a guard breach: a malformed checklist (R2) or a value ∉ [0,1] (R3)."""
+    from benchmark.workload._oracle_lib import running_app  # lazy: avoids import cycle
+
+    rows = _load_checklist(wm, family)
+    total = len(rows)
+    covered = 0
+    try:
+        with running_app(str(workspace)) as base:
+            for row in rows:
+                try:
+                    if row["probe"](base, pathlib.Path(workspace)):
+                        covered += 1
+                except Exception:
+                    pass  # fail-closed: a raising probe = requirement NOT covered
+    except Exception:
+        covered = 0  # unbootable workspace: nothing covered, never a scorer crash
+    value = covered / total
+    if not (0.0 <= value <= 1.0):
+        raise BenchError(f"invalid_coverage: {value!r} out of [0.0, 1.0]")
+    return value
+
+
+def _read_prior_metrics_lenient(
+    root: pathlib.Path, arm_name: str, wm: int, family: str = "wm"
+) -> dict:
+    """Read a prior WM's record.json metrics WITHOUT strict validate() — a legacy
+    record carries only `spec_fidelity` (no `requirement_coverage`) and would be
+    rejected by the v3 schema, but the slope prior-read must still see its value.
+    Enforces the same absent/not-done guard as read_prior_wm_record."""
+    path = _record_path(root, arm_name, wm, family)
+    if not path.exists():
+        raise BenchError(f"missing_prior_wm_record: {path} does not exist")
+    data = json.loads(path.read_text())
+    if data.get("status") != "done":
+        raise BenchError(f"missing_prior_wm_record: {path} status={data.get('status')!r} (must be 'done')")
+    return data.get("metrics", {})
+
+
+def _read_target_record_lenient(record_path: pathlib.Path) -> RunRecord:
+    """Read the record being scored WITHOUT strict validate(), constructing the
+    RunRecord dataclass directly. An archived v1/v2 record carries the retired
+    `spec_fidelity` (no `requirement_coverage`) and would be rejected by the v3
+    schema — yet RE-SCORING is precisely how it migrates forward: score_record
+    recomputes every metric and re-validates the full dict before writing, so
+    the target read need not (and must not) pre-validate. Malformed shapes still
+    fail loud (KeyError/TypeError surface as a clear error, never a silent skip)."""
+    data = json.loads(record_path.read_text())
+    return RunRecord(
+        arm=str(data["arm"]),
+        wm=int(data["wm"]),
+        rep=int(data["rep"]),
+        status=str(data["status"]),
+        metrics=dict(data["metrics"]),
+        artifacts=dict(data["artifacts"]),
+    )
+
+
+def _prior_fidelity_value(metrics: dict) -> float:
+    """The slope-trajectory value of a prior WM: its deterministic
+    `requirement_coverage`, or (archived-record shim, M4) its legacy
+    `spec_fidelity` when coverage is absent; 0.0 if neither exists."""
+    v = metrics.get("requirement_coverage", metrics.get("spec_fidelity", 0.0))
+    return float(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else 0.0
+
+
 def compute_regression_rate_v2(workspace: pathlib.Path, wm: int, family: str = "wm") -> float:
     """v2 regression semantics (v2-wv1-longitudinal §3 @ v3, M7 — supersedes
     the wholesale-suite form): re-run each earlier WM's SURVIVORS — the
@@ -255,7 +358,10 @@ def score_record(
     if not record_path.exists():
         raise BenchError(f"record_not_found: {record_path}")
 
-    record = RunRecord.from_json(record_path.read_text())
+    # Lenient target read: an archived v1/v2 record carries the retired
+    # spec_fidelity and would fail strict validate() — re-scoring migrates it
+    # forward (recompute + re-validate before write, below).
+    record = _read_target_record_lenient(record_path)
     if record.status != "done":
         raise BenchError(f"record_not_done: status={record.status!r} (nothing to score)")
 
@@ -266,8 +372,8 @@ def score_record(
     prior_fidelities: list[float] = []
     if wm >= 3:
         for prior_wm in range(1, wm):
-            prior = read_prior_wm_record(arm_name, prior_wm, runs_root=root, family=family)
-            prior_fidelities.append(prior.metrics["spec_fidelity"])
+            prior_metrics = _read_prior_metrics_lenient(root, arm_name, prior_wm, family)
+            prior_fidelities.append(_prior_fidelity_value(prior_metrics))
 
     metrics = dict(record.metrics)
     artifacts = dict(record.artifacts)
@@ -292,12 +398,12 @@ def score_record(
         if oracle_report_path.exists():
             oracle_report = json.loads(oracle_report_path.read_text())
 
-    # M3: spec_fidelity always recomputed via the injectable judge seam —
-    # median-of-3 to damp single-call variance, raw scores kept auditable.
-    spec_fidelity, judge_scores = judge.judge_fidelity_median(
-        workspace, wm, oracle_report, judge_cmd=judge_cmd
-    )
-    artifacts["judge_scores"] = ";".join(str(s) for s in judge_scores)
+    # Deterministic fidelity of record (honest-fidelity-meter): requirement_coverage
+    # from the WM's frozen checklist — the ONLY fidelity signal, NO LLM in the path.
+    # The LLM judge has LEFT the metric path entirely; task judge-advisory re-adds it
+    # as an advisory, source-aware `code_quality_annotation` artifact (never a metric).
+    requirement_coverage = compute_requirement_coverage(workspace, wm, family)
+    artifacts["judge_scores"] = "deferred: see code_quality_annotation (task judge-advisory)"
 
     transcript_str = artifacts.get("transcript", "")
     artifacts["engine_calls"] = str(
@@ -308,10 +414,10 @@ def score_record(
     )
 
     if wm >= 3:
-        # context_rot_slope over the FULL spec_fidelity trajectory at every
-        # WM>=3 (v1 semantics, judge-fed, kept as a secondary trend signal).
-        context_rot_slope = compute_context_rot_slope([*prior_fidelities, spec_fidelity])
-        artifacts.update(_fidelity_artifacts(prior_fidelities, spec_fidelity))
+        # context_rot_slope over the FULL requirement_coverage trajectory at every
+        # WM>=3 — now a deterministic coverage-degradation signal (was judge-fed).
+        context_rot_slope = compute_context_rot_slope([*prior_fidelities, requirement_coverage])
+        artifacts.update(_fidelity_artifacts(prior_fidelities, requirement_coverage))
     else:
         context_rot_slope = 0.0
 
@@ -321,12 +427,12 @@ def score_record(
     regression_rate = compute_regression_rate_v2(workspace, wm, family)
     artifacts["regression_source"] = "v2-earlier-oracles"
 
-    metrics["spec_fidelity"] = spec_fidelity
+    metrics.pop("spec_fidelity", None)  # v3: the retired LLM metric never survives into a scored record
+    metrics["requirement_coverage"] = requirement_coverage
     metrics["regression_rate"] = regression_rate
     metrics["context_rot_slope"] = context_rot_slope
 
-    # v2 deterministic fidelity of record (M1) — always computed; the judge
-    # float above stays as a SECONDARY, v1-comparable annotator.
+    # black-box behavioral floor (now REQUIRED) — always computed.
     metrics["oracle_pass_rate"] = compute_oracle_pass_rate(workspace, wm, family)
 
     # v2 mechanical tamper count (M4/M7) — only when the snapshot pair for

--- a/benchmark/tests/test_code_quality_annotation.py
+++ b/benchmark/tests/test_code_quality_annotation.py
@@ -1,0 +1,92 @@
+"""code_quality_annotation (task judge-advisory): the demoted LLM judge returns
+as a SOURCE-AWARE, NON-GATING advisory artifact.
+
+The honest-fidelity-meter law is "NO LLM in the metric path" — so the judge is
+back only as an `artifacts` string, never a `metrics` key. It is CLAUDE-LESS BY
+DEFAULT (no judge_cmd -> "unavailable", zero subprocesses, so deterministic
+re-scoring never spawns an LLM) and BEST-EFFORT when a judge_cmd is supplied
+(a judge failure degrades to "unavailable", never raises, never a score).
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from benchmark import judge
+from benchmark.judge import build_code_quality_prompt, code_quality_annotation
+from benchmark.schema.run_record import BenchError, OPTIONAL_METRICS, REQUIRED_METRICS, validate
+
+
+def _workspace_with_app(tmp_path, marker="SENTINEL_BOOKING_SYMBOL"):
+    ws = tmp_path / "workspace"
+    (ws / "app").mkdir(parents=True)
+    (ws / "app" / "__init__.py").write_text("")
+    (ws / "app" / "api.py").write_text(f"def {marker}():\n    return 'booking created'\n")
+    return ws
+
+
+# --- M3: claude-less by default (no subprocess) --------------------------------
+
+def test_claudeless_by_default_no_subprocess(tmp_path, monkeypatch):
+    ws = _workspace_with_app(tmp_path)
+    calls = []
+    monkeypatch.setattr(judge.subprocess, "run", lambda *a, **k: calls.append(a) or None)
+
+    note = code_quality_annotation(ws, 1, judge_cmd=None)
+
+    assert note.startswith("unavailable")
+    assert calls == []  # NO LLM subprocess spawned on the deterministic path
+
+
+# --- M2: source-aware prompt (reads the built app) -----------------------------
+
+def test_prompt_is_source_aware(tmp_path):
+    ws = _workspace_with_app(tmp_path)
+    prompt = build_code_quality_prompt(1, ws)
+    # the built app's actual source symbol is in the prompt (fixes the retired
+    # rubric's artifact-blindness — it only saw PROMPT.md + oracle booleans)
+    assert "SENTINEL_BOOKING_SYMBOL" in prompt
+    assert "api.py" in prompt
+
+
+# --- M4: best-effort when a judge_cmd IS supplied ------------------------------
+
+def test_judge_cmd_stdout_becomes_the_annotation(tmp_path):
+    ws = _workspace_with_app(tmp_path)
+    cmd = [sys.executable, "-c", "print('idiomatic; small; clear')"]
+    note = code_quality_annotation(ws, 1, judge_cmd=cmd)
+    assert note == "idiomatic; small; clear"
+
+
+def test_launch_failure_degrades_to_unavailable(tmp_path):
+    ws = _workspace_with_app(tmp_path)
+    note = code_quality_annotation(ws, 1, judge_cmd=["/no/such/judge/binary"])
+    assert note.startswith("unavailable")  # never raises
+
+
+def test_empty_judge_output_degrades_to_unavailable(tmp_path):
+    ws = _workspace_with_app(tmp_path)
+    cmd = [sys.executable, "-c", "import sys; sys.exit(3)"]  # nonzero, empty stdout
+    note = code_quality_annotation(ws, 1, judge_cmd=cmd)
+    assert note.startswith("unavailable")
+
+
+# --- R1: the annotation can NEVER become a gating metric -----------------------
+
+def test_code_quality_annotation_is_not_a_metric():
+    assert "code_quality_annotation" not in REQUIRED_METRICS
+    assert "code_quality_annotation" not in OPTIONAL_METRICS
+
+    record = {
+        "arm": "vanilla", "wm": 1, "rep": 0, "status": "done",
+        "metrics": {
+            "regression_rate": 0.0, "requirement_coverage": 1.0,
+            "oracle_pass_rate": 1.0, "tokens_total": 10.0, "cost_usd": 0.1,
+            "context_rot_slope": 0.0, "time_to_first_edit": 1.0,
+            "code_quality_annotation": "looks clean",  # forbidden as a metric
+        },
+        "artifacts": {"workspace": "/x", "transcript": "", "oracle_report": ""},
+    }
+    with pytest.raises(BenchError, match="invalid_run_record"):
+        validate(record)

--- a/benchmark/tests/test_coverage_detail.py
+++ b/benchmark/tests/test_coverage_detail.py
@@ -1,0 +1,126 @@
+"""Red/green for coverage-detail (honest-fidelity-meter, frozen §3 v1).
+
+`score_record` emits a per-WM `coverage_detail` artifact — one {"id","covered"}
+row per frozen checklist requirement — so every `requirement_coverage` score is
+self-explaining (a 0.0 says WHICH requirements failed, not just that it failed).
+Non-gating: an `artifacts` string, never a metric; the float is derived from the
+SAME detail (one boot) so they can never disagree.
+
+Reuses the WM1 booking-app fixtures from test_requirement_coverage.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchmark import score as score_mod
+from benchmark.schema.run_record import (
+    OPTIONAL_METRICS,
+    REQUIRED_METRICS,
+    BenchError,
+    validate,
+)
+from benchmark.tests.test_requirement_coverage import _write_wm1_app
+
+
+def _checklist_ids(wm):
+    return [r["id"] for r in score_mod._load_checklist(wm, "wm")]
+
+
+# --- M1/M2: shape + agreement with the aggregate (single boot) -----------------
+
+def test_coverage_detail_shape_and_agrees_with_coverage(tmp_path):
+    ws = tmp_path / "workspace"
+    _write_wm1_app(ws)  # complete WM1 app -> every requirement covered
+    detail = score_mod.compute_coverage_detail(ws, 1)
+
+    assert [d["id"] for d in detail] == _checklist_ids(1)  # one row per req, in order
+    assert all(isinstance(d["covered"], bool) for d in detail)
+    assert all(d["covered"] for d in detail)  # complete app
+    # the float is DERIVED from this detail -> they agree by construction
+    assert score_mod._coverage_from_detail(detail) == score_mod.compute_requirement_coverage(ws, 1) == 1.0
+
+
+def test_coverage_detail_flags_the_uncovered_row(tmp_path):
+    ws = tmp_path / "workspace"
+    _write_wm1_app(ws, with_delete=False)  # DELETE disabled -> R-delete uncovered
+    detail = score_mod.compute_coverage_detail(ws, 1)
+
+    by_id = {d["id"]: d["covered"] for d in detail}
+    assert by_id["R-delete"] is False
+    covered = sum(1 for d in detail if d["covered"])
+    assert score_mod._coverage_from_detail(detail) == score_mod.compute_requirement_coverage(ws, 1)
+    assert score_mod._coverage_from_detail(detail) == covered / len(detail)
+
+
+# --- M3: an unbootable app still emits a detail (all covered:false) -------------
+
+def test_unbootable_workspace_detail_all_false(tmp_path):
+    ws = tmp_path / "workspace"
+    ws.mkdir()  # no app -> nothing boots
+    detail = score_mod.compute_coverage_detail(ws, 1)
+
+    assert [d["id"] for d in detail] == _checklist_ids(1)  # detail STILL present
+    assert all(d["covered"] is False for d in detail)      # every row false, not mute
+    assert score_mod.compute_requirement_coverage(ws, 1) == 0.0
+
+
+# --- M1/M4: score_record persists the artifact, never a metric -----------------
+
+def test_score_record_writes_coverage_detail(tmp_path, monkeypatch):
+    ws = tmp_path / "runs" / "vanilla" / "wm2" / "workspace"
+    ws.mkdir(parents=True)
+    record = {
+        "arm": "vanilla", "wm": 2, "rep": 0, "status": "done",
+        "metrics": {"regression_rate": 0.0, "requirement_coverage": 0.0,
+                    "oracle_pass_rate": 0.0, "tokens_total": 10.0, "cost_usd": 0.1,
+                    "context_rot_slope": 0.0, "time_to_first_edit": 1.0},
+        "artifacts": {"workspace": str(ws), "transcript": "", "oracle_report": "",
+                      "attempts": "attempt 1: done"},
+    }
+    # wm2 needs a prior wm1 record for the (unused-here) slope chain? wm==2 < 3, so no.
+    (tmp_path / "runs" / "vanilla" / "wm2" / "record.json").write_text(json.dumps(record))
+
+    fake_detail = [
+        {"id": "R-auth-401", "covered": True},
+        {"id": "R-ownership-403", "covered": False},
+        {"id": "R-double-booking-409", "covered": True},
+        {"id": "R-cancellation-window-422", "covered": True},
+        {"id": "R-tenant-isolation", "covered": True},
+    ]  # 4/5 covered
+    monkeypatch.setattr("benchmark.score.compute_coverage_detail", lambda ws, wm, family="wm": fake_detail)
+    monkeypatch.setattr("benchmark.score.compute_oracle_pass_rate", lambda ws, wm, family="wm": 1.0)
+    monkeypatch.setattr("benchmark.score.compute_regression_rate_v2", lambda ws, wm, family="wm": 0.0)
+
+    scored = score_mod.score_record("vanilla", 2, runs_root=tmp_path / "runs")
+
+    assert scored.metrics["requirement_coverage"] == 0.8              # derived from the detail
+    assert "coverage_detail" not in scored.metrics                   # never a metric
+    assert json.loads(scored.artifacts["coverage_detail"]) == fake_detail  # emitted verbatim
+
+
+# --- R1: coverage_detail can never become a gating metric ----------------------
+
+def test_coverage_detail_is_not_a_metric():
+    assert "coverage_detail" not in REQUIRED_METRICS
+    assert "coverage_detail" not in OPTIONAL_METRICS
+    record = {
+        "arm": "vanilla", "wm": 1, "rep": 0, "status": "done",
+        "metrics": {
+            "regression_rate": 0.0, "requirement_coverage": 1.0,
+            "oracle_pass_rate": 1.0, "tokens_total": 10.0, "cost_usd": 0.1,
+            "context_rot_slope": 0.0, "time_to_first_edit": 1.0,
+            "coverage_detail": "[]",  # forbidden as a metric
+        },
+        "artifacts": {"workspace": "/x", "transcript": "", "oracle_report": ""},
+    }
+    with pytest.raises(BenchError, match="invalid_run_record"):
+        validate(record)
+
+
+# --- R2: a checklist row without a stable id is rejected -----------------------
+
+def test_checklist_row_without_id_rejected():
+    with pytest.raises(BenchError, match="invalid_checklist"):
+        score_mod.validate_checklist([{"description": "x", "probe": lambda b, w: True}])

--- a/benchmark/tests/test_hermetic_scoring.py
+++ b/benchmark/tests/test_hermetic_scoring.py
@@ -1,0 +1,148 @@
+"""Hermetic scoring (hermetic-scoring §3 CONTRACT @ v1): scoring boots the app
+in an ISOLATED copy of the workspace with the persistent store RESET, so the
+source workspace is never mutated and coverage/oracle are reproducible on
+archived builds.
+
+`isolated_workspace` is imported LAZILY inside each test so the suite runs RED
+test-by-test on the missing implementation, not dying at collection.
+"""
+from __future__ import annotations
+
+import importlib
+import pathlib
+import textwrap
+
+from benchmark.score import compute_requirement_coverage
+
+
+def _oracle_lib():
+    return importlib.import_module("benchmark.workload._oracle_lib")
+
+
+# A minimal `python -m app` booking app that PERSISTS to bookings.json in cwd —
+# enough to exercise the store-write path (the wm1 checklist probes POST to it).
+_STORE_APP = '''
+import json, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+STORE = "bookings.json"
+
+
+def _load():
+    try:
+        with open(STORE) as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        data = _load()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(list(data.values())).encode())
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(n) or b"{}")
+        data = _load()
+        bid = str(len(data) + 1)
+        body["id"] = bid
+        data[bid] = body
+        with open(STORE, "w") as f:   # PERSIST to cwd — the contamination source
+            json.dump(data, f)
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+
+def main():
+    HTTPServer(("127.0.0.1", int(os.environ.get("PORT", "8000"))), H).serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def _write_store_app(ws: pathlib.Path) -> None:
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / "app.py").write_text(textwrap.dedent(_STORE_APP))
+
+
+# --------------------------------------------------------------------------
+# isolated_workspace — the core new symbol (Contract)
+# --------------------------------------------------------------------------
+
+
+def test_isolated_workspace_resets_store_and_excludes_heavy(tmp_path):
+    ws = tmp_path / "ws"
+    _write_store_app(ws)
+    (ws / "bookings.json").write_text('{"seed": {"id": "seed"}}')
+    (ws / "bookings_data.json").write_text("{}")  # a differently-named store
+    (ws / ".venv").mkdir()
+    (ws / ".venv" / "big").write_text("x" * 1000)
+    (ws / "__pycache__").mkdir()
+    (ws / "__pycache__" / "junk.pyc").write_text("x")
+
+    isolated_workspace = _oracle_lib().isolated_workspace
+    with isolated_workspace(ws) as copy:
+        copy = pathlib.Path(copy)
+        assert (copy / "app.py").is_file()          # code copied
+        assert not (copy / ".venv").exists()         # heavy dir excluded
+        assert not (copy / "__pycache__").exists()
+        assert not (copy / "bookings.json").exists()      # root *.json store reset
+        assert not (copy / "bookings_data.json").exists()  # name-agnostic reset
+        held = copy
+
+    assert not held.exists()  # temp removed on exit
+
+
+def test_isolated_workspace_never_writes_source(tmp_path):
+    ws = tmp_path / "ws"
+    _write_store_app(ws)
+    (ws / "bookings.json").write_text('{"seed": 1}')
+    before = (ws / "bookings.json").read_bytes()
+
+    isolated_workspace = _oracle_lib().isolated_workspace
+    with isolated_workspace(ws) as copy:
+        copy = pathlib.Path(copy)
+        (copy / "bookings.json").write_text('{"mutated": true}')  # write into the COPY
+
+    assert (ws / "bookings.json").read_bytes() == before  # source byte-unchanged
+    assert (ws / ".venv" if (ws / ".venv").exists() else ws).exists()
+
+
+# --------------------------------------------------------------------------
+# scoring is hermetic (M1/M2) — the source store is never mutated by scoring
+# --------------------------------------------------------------------------
+
+
+def test_coverage_does_not_mutate_source_store(tmp_path):
+    ws = tmp_path / "ws"
+    _write_store_app(ws)
+    (ws / "bookings.json").write_text('{"seed": {"id": "seed"}}')
+    before = (ws / "bookings.json").read_bytes()
+
+    # the wm1 probes POST to the app; without isolation those bookings would be
+    # persisted into THIS workspace's store — with isolation they land in a copy.
+    compute_requirement_coverage(ws, 1)
+
+    assert (ws / "bookings.json").read_bytes() == before
+
+
+def test_coverage_reproducible_across_repeated_scorings(tmp_path):
+    ws = tmp_path / "ws"
+    _write_store_app(ws)
+    # no pre-seeded store: each scoring must start from the SAME reset state,
+    # so repeated calls yield the identical value despite probe writes.
+    first = compute_requirement_coverage(ws, 1)
+    second = compute_requirement_coverage(ws, 1)
+    third = compute_requirement_coverage(ws, 1)
+    assert first == second == third

--- a/benchmark/tests/test_judge_median.py
+++ b/benchmark/tests/test_judge_median.py
@@ -1,6 +1,11 @@
 """Median-of-N judging (bench-judge-median fast task): variance-resistant
-spec_fidelity via judge_fidelity_median + auditable raw scores persisted in
-artifacts["judge_scores"]."""
+judging via judge_fidelity_median + auditable raw scores.
+
+`judge_fidelity_median` itself is unchanged and still tested here. What CHANGED
+at honest-fidelity-meter: the judge LEFT the score_record metric path entirely
+(fidelity is now deterministic requirement_coverage), so the integration test
+pins the DEFERRAL — task judge-advisory re-adds the judge as an advisory,
+source-aware `code_quality_annotation` artifact (never a metric)."""
 from __future__ import annotations
 
 import json
@@ -54,19 +59,30 @@ def test_two_failures_raise(tmp_path):
         judge_fidelity_median(tmp_path, 1, {}, judge_cmd=cmd, n=3)
 
 
-def test_score_record_persists_judge_scores(tmp_path):
+def test_score_record_defers_judge_out_of_metric_path(tmp_path, monkeypatch):
+    """The judge no longer feeds any metric: score_record records deterministic
+    requirement_coverage, no spec_fidelity, and a deferred judge_scores sentinel
+    even when a (would-succeed) judge_cmd is supplied."""
     ws = tmp_path / "runs" / "vanilla" / "wm1" / "workspace"
     ws.mkdir(parents=True)
     record = {
         "arm": "vanilla", "wm": 1, "rep": 0, "status": "done",
-        "metrics": {"regression_rate": 0.0, "spec_fidelity": 0.0,
-                    "tokens_total": 10.0, "cost_usd": 0.1,
+        "metrics": {"regression_rate": 0.0, "requirement_coverage": 0.0,
+                    "oracle_pass_rate": 0.0, "tokens_total": 10.0, "cost_usd": 0.1,
                     "context_rot_slope": 0.0, "time_to_first_edit": 1.0},
         "artifacts": {"workspace": str(ws), "transcript": "", "oracle_report": "",
                       "attempts": "attempt 1: done"},
     }
     (tmp_path / "runs" / "vanilla" / "wm1" / "record.json").write_text(json.dumps(record))
+
+    # deterministic seams — no live pytest / app boot in this wiring test.
+    monkeypatch.setattr("benchmark.score.compute_requirement_coverage", lambda ws, wm, family="wm": 0.5)
+    monkeypatch.setattr("benchmark.score.compute_oracle_pass_rate", lambda ws, wm, family="wm": 1.0)
+    monkeypatch.setattr("benchmark.score.compute_regression_rate_v2", lambda ws, wm, family="wm": 0.0)
+
     cmd = _stateful_judge(tmp_path, ["0.9", "0.5", "0.9"])
     scored = score_record("vanilla", 1, judge_cmd=cmd, runs_root=tmp_path / "runs")
-    assert scored.metrics["spec_fidelity"] == 0.9
-    assert scored.artifacts["judge_scores"] == "0.9;0.5;0.9"
+
+    assert scored.metrics["requirement_coverage"] == 0.5
+    assert "spec_fidelity" not in scored.metrics
+    assert scored.artifacts["judge_scores"].startswith("deferred:")

--- a/benchmark/tests/test_judge_median.py
+++ b/benchmark/tests/test_judge_median.py
@@ -3,9 +3,11 @@ judging via judge_fidelity_median + auditable raw scores.
 
 `judge_fidelity_median` itself is unchanged and still tested here. What CHANGED
 at honest-fidelity-meter: the judge LEFT the score_record metric path entirely
-(fidelity is now deterministic requirement_coverage), so the integration test
-pins the DEFERRAL — task judge-advisory re-adds the judge as an advisory,
-source-aware `code_quality_annotation` artifact (never a metric)."""
+(fidelity is now deterministic requirement_coverage). Task judge-advisory then
+re-added the judge as an advisory, source-aware `code_quality_annotation`
+artifact (never a metric) — so the integration test pins that the annotation
+lands in `artifacts`, never in `metrics`, and the old `judge_scores` sentinel
+is gone."""
 from __future__ import annotations
 
 import json
@@ -59,10 +61,11 @@ def test_two_failures_raise(tmp_path):
         judge_fidelity_median(tmp_path, 1, {}, judge_cmd=cmd, n=3)
 
 
-def test_score_record_defers_judge_out_of_metric_path(tmp_path, monkeypatch):
+def test_score_record_annotates_judge_out_of_metric_path(tmp_path, monkeypatch):
     """The judge no longer feeds any metric: score_record records deterministic
-    requirement_coverage, no spec_fidelity, and a deferred judge_scores sentinel
-    even when a (would-succeed) judge_cmd is supplied."""
+    requirement_coverage and no spec_fidelity, and the judge's output lands in
+    `artifacts["code_quality_annotation"]` (never in metrics); the old
+    `judge_scores` deferral sentinel is gone."""
     ws = tmp_path / "runs" / "vanilla" / "wm1" / "workspace"
     ws.mkdir(parents=True)
     record = {
@@ -85,4 +88,8 @@ def test_score_record_defers_judge_out_of_metric_path(tmp_path, monkeypatch):
 
     assert scored.metrics["requirement_coverage"] == 0.5
     assert "spec_fidelity" not in scored.metrics
-    assert scored.artifacts["judge_scores"].startswith("deferred:")
+    assert "judge_scores" not in scored.artifacts
+    assert "code_quality_annotation" in scored.artifacts
+    assert "code_quality_annotation" not in scored.metrics
+    # judge_cmd supplied + would-succeed -> the annotation is that judge's stdout
+    assert scored.artifacts["code_quality_annotation"] == "0.9"

--- a/benchmark/tests/test_judge_median.py
+++ b/benchmark/tests/test_judge_median.py
@@ -79,7 +79,10 @@ def test_score_record_annotates_judge_out_of_metric_path(tmp_path, monkeypatch):
     (tmp_path / "runs" / "vanilla" / "wm1" / "record.json").write_text(json.dumps(record))
 
     # deterministic seams — no live pytest / app boot in this wiring test.
-    monkeypatch.setattr("benchmark.score.compute_requirement_coverage", lambda ws, wm, family="wm": 0.5)
+    # score_record derives coverage from compute_coverage_detail (coverage-detail):
+    # a 1-of-2-covered detail -> requirement_coverage 0.5.
+    monkeypatch.setattr("benchmark.score.compute_coverage_detail",
+                        lambda ws, wm, family="wm": [{"id": "a", "covered": True}, {"id": "b", "covered": False}])
     monkeypatch.setattr("benchmark.score.compute_oracle_pass_rate", lambda ws, wm, family="wm": 1.0)
     monkeypatch.setattr("benchmark.score.compute_regression_rate_v2", lambda ws, wm, family="wm": 0.0)
 
@@ -113,7 +116,8 @@ def test_score_record_purges_stale_judge_scores_sentinel(tmp_path, monkeypatch):
     }
     (tmp_path / "runs" / "vanilla" / "wm1" / "record.json").write_text(json.dumps(record))
 
-    monkeypatch.setattr("benchmark.score.compute_requirement_coverage", lambda ws, wm, family="wm": 1.0)
+    monkeypatch.setattr("benchmark.score.compute_coverage_detail",
+                        lambda ws, wm, family="wm": [{"id": "a", "covered": True}])
     monkeypatch.setattr("benchmark.score.compute_oracle_pass_rate", lambda ws, wm, family="wm": 1.0)
     monkeypatch.setattr("benchmark.score.compute_regression_rate_v2", lambda ws, wm, family="wm": 0.0)
 

--- a/benchmark/tests/test_judge_median.py
+++ b/benchmark/tests/test_judge_median.py
@@ -93,3 +93,31 @@ def test_score_record_annotates_judge_out_of_metric_path(tmp_path, monkeypatch):
     assert "code_quality_annotation" not in scored.metrics
     # judge_cmd supplied + would-succeed -> the annotation is that judge's stdout
     assert scored.artifacts["code_quality_annotation"] == "0.9"
+
+
+def test_score_record_purges_stale_judge_scores_sentinel(tmp_path, monkeypatch):
+    """A record persisted BEFORE judge-advisory carries the superseded
+    `judge_scores` deferral sentinel in its artifacts. Re-scoring must PURGE it
+    (the frozen contract: "the judge_scores deferred sentinel is REMOVED") — a
+    re-scored record never carries both keys."""
+    ws = tmp_path / "runs" / "vanilla" / "wm1" / "workspace"
+    ws.mkdir(parents=True)
+    record = {
+        "arm": "vanilla", "wm": 1, "rep": 0, "status": "done",
+        "metrics": {"regression_rate": 0.0, "requirement_coverage": 1.0,
+                    "oracle_pass_rate": 1.0, "tokens_total": 10.0, "cost_usd": 0.1,
+                    "context_rot_slope": 0.0, "time_to_first_edit": 1.0},
+        "artifacts": {"workspace": str(ws), "transcript": "", "oracle_report": "",
+                      # the stale sentinel a pre-judge-advisory scoring left behind:
+                      "judge_scores": "deferred: see code_quality_annotation (task judge-advisory)"},
+    }
+    (tmp_path / "runs" / "vanilla" / "wm1" / "record.json").write_text(json.dumps(record))
+
+    monkeypatch.setattr("benchmark.score.compute_requirement_coverage", lambda ws, wm, family="wm": 1.0)
+    monkeypatch.setattr("benchmark.score.compute_oracle_pass_rate", lambda ws, wm, family="wm": 1.0)
+    monkeypatch.setattr("benchmark.score.compute_regression_rate_v2", lambda ws, wm, family="wm": 0.0)
+
+    scored = score_record("vanilla", 1, runs_root=tmp_path / "runs")  # no judge_cmd
+
+    assert "judge_scores" not in scored.artifacts  # purged
+    assert scored.artifacts["code_quality_annotation"].startswith("unavailable")

--- a/benchmark/tests/test_pilot.py
+++ b/benchmark/tests/test_pilot.py
@@ -1,4 +1,4 @@
-"""Scenarios: pilot orchestration — resolve_setup_steps, attest_record,
+"""Scenarios: pilot orchestration — resolve_setup_steps,
 run_pilot (M4-M10, R3-R7) — fully hermetic via the fake-agent/fake-judge
 seam, zero live `claude` calls (grep-checked: this module never invokes the
 live claude binary)."""
@@ -108,7 +108,8 @@ def _seed_record(runs_root: pathlib.Path, arm: str, wm: int, **overrides) -> Non
         status="done",
         metrics={
             "regression_rate": 0.0,
-            "spec_fidelity": 0.0,
+            "requirement_coverage": 0.0,
+            "oracle_pass_rate": 0.0,
             "tokens_total": 0.0,
             "cost_usd": 0.0,
             "context_rot_slope": 0.0,
@@ -175,64 +176,9 @@ def test_add_arm_setup_succeeds_in_bare_sandbox(tmp_path):
     assert record.status != "failed" or "setup" not in record.artifacts.get("attempts", "")
 
 
-# --------------------------------------------------------------------------
-# M4, R3-R5 — attest_record
-# --------------------------------------------------------------------------
-
-
-def test_attest_then_report_drops_unaudited(tmp_path):
-    from benchmark import report as report_mod
-
-    runs_root = tmp_path / "runs"
-    _seed_record(runs_root, "add", 1, metrics={
-        "regression_rate": 0.0,
-        "spec_fidelity": 0.82,
-        "tokens_total": 100.0,
-        "cost_usd": 0.1,
-        "context_rot_slope": 0.0,
-        "time_to_first_edit": 1.0,
-    })
-
-    before = report_mod.render_report(runs_root, arms=["add"], wms=[1])
-    assert "(unaudited)" in before
-
-    updated = pilot_mod.attest_record("add", 1, "matches PROMPT.md requirements", runs_root=runs_root)
-    assert updated.artifacts["spec_fidelity_audit"] == "spot-checked: matches PROMPT.md requirements"
-
-    after = report_mod.render_report(runs_root, arms=["add"], wms=[1])
-    assert "(unaudited)" not in after
-    assert "0.82" in after
-
-
-def test_attest_record_not_found(tmp_path):
-    runs_root = tmp_path / "runs"
-    with pytest.raises(BenchError, match="record_not_found"):
-        pilot_mod.attest_record("add", 2, "x", runs_root=runs_root)
-    assert not (runs_root / "add" / "wm2" / "record.json").exists()
-
-
-def test_attest_record_not_done(tmp_path):
-    runs_root = tmp_path / "runs"
-    _seed_record(runs_root, "add", 1, status="failed")
-    record_path = runs_root / "add" / "wm1" / "record.json"
-    before_bytes = record_path.read_bytes()
-
-    with pytest.raises(BenchError, match="record_not_done"):
-        pilot_mod.attest_record("add", 1, "x", runs_root=runs_root)
-
-    assert record_path.read_bytes() == before_bytes
-
-
-def test_attest_record_not_scored(tmp_path):
-    runs_root = tmp_path / "runs"
-    _seed_record(runs_root, "add", 1, status="done")  # spec_fidelity default 0.0 placeholder
-    record_path = runs_root / "add" / "wm1" / "record.json"
-    before_bytes = record_path.read_bytes()
-
-    with pytest.raises(BenchError, match="record_not_scored"):
-        pilot_mod.attest_record("add", 1, "x", runs_root=runs_root)
-
-    assert record_path.read_bytes() == before_bytes
+# (honest-fidelity-meter) the `attest_record` spot-check writer + its
+# `pilot.py attest` CLI were RETIRED alongside the spec_fidelity_audit report
+# hook: deterministic requirement_coverage has no subjective score to attest.
 
 
 # --------------------------------------------------------------------------
@@ -338,7 +284,8 @@ def test_run_pilot_resumes_without_reinvoking(tmp_path, monkeypatch):
             wm,
             metrics={
                 "regression_rate": 0.0 if wm != 3 else 0.1,
-                "spec_fidelity": 0.8,
+                "requirement_coverage": 0.8,
+                "oracle_pass_rate": 1.0,
                 "tokens_total": 10.0,
                 "cost_usd": 0.01,
                 "context_rot_slope": 0.0,
@@ -376,37 +323,8 @@ def test_run_pilot_rejects_unknown_arm(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# CLI surface: `pilot.py attest` / `pilot.py run-all`
+# CLI surface: `pilot.py run-all`
 # --------------------------------------------------------------------------
-
-
-def test_cli_attest_success_and_rejection(tmp_path, capsys):
-    runs_root = tmp_path / "runs"
-    _seed_record(
-        runs_root,
-        "add",
-        1,
-        metrics={
-            "regression_rate": 0.0,
-            "spec_fidelity": 0.9,
-            "tokens_total": 10.0,
-            "cost_usd": 0.01,
-            "context_rot_slope": 0.0,
-            "time_to_first_edit": 1.0,
-        },
-    )
-
-    rc = pilot_mod.main(["attest", "--arm", "add", "--wm", "1", "--note", "x", "--runs-root", str(runs_root)])
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "spot-checked: x" in out
-
-    rc2 = pilot_mod.main(
-        ["attest", "--arm", "add", "--wm", "2", "--note", "x", "--runs-root", str(runs_root)]
-    )
-    assert rc2 == 2
-    err = capsys.readouterr().err
-    assert "record_not_found" in err
 
 
 def test_cli_run_all_rejects_unknown_arm(tmp_path, capsys):
@@ -434,7 +352,8 @@ def _rec(arm: str, wm: int, *, tokens: float, cost: float, fidelity: float) -> "
             status="done",
             metrics={
                 "regression_rate": 0.0,
-                "spec_fidelity": fidelity,
+                "requirement_coverage": fidelity,
+                "oracle_pass_rate": 1.0,
                 "tokens_total": tokens,
                 "cost_usd": cost,
                 "context_rot_slope": 0.0,

--- a/benchmark/tests/test_report.py
+++ b/benchmark/tests/test_report.py
@@ -18,7 +18,8 @@ def _record(
     wm: int,
     *,
     status: str = "done",
-    spec_fidelity: float = 0.82,
+    requirement_coverage: float = 0.82,
+    oracle_pass_rate: float = 1.0,
     regression_rate: float = 0.0,
     context_rot_slope: float = 0.0,
     tokens_total: float = 4200.0,
@@ -40,7 +41,8 @@ def _record(
             "status": status,
             "metrics": {
                 "regression_rate": regression_rate,
-                "spec_fidelity": spec_fidelity,
+                "requirement_coverage": requirement_coverage,
+                "oracle_pass_rate": oracle_pass_rate,
                 "tokens_total": tokens_total,
                 "cost_usd": cost_usd,
                 "context_rot_slope": context_rot_slope,
@@ -54,7 +56,7 @@ def _record(
 def _seed_full_grid(runs_root: pathlib.Path) -> None:
     for arm in ARM_NAMES:
         for wm in (1, 2, 3):
-            record = _record(arm, wm, extra_artifacts={"spec_fidelity_audit": "spot-checked: seed"})
+            record = _record(arm, wm)
             write_record_atomic(runs_root / arm / f"wm{wm}" / "record.json", record)
 
 
@@ -109,15 +111,9 @@ def test_report_wm1_wm2_na_annotation(tmp_path):
     assert "0.00" not in text
 
 
-def test_report_unaudited_suffix(tmp_path):
-    runs_root = tmp_path / "runs"
-    record = _record("add", 1, spec_fidelity=0.82)  # no spec_fidelity_audit key
-    write_record_atomic(runs_root / "add" / "wm1" / "record.json", record)
-
-    text = report_mod.render_report(runs_root, arms=["add"], wms=[1])
-
-    assert "(unaudited)" in text
-    assert "0.82" in text
+# (honest-fidelity-meter) the spec_fidelity_audit / "(unaudited)" annotation
+# was DROPPED: requirement_coverage is deterministic (probes against the built
+# app), so there is no subjective per-record score for a human to attest.
 
 
 def test_report_rejects_unknown_arm(tmp_path):

--- a/benchmark/tests/test_report.py
+++ b/benchmark/tests/test_report.py
@@ -136,3 +136,52 @@ def test_report_rejects_invalid_wm(tmp_path, capsys):
     assert rc == 2
     out = capsys.readouterr()
     assert "invalid_wm" in out.err
+
+
+# --------------------------------------------------------------------------
+# report-diagnostics: surface coverage_detail + code_quality_annotation
+# --------------------------------------------------------------------------
+
+import json as _json
+
+
+def test_report_diagnostics_shows_uncovered_and_annotation(tmp_path):
+    runs_root = tmp_path / "runs"
+    _seed_full_grid(runs_root)
+    # gsd/wm2 missed exactly the cancellation-window requirement (the real signal)
+    detail = [
+        {"id": "R-auth-401", "covered": True},
+        {"id": "R-ownership-403", "covered": True},
+        {"id": "R-double-booking-409", "covered": True},
+        {"id": "R-cancellation-window-422", "covered": False},
+        {"id": "R-tenant-isolation", "covered": True},
+    ]
+    rec = _record("gsd", 2, requirement_coverage=0.8, extra_artifacts={
+        "coverage_detail": _json.dumps(detail),
+        "code_quality_annotation": "idiomatic but omits the cancellation window rule",
+    })
+    write_record_atomic(runs_root / "gsd" / "wm2" / "record.json", rec)
+
+    text = report_mod.render_report(runs_root)
+
+    # the diagnostics table header (distinctive — never appears in an evidence path)
+    assert "| arm | coverage | uncovered | code quality |" in text
+    assert "R-cancellation-window-422" in text          # the uncovered requirement is named
+    assert "omits the cancellation window" in text      # the annotation text is surfaced
+    assert "4/5" in text                                 # coverage breakdown
+
+
+def test_report_diagnostics_tolerates_missing_and_malformed(tmp_path):
+    runs_root = tmp_path / "runs"
+    _seed_full_grid(runs_root)  # base records carry NO coverage_detail
+    # one record with a MALFORMED coverage_detail string
+    bad = _record("add", 2, extra_artifacts={"coverage_detail": "{not valid json"})
+    write_record_atomic(runs_root / "add" / "wm2" / "record.json", bad)
+
+    text = report_mod.render_report(runs_root)  # must NOT raise
+
+    # the section renders (distinctive header) despite absent/malformed artifacts
+    assert "| arm | coverage | uncovered | code quality |" in text
+    # the malformed add/wm2 coverage cell degrades to the em-dash placeholder, not a crash
+    diag_wm2 = text.split("### WM2 diagnostics")[1].split("###")[0]
+    assert "| add | — |" in diag_wm2

--- a/benchmark/tests/test_requirement_coverage.py
+++ b/benchmark/tests/test_requirement_coverage.py
@@ -1,0 +1,278 @@
+"""Red/green for coverage-scorer (honest-fidelity-meter, frozen §3 v1).
+
+Deterministic `requirement_coverage` replaces the artifact-blind LLM `spec_fidelity`:
+a frozen per-WM requirement checklist (1 requirement -> >=1 probe) is run against
+the built app; coverage = covered/total, in [0,1], with NO LLM in the metric path.
+
+One test per §2 scenario. App-dependent probes use a minimal WM1 booking-app
+fixture served via the entry contract `python -m app`.
+
+Run: python3 -m pytest tests/test_requirement_coverage.py -q
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from benchmark import score as score_mod
+from benchmark.schema.run_record import (
+    OPTIONAL_METRICS,
+    REQUIRED_METRICS,
+    BenchError,
+    validate,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# fixtures — a minimal WM1 booking app (entry contract: python -m app on $PORT)
+# --------------------------------------------------------------------------
+
+_WM1_APP = '''
+import json, os, re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+BOOKINGS = {}
+NEXT_ID = [1]
+STATUSES = {"pending", "confirmed", "cancelled"}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, status, body):
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _read_json(self):
+        length = int(self.headers.get("Content-Length", 0))
+        return json.loads(self.rfile.read(length)) if length else {}
+
+    def do_POST(self):
+        if self.path != "/bookings":
+            return self._send(404, {"error": "not_found"})
+        b = self._read_json()
+        if not b.get("title") or not b.get("start_time"):
+            return self._send(400, {"error": "missing_required_field"})
+        dur = b.get("duration_minutes")
+        if not isinstance(dur, int) or isinstance(dur, bool) or dur <= 0:
+            return self._send(400, {"error": "bad_duration"})
+        if b.get("status", "pending") not in STATUSES:
+            return self._send(400, {"error": "bad_status"})
+        bid = str(NEXT_ID[0]); NEXT_ID[0] += 1
+        rec = {"id": bid, "title": b["title"], "start_time": b["start_time"],
+               "duration_minutes": dur, "status": b.get("status", "pending")}
+        BOOKINGS[bid] = rec
+        return self._send(201, rec)
+
+    def do_GET(self):
+        if self.path == "/bookings":
+            return self._send(200, list(BOOKINGS.values()))
+        m = re.fullmatch(r"/bookings/([^/]+)", self.path)
+        if m:
+            rec = BOOKINGS.get(m.group(1))
+            return self._send(200, rec) if rec else self._send(404, {"error": "not_found"})
+        return self._send(404, {"error": "not_found"})
+
+    def do_PATCH(self):
+        m = re.fullmatch(r"/bookings/([^/]+)", self.path)
+        if not m:
+            return self._send(404, {"error": "not_found"})
+        rec = BOOKINGS.get(m.group(1))
+        if not rec:
+            return self._send(404, {"error": "not_found"})
+        b = self._read_json()
+        if "status" in b and b["status"] not in STATUSES:
+            return self._send(400, {"error": "bad_status"})
+        rec.update({k: v for k, v in b.items() if k in ("title", "start_time", "duration_minutes", "status")})
+        return self._send(200, rec)
+
+    def do_DELETE(self):
+        m = re.fullmatch(r"/bookings/([^/]+)", self.path)
+        if not m:
+            return self._send(404, {"error": "not_found"})
+        return self._send(200, {}) if BOOKINGS.pop(m.group(1), None) is not None \\
+            else self._send(404, {"error": "not_found"})
+
+    def log_message(self, *a):
+        pass
+
+
+def main():
+    HTTPServer(("127.0.0.1", int(os.environ["PORT"])), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+# a CLI so the WM1 "CLI parity" requirement can be probed
+_WM1_CLI = '''
+import sys, json, urllib.request, os
+
+def main(argv):
+    base = os.environ.get("APP_BASE", "http://127.0.0.1:" + os.environ.get("PORT", "0"))
+    cmd = argv[0] if argv else ""
+    if cmd == "list":
+        with urllib.request.urlopen(base + "/bookings") as r:
+            print(r.read().decode()); return 0
+    return 1
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+'''
+
+
+def _write_wm1_app(ws: pathlib.Path, *, with_delete: bool = True, with_cli: bool = True) -> None:
+    ws.mkdir(parents=True, exist_ok=True)
+    app = _WM1_APP if with_delete else _WM1_APP.replace("def do_DELETE", "def _disabled_DELETE")
+    (ws / "app.py").write_text(app)
+    if with_cli:
+        (ws / "cli.py").write_text(_WM1_CLI)
+
+
+def _write_record(runs_root: pathlib.Path, arm: str, wm: int, metrics: dict) -> pathlib.Path:
+    wm_dir = runs_root / arm / f"wm{wm}"
+    ws = wm_dir / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    rec = {
+        "arm": arm, "wm": wm, "rep": 0, "status": "done",
+        "metrics": metrics,
+        "artifacts": {"workspace": str(ws), "transcript": str(wm_dir / "t.jsonl"),
+                      "oracle_report": str(wm_dir / "oracle_report.json")},
+    }
+    (wm_dir / "record.json").write_text(json.dumps(rec))
+    (wm_dir / "t.jsonl").write_text("")
+    (wm_dir / "oracle_report.json").write_text(json.dumps(
+        {"app_check": {"app_reachable": True, "status": 200}, "isolation_clean": True, "leaks": []}))
+    return wm_dir / "record.json"
+
+
+# --------------------------------------------------------------------------
+# Scenario: deterministic coverage from a WM1 checklist   (M2, M5)
+# --------------------------------------------------------------------------
+
+def test_deterministic_coverage_from_wm1_checklist(tmp_path):
+    ws = tmp_path / "workspace"
+    _write_wm1_app(ws)
+    first = score_mod.compute_requirement_coverage(ws, 1)
+    second = score_mod.compute_requirement_coverage(ws, 1)
+    assert 0.0 <= first <= 1.0, first
+    assert first == second, f"non-deterministic: {first} != {second}"
+    # a correct WM1 app covers every requirement
+    assert first == 1.0, f"complete WM1 app should score 1.0, got {first}"
+
+
+# --------------------------------------------------------------------------
+# Scenario: a failing probe lowers coverage, never crashes   (M3)
+# --------------------------------------------------------------------------
+
+def test_failing_probe_lowers_coverage_no_crash(tmp_path):
+    ws = tmp_path / "workspace"
+    _write_wm1_app(ws, with_delete=False)  # DELETE endpoint missing
+    cov = score_mod.compute_requirement_coverage(ws, 1)  # must NOT raise
+    assert 0.0 <= cov < 1.0, f"a missing DELETE must lower coverage below 1.0, got {cov}"
+
+
+# --------------------------------------------------------------------------
+# Scenario: metric set swapped — old key rejected   (M1, R1)
+# --------------------------------------------------------------------------
+
+def test_metric_set_swapped():
+    assert "requirement_coverage" in REQUIRED_METRICS
+    assert "oracle_pass_rate" in REQUIRED_METRICS
+    assert "spec_fidelity" not in REQUIRED_METRICS
+    assert "spec_fidelity" not in OPTIONAL_METRICS
+
+
+def _base_metrics(**over):
+    m = {"regression_rate": 0.0, "requirement_coverage": 0.9, "tokens_total": 1.0,
+         "cost_usd": 0.1, "context_rot_slope": 0.0, "time_to_first_edit": 1.0,
+         "oracle_pass_rate": 1.0}
+    m.update(over)
+    return m
+
+
+def test_spec_fidelity_only_record_rejected():
+    bad = {"arm": "add", "wm": 1, "rep": 0, "status": "done",
+           "metrics": _base_metrics(spec_fidelity=0.9, requirement_coverage=None),
+           "artifacts": {"workspace": "w", "transcript": "t", "oracle_report": "o"}}
+    del bad["metrics"]["requirement_coverage"]
+    bad["metrics"]["spec_fidelity"] = 0.9
+    with pytest.raises(BenchError, match="invalid_run_record"):
+        validate(bad)
+
+
+def test_new_metric_record_validates_clean():
+    good = {"arm": "add", "wm": 1, "rep": 0, "status": "done",
+            "metrics": _base_metrics(),
+            "artifacts": {"workspace": "w", "transcript": "t", "oracle_report": "o"}}
+    validate(good)  # must not raise
+
+
+# --------------------------------------------------------------------------
+# Scenario: slope over coverage with an archived-record shim   (M4)
+# --------------------------------------------------------------------------
+
+def test_slope_shim_reads_archived_spec_fidelity(tmp_path):
+    # M4: the WM3+ slope prior-read must read a LEGACY record (spec_fidelity only,
+    # no requirement_coverage) leniently — never through the v3-strict validate() —
+    # and fall back to spec_fidelity, so a mixed old/new trajectory never KeyErrors.
+    runs_root = tmp_path / "runs"
+    # WM1 archived: only spec_fidelity (would be REJECTED by validate())
+    m1 = {"regression_rate": 0.0, "spec_fidelity": 0.8, "tokens_total": 1.0,
+          "cost_usd": 0.1, "context_rot_slope": 0.0, "time_to_first_edit": 1.0}
+    _write_record(runs_root, "add", 1, m1)
+    _write_record(runs_root, "add", 2, _base_metrics(requirement_coverage=0.9))
+
+    m1_read = score_mod._read_prior_metrics_lenient(runs_root, "add", 1)
+    m2_read = score_mod._read_prior_metrics_lenient(runs_root, "add", 2)
+    assert score_mod._prior_fidelity_value(m1_read) == 0.8, "legacy spec_fidelity read via shim"
+    assert score_mod._prior_fidelity_value(m2_read) == 0.9, "new requirement_coverage read directly"
+
+    # the full trajectory (legacy 0.8, new 0.9, this-WM 0.95) computes a float, no KeyError
+    slope = score_mod.compute_context_rot_slope([0.8, 0.9, 0.95])
+    assert isinstance(slope, float)
+
+
+# --------------------------------------------------------------------------
+# Scenario: no LLM in the metric path   (After)
+# --------------------------------------------------------------------------
+
+def test_no_llm_in_metric_path(tmp_path, monkeypatch):
+    runs_root = tmp_path / "runs"
+    ws = runs_root / "add" / "wm1" / "workspace"
+    _write_wm1_app(ws)
+    _write_record(runs_root, "add", 1, _base_metrics())
+
+    def _boom(*a, **k):
+        raise AssertionError("judge must not be on the metric path")
+
+    monkeypatch.setattr(score_mod.judge, "judge_fidelity_median", _boom, raising=False)
+    rec = score_mod.score_record("add", 1, runs_root=runs_root)
+    assert "requirement_coverage" in rec.metrics
+    assert "spec_fidelity" not in rec.metrics
+
+
+# --------------------------------------------------------------------------
+# Scenario: malformed checklist rejected   (R2)
+# --------------------------------------------------------------------------
+
+def test_malformed_checklist_rejected():
+    with pytest.raises(BenchError, match="invalid_checklist"):
+        score_mod.validate_checklist([{"id": "x", "description": "no probe"}])
+
+
+# --------------------------------------------------------------------------
+# Scenario: report shows the new column   (M6)
+# --------------------------------------------------------------------------
+
+def test_report_shows_requirement_coverage_column():
+    from benchmark.report import METRIC_COLUMNS
+    assert "requirement_coverage" in METRIC_COLUMNS
+    assert "spec_fidelity" not in METRIC_COLUMNS

--- a/benchmark/tests/test_run_cli.py
+++ b/benchmark/tests/test_run_cli.py
@@ -136,7 +136,8 @@ def test_resume_cli_sequences_remaining_wms(tmp_path, monkeypatch):
             "status": "done",
             "metrics": {
                 "regression_rate": 0.0,
-                "spec_fidelity": 0.0,
+                "requirement_coverage": 0.0,
+                "oracle_pass_rate": 0.0,
                 "tokens_total": 0.0,
                 "cost_usd": 0.0,
                 "context_rot_slope": 0.0,

--- a/benchmark/tests/test_run_record.py
+++ b/benchmark/tests/test_run_record.py
@@ -12,7 +12,8 @@ VALID = {
     "status": "done",
     "metrics": {
         "regression_rate": 0.0,
-        "spec_fidelity": 0.9,
+        "requirement_coverage": 0.9,
+        "oracle_pass_rate": 1.0,
         "tokens_total": 12345,
         "cost_usd": 0.42,
         "context_rot_slope": 0.01,

--- a/benchmark/tests/test_runner_records.py
+++ b/benchmark/tests/test_runner_records.py
@@ -17,7 +17,8 @@ VALID = {
     "status": "done",
     "metrics": {
         "regression_rate": 0.0,
-        "spec_fidelity": 0.0,
+        "requirement_coverage": 0.0,
+        "oracle_pass_rate": 0.0,
         "tokens_total": 0.0,
         "cost_usd": 0.0,
         "context_rot_slope": 0.0,

--- a/benchmark/tests/test_runner_resume.py
+++ b/benchmark/tests/test_runner_resume.py
@@ -33,7 +33,8 @@ def _seed_done_record(runs_root: pathlib.Path, arm_name: str, wm: int) -> None:
             "status": "done",
             "metrics": {
                 "regression_rate": 0.0,
-                "spec_fidelity": 0.0,
+                "requirement_coverage": 0.0,
+                "oracle_pass_rate": 0.0,
                 "tokens_total": 0.0,
                 "cost_usd": 0.0,
                 "context_rot_slope": 0.0,

--- a/benchmark/tests/test_score.py
+++ b/benchmark/tests/test_score.py
@@ -395,8 +395,10 @@ def test_context_rot_slope_computed_at_wm3(tmp_path, monkeypatch):
     _write_fixture_app(workspace_dir)
     # wm3 coverage pinned so the 3-point trend is exactly [0.9, 0.75, 0.6] and
     # the slope wiring is tested independent of the fixture's exact probe count
-    # (wm3's 4-row checklist could only ever yield a multiple of 0.25).
-    monkeypatch.setattr(score_mod, "compute_requirement_coverage", lambda ws, wm, family="wm": 0.6)
+    # (wm3's 4-row checklist could only ever yield a multiple of 0.25). score_record
+    # derives coverage from compute_coverage_detail -> a 3-of-5 detail yields 0.6.
+    monkeypatch.setattr(score_mod, "compute_coverage_detail",
+                        lambda ws, wm, family="wm": [{"id": f"r{i}", "covered": i < 3} for i in range(5)])
 
     score_mod.score_record("add", 3, runs_root=runs_root)
 
@@ -472,7 +474,8 @@ def test_score_rereads_archived_spec_fidelity_target(tmp_path, monkeypatch):
     record_path.write_text(json.dumps(old))
 
     # deterministic seams — the read-migration is the subject, not probe values
-    monkeypatch.setattr(score_mod, "compute_requirement_coverage", lambda ws, wm, family="wm": 1.0)
+    monkeypatch.setattr(score_mod, "compute_coverage_detail",
+                        lambda ws, wm, family="wm": [{"id": "a", "covered": True}])
     monkeypatch.setattr(score_mod, "compute_oracle_pass_rate", lambda ws, wm, family="wm": 1.0)
 
     scored = score_mod.score_record("add", 1, runs_root=runs_root)

--- a/benchmark/tests/test_score.py
+++ b/benchmark/tests/test_score.py
@@ -55,7 +55,8 @@ def _make_record(
     tokens_total: float = 4200.0,
     cost_usd: float = 0.31,
     time_to_first_edit: float = 12.5,
-    spec_fidelity: float = 0.0,
+    requirement_coverage: float = 0.0,
+    oracle_pass_rate: float = 0.0,
     regression_rate: float = 0.0,
     context_rot_slope: float = 0.0,
     token_source: str | None = None,
@@ -84,7 +85,8 @@ def _make_record(
             "status": status,
             "metrics": {
                 "regression_rate": regression_rate,
-                "spec_fidelity": spec_fidelity,
+                "requirement_coverage": requirement_coverage,
+                "oracle_pass_rate": oracle_pass_rate,
                 "tokens_total": tokens_total,
                 "cost_usd": cost_usd,
                 "context_rot_slope": context_rot_slope,
@@ -283,31 +285,33 @@ def test_unparseable_token_source_surfaced_not_masked(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# M3 - spec_fidelity via injected fake judge
+# fidelity of record is requirement_coverage (deterministic) — NOT the LLM judge
 # --------------------------------------------------------------------------
 
 
-def test_spec_fidelity_via_fake_judge(tmp_path, monkeypatch):
+def test_requirement_coverage_metric_not_from_judge(tmp_path, monkeypatch):
+    """The fidelity metric is deterministic requirement_coverage — the LLM judge
+    is OFF the metric path (score never calls either judge entrypoint). The
+    deterministic coverage probes DO use subprocess to boot the app / run the
+    CLI, so the pin is on the judge FUNCTIONS, not the global subprocess."""
     runs_root = tmp_path / "runs"
     record_path = _make_record(tmp_path, runs_root, "add", 1)
-    judge_cmd = _fake_judge(tmp_path, "0.82")
 
-    calls = []
-    real_run = subprocess.run
+    judge_calls = []
 
-    def _spy_run(argv, **kwargs):
-        calls.append(argv)
-        return real_run(argv, **kwargs)
+    def _boom(*args, **kwargs):
+        judge_calls.append(args)
+        raise AssertionError("judge invoked on the metric path")
 
-    monkeypatch.setattr(score_mod.judge.subprocess, "run", _spy_run)
+    monkeypatch.setattr(score_mod.judge, "judge_fidelity_median", _boom)
+    monkeypatch.setattr(score_mod.judge, "judge_fidelity", _boom)
 
-    score_mod.score_record("add", 1, judge_cmd=judge_cmd, runs_root=runs_root)
+    score_mod.score_record("add", 1, runs_root=runs_root)
 
     written = json.loads(record_path.read_text())
-    assert written["metrics"]["spec_fidelity"] == 0.82
-    assert calls, "judge subprocess.run was never invoked"
-    for argv in calls:
-        assert "claude" not in argv
+    assert "requirement_coverage" in written["metrics"]
+    assert "spec_fidelity" not in written["metrics"]
+    assert judge_calls == [], "score must not call a judge function on the metric path"
 
 
 # --------------------------------------------------------------------------
@@ -317,9 +321,9 @@ def test_spec_fidelity_via_fake_judge(tmp_path, monkeypatch):
 
 def test_regression_rate_computed_at_wm3(tmp_path):
     runs_root = tmp_path / "runs"
-    _make_record(tmp_path, runs_root, "add", 1, status="done", spec_fidelity=0.9)
-    _make_record(tmp_path, runs_root, "add", 2, status="done", spec_fidelity=0.75)
-    record_path = _make_record(tmp_path, runs_root, "add", 3, spec_fidelity=0.0)
+    _make_record(tmp_path, runs_root, "add", 1, status="done", requirement_coverage=0.9)
+    _make_record(tmp_path, runs_root, "add", 2, status="done", requirement_coverage=0.75)
+    record_path = _make_record(tmp_path, runs_root, "add", 3, requirement_coverage=0.0)
 
     workspace_dir = runs_root / "add" / "wm3" / "workspace"
     _write_fixture_app(workspace_dir)
@@ -338,9 +342,9 @@ def test_regression_rate_computed_at_wm3(tmp_path):
 
 def test_regression_rate_counts_must_survive_failures(tmp_path):
     runs_root = tmp_path / "runs"
-    _make_record(tmp_path, runs_root, "add", 1, status="done", spec_fidelity=0.9)
-    _make_record(tmp_path, runs_root, "add", 2, status="done", spec_fidelity=0.75)
-    record_path = _make_record(tmp_path, runs_root, "add", 3, spec_fidelity=0.0)
+    _make_record(tmp_path, runs_root, "add", 1, status="done", requirement_coverage=0.9)
+    _make_record(tmp_path, runs_root, "add", 2, status="done", requirement_coverage=0.75)
+    record_path = _make_record(tmp_path, runs_root, "add", 3, requirement_coverage=0.0)
 
     workspace_dir = runs_root / "add" / "wm3" / "workspace"
     workspace_dir.mkdir(parents=True, exist_ok=True)
@@ -381,17 +385,20 @@ def test_regression_rate_zero_before_wm3(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------
 
 
-def test_context_rot_slope_computed_at_wm3(tmp_path):
+def test_context_rot_slope_computed_at_wm3(tmp_path, monkeypatch):
     runs_root = tmp_path / "runs"
-    _make_record(tmp_path, runs_root, "add", 1, status="done", spec_fidelity=0.9)
-    _make_record(tmp_path, runs_root, "add", 2, status="done", spec_fidelity=0.75)
-    record_path = _make_record(tmp_path, runs_root, "add", 3, spec_fidelity=0.0)
+    _make_record(tmp_path, runs_root, "add", 1, status="done", requirement_coverage=0.9)
+    _make_record(tmp_path, runs_root, "add", 2, status="done", requirement_coverage=0.75)
+    record_path = _make_record(tmp_path, runs_root, "add", 3, requirement_coverage=0.0)
 
     workspace_dir = runs_root / "add" / "wm3" / "workspace"
     _write_fixture_app(workspace_dir)
-    judge_cmd = _fake_judge(tmp_path, "0.6")
+    # wm3 coverage pinned so the 3-point trend is exactly [0.9, 0.75, 0.6] and
+    # the slope wiring is tested independent of the fixture's exact probe count
+    # (wm3's 4-row checklist could only ever yield a multiple of 0.25).
+    monkeypatch.setattr(score_mod, "compute_requirement_coverage", lambda ws, wm, family="wm": 0.6)
 
-    score_mod.score_record("add", 3, judge_cmd=judge_cmd, runs_root=runs_root)
+    score_mod.score_record("add", 3, runs_root=runs_root)
 
     written = json.loads(record_path.read_text())
     assert written["metrics"]["context_rot_slope"] == pytest.approx(-0.15)
@@ -430,9 +437,51 @@ def test_scored_record_still_validates(tmp_path):
     score_mod.score_record("add", 1, judge_cmd=judge_cmd, runs_root=runs_root)
 
     reloaded = validate(json.loads(record_path.read_text()))
-    # v2-meter-fixes M1/M6: the deterministic fidelity of record is always
-    # written; tests_weakened stays absent here (no snapshots in this fixture).
-    assert set(reloaded.metrics.keys()) == set(REQUIRED_METRICS) | {"oracle_pass_rate"}
+    # v3: requirement_coverage + oracle_pass_rate are both REQUIRED now;
+    # tests_weakened stays absent here (no snapshots in this fixture).
+    assert set(reloaded.metrics.keys()) == set(REQUIRED_METRICS)
+    assert "requirement_coverage" in reloaded.metrics
+    assert "spec_fidelity" not in reloaded.metrics
+
+
+def test_score_rereads_archived_spec_fidelity_target(tmp_path, monkeypatch):
+    """An archived v1/v2 record carries the retired spec_fidelity and NO
+    requirement_coverage — strict validate() rejects it, but RE-SCORING is
+    exactly how it migrates forward. score_record must read the TARGET record
+    leniently, recompute every metric, and rewrite it in the v3 schema (this is
+    what makes `run.py score` on every existing runs/*/wm* record work)."""
+    runs_root = tmp_path / "runs"
+    wm_dir = runs_root / "add" / "wm1"
+    workspace_dir = wm_dir / "workspace"
+    workspace_dir.mkdir(parents=True)
+    (wm_dir / "transcript.jsonl").write_text("")
+    (wm_dir / "oracle_report.json").write_text(
+        json.dumps({"app_check": {"app_reachable": True}, "isolation_clean": True})
+    )
+    # an OLD-schema record written RAW (bypasses validate): spec_fidelity, no coverage
+    old = {
+        "arm": "add", "wm": 1, "rep": 0, "status": "done",
+        "metrics": {"regression_rate": 0.0, "spec_fidelity": 0.95,
+                    "tokens_total": 4200.0, "cost_usd": 0.31,
+                    "context_rot_slope": 0.0, "time_to_first_edit": 12.5},
+        "artifacts": {"workspace": str(workspace_dir),
+                      "transcript": str(wm_dir / "transcript.jsonl"),
+                      "oracle_report": str(wm_dir / "oracle_report.json")},
+    }
+    record_path = wm_dir / "record.json"
+    record_path.write_text(json.dumps(old))
+
+    # deterministic seams — the read-migration is the subject, not probe values
+    monkeypatch.setattr(score_mod, "compute_requirement_coverage", lambda ws, wm, family="wm": 1.0)
+    monkeypatch.setattr(score_mod, "compute_oracle_pass_rate", lambda ws, wm, family="wm": 1.0)
+
+    scored = score_mod.score_record("add", 1, runs_root=runs_root)
+
+    assert scored.metrics["requirement_coverage"] == 1.0
+    assert "spec_fidelity" not in scored.metrics
+    # persisted in the v3 schema — reloads clean through strict validate
+    reloaded = validate(json.loads(record_path.read_text()))
+    assert set(reloaded.metrics.keys()) == set(REQUIRED_METRICS)
 
 
 # --------------------------------------------------------------------------
@@ -528,20 +577,22 @@ def test_unknown_arm(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# R6 - judge output is not a parseable float
+# v3: a bad/unavailable judge no longer breaks scoring — it is OFF the metric path
 # --------------------------------------------------------------------------
 
 
-def test_unparseable_judge_output(tmp_path):
+def test_bad_judge_does_not_break_scoring(tmp_path):
+    """A non-numeric judge output used to fail the score; now the judge is off the
+    metric path, so scoring succeeds and records deterministic requirement_coverage."""
     runs_root = tmp_path / "runs"
     record_path = _make_record(tmp_path, runs_root, "add", 1)
-    before = record_path.read_bytes()
     judge_cmd = _fake_judge(tmp_path, "not-a-number")
 
-    with pytest.raises(score_mod.BenchError, match="unparseable_judge_output"):
-        score_mod.score_record("add", 1, judge_cmd=judge_cmd, runs_root=runs_root)
-
-    assert record_path.read_bytes() == before
+    record = score_mod.score_record("add", 1, judge_cmd=judge_cmd, runs_root=runs_root)
+    assert "requirement_coverage" in record.metrics
+    assert "spec_fidelity" not in record.metrics
+    # a valid float in [0,1] was recorded despite the unparseable judge output
+    assert 0.0 <= record.metrics["requirement_coverage"] <= 1.0
 
 
 # --------------------------------------------------------------------------
@@ -551,8 +602,8 @@ def test_unparseable_judge_output(tmp_path):
 
 def test_regression_run_failed(tmp_path, monkeypatch):
     runs_root = tmp_path / "runs"
-    _make_record(tmp_path, runs_root, "add", 1, status="done", spec_fidelity=0.9)
-    _make_record(tmp_path, runs_root, "add", 2, status="done", spec_fidelity=0.75)
+    _make_record(tmp_path, runs_root, "add", 1, status="done", requirement_coverage=0.9)
+    _make_record(tmp_path, runs_root, "add", 2, status="done", requirement_coverage=0.75)
     record_path = _make_record(tmp_path, runs_root, "add", 3)
     before = record_path.read_bytes()
 

--- a/benchmark/tests/test_trust_report.py
+++ b/benchmark/tests/test_trust_report.py
@@ -133,7 +133,7 @@ def _fixture_archive(tmp_path: pathlib.Path) -> pathlib.Path:
     pass_rate miss at step 2 — enough to exercise trusted + untrusted paths."""
     root = tmp_path / "rep0"
     base_metrics = {
-        "spec_fidelity": 0.9, "regression_rate": 0.0, "tokens_total": 1000.0,
+        "requirement_coverage": 0.9, "regression_rate": 0.0, "tokens_total": 1000.0,
         "cost_usd": 2.0, "context_rot_slope": 0.0, "time_to_first_edit": 10.0,
         "oracle_pass_rate": 1.0, "tests_weakened": 0.0,
     }

--- a/benchmark/tests/test_v2_meter.py
+++ b/benchmark/tests/test_v2_meter.py
@@ -418,12 +418,13 @@ def test_score_record_writes_v2_metrics(tmp_path, monkeypatch):
         seen_families.append(family)
         return 0.125
 
-    def fake_coverage(ws, wm, family="wm"):
-        return 0.5
+    def fake_detail(ws, wm, family="wm"):
+        # score_record derives coverage from the detail: 1-of-2 covered -> 0.5
+        return [{"id": "a", "covered": True}, {"id": "b", "covered": False}]
 
     monkeypatch.setattr(score_mod, "compute_oracle_pass_rate", fake_pass_rate)
     monkeypatch.setattr(score_mod, "compute_regression_rate_v2", fake_regression)
-    monkeypatch.setattr(score_mod, "compute_requirement_coverage", fake_coverage)
+    monkeypatch.setattr(score_mod, "compute_coverage_detail", fake_detail)
 
     scored = score_mod.score_record("add", 2, judge_cmd=_fake_judge(tmp_path, "0.9"), runs_root=runs_root)
 

--- a/benchmark/tests/test_v2_meter.py
+++ b/benchmark/tests/test_v2_meter.py
@@ -68,7 +68,8 @@ def _fake_judge(tmp_path: pathlib.Path, value: str) -> list[str]:
 
 _BASE_METRICS = {
     "regression_rate": 0.0,
-    "spec_fidelity": 0.5,
+    "requirement_coverage": 0.5,
+    "oracle_pass_rate": 1.0,
     "tokens_total": 4200.0,
     "cost_usd": 0.31,
     "context_rot_slope": 0.0,
@@ -334,13 +335,24 @@ def test_injected_judge_cmd_unchanged(tmp_path):
 # --------------------------------------------------------------------------
 
 
-def test_v1_records_still_validate():
+def test_spec_fidelity_swap_is_breaking():
+    # the new metric set (requirement_coverage + oracle_pass_rate, no
+    # spec_fidelity) validates.
     record = validate(_record_dict(dict(_BASE_METRICS)))
     assert record.metrics == _BASE_METRICS
-    # every archived v1 record on disk still loads byte-unchanged
-    archived = sorted((REPO_ROOT / "benchmark" / "runs").rglob("record.json"))
-    for path in archived:
-        validate(json.loads(path.read_text()))
+    # the swap is a DELIBERATE breaking replace, not additive-optional: a
+    # record carrying the retired spec_fidelity key (and lacking the new
+    # required metrics) is rejected by strict validate. Archived on-disk v1
+    # records are migrated forward by the rescore pass; until then the
+    # lenient reader (test_requirement_coverage: slope-shim) handles them.
+    v1 = {
+        k: v
+        for k, v in _BASE_METRICS.items()
+        if k not in ("requirement_coverage", "oracle_pass_rate")
+    }
+    v1["spec_fidelity"] = 0.9
+    with pytest.raises(BenchError, match="invalid_run_record"):
+        validate(_record_dict(v1))
 
 
 def test_optional_keys_accepted():
@@ -406,15 +418,20 @@ def test_score_record_writes_v2_metrics(tmp_path, monkeypatch):
         seen_families.append(family)
         return 0.125
 
+    def fake_coverage(ws, wm, family="wm"):
+        return 0.5
+
     monkeypatch.setattr(score_mod, "compute_oracle_pass_rate", fake_pass_rate)
     monkeypatch.setattr(score_mod, "compute_regression_rate_v2", fake_regression)
+    monkeypatch.setattr(score_mod, "compute_requirement_coverage", fake_coverage)
 
     scored = score_mod.score_record("add", 2, judge_cmd=_fake_judge(tmp_path, "0.9"), runs_root=runs_root)
 
     assert scored.metrics["oracle_pass_rate"] == 0.75
     assert scored.metrics["tests_weakened"] == 0.0
     assert scored.metrics["regression_rate"] == 0.125
-    assert scored.metrics["spec_fidelity"] == 0.9  # kept, judge-sourced, secondary
+    assert scored.metrics["requirement_coverage"] == 0.5  # deterministic primary
+    assert "spec_fidelity" not in scored.metrics  # judge demoted to code_quality_annotation
     assert scored.artifacts["regression_source"] == "v2-earlier-oracles"
     assert seen_families == ["wm", "wm"], "family default must flow through both seams"
     # the written record round-trips through validate

--- a/benchmark/tests/test_wv1_aggregate.py
+++ b/benchmark/tests/test_wv1_aggregate.py
@@ -11,7 +11,7 @@ from benchmark.schema.run_record import RunRecord
 
 _V1_METRICS = {
     "regression_rate": 0.0,
-    "spec_fidelity": 0.9,
+    "requirement_coverage": 0.9,
     "tokens_total": 1000.0,
     "cost_usd": 1.0,
     "context_rot_slope": 0.0,
@@ -60,7 +60,7 @@ def test_aggregate_mixed_records_n_missing():
     records = [
         _record(2, 0, {**_V1_METRICS, "oracle_pass_rate": 0.8}),
         _record(2, 1, {**_V1_METRICS, "oracle_pass_rate": 1.0}),
-        _record(2, 2, dict(_V1_METRICS)),  # archived v1 record — no optional keys
+        _record(2, 2, dict(_V1_METRICS)),  # no oracle_pass_rate -> aggregator discloses n_missing
     ]
     entry = aggregate_reps(records)[("add", 2)]
     assert entry["pass_rate"]["mean"] == pytest.approx(0.9)

--- a/benchmark/workload/_oracle_lib.py
+++ b/benchmark/workload/_oracle_lib.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import pathlib
+import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -21,11 +24,46 @@ import urllib.request
 STARTUP_TIMEOUT_S = 10.0
 POLL_INTERVAL_S = 0.2
 
+# Dirs never needed to boot `python -m app` (stdlib entry contract) — excluded
+# from the isolation copy so it stays fast (a per-arm .venv is large/slow).
+_ISOLATION_EXCLUDE = ("__pycache__", ".venv", ".git", "node_modules", ".add")
+
 
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
+
+
+@contextlib.contextmanager
+def isolated_workspace(workspace):
+    """Yield a fresh temp copy of `workspace` with the app's persistent store
+    RESET, so scoring is reproducible on archived builds and never mutates the
+    source (hermetic-scoring §3 CONTRACT @ v1).
+
+    The copy excludes the heavy dirs the stdlib `python -m app` entry contract
+    never needs (`.venv`/`.git`/`__pycache__`/`node_modules`/`.add`), and every
+    root-level `*.json` in the copy — the booking store, whatever its name
+    (`bookings.json`, `bookings_data.json`, ...) — is removed so the app boots
+    empty. The temp dir is always removed on exit; the SOURCE is never written.
+
+    Fail-closed: a missing/uncopyable source yields an empty temp dir the app
+    cannot boot from (callers see the ordinary unreachable-app red), never a raise.
+    """
+    src = pathlib.Path(workspace)
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="bench-iso-"))
+    copy = tmp / "workspace"
+    try:
+        try:
+            shutil.copytree(src, copy, ignore=shutil.ignore_patterns(*_ISOLATION_EXCLUDE))
+        except Exception:
+            copy.mkdir(parents=True, exist_ok=True)  # fail-closed: empty, unbootable
+        for store in copy.glob("*.json"):  # root-level store, name-agnostic
+            with contextlib.suppress(Exception):
+                store.unlink()
+        yield copy
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
 @contextlib.contextmanager

--- a/benchmark/workload/wm1/checklist.py
+++ b/benchmark/workload/wm1/checklist.py
@@ -1,0 +1,133 @@
+"""WM1 FROZEN requirement checklist — the deterministic fidelity of record.
+
+One row per enumerated requirement in wm1/PROMPT.md. `compute_requirement_coverage`
+(benchmark/score.py) boots the built app once and runs each row's `probe(base, workspace)`;
+coverage = covered / total. A probe returns True iff the built app satisfies that
+requirement. NO LLM anywhere — identical workspace yields the identical score.
+
+This checklist deliberately probes requirements the ad-hoc oracle suite left blind
+(CLI parity, duration_minutes positive-int, status enum), so an app that boots but
+skips them scores below 1.0 — the whole point of coverage over oracle_pass_rate.
+
+FROZEN: adding/removing a row is a deliberate versioned change (it moves every arm's
+coverage denominator). Each `id` is stable — reports key off it.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+from benchmark.workload._oracle_lib import http_call
+
+_GOOD = {"title": "Standup", "start_time": "2026-08-01T09:00:00Z", "duration_minutes": 30}
+
+
+def _create(base: str) -> tuple[int, dict]:
+    return http_call("POST", f"{base}/bookings", dict(_GOOD))
+
+
+def _p_post_create(base, ws):
+    status, body = _create(base)
+    return status in (200, 201) and isinstance(body, dict) and bool(body.get("id"))
+
+
+def _p_get_list(base, ws):
+    status, body = http_call("GET", f"{base}/bookings")
+    return status == 200 and isinstance(body, list)
+
+
+def _p_get_one(base, ws):
+    _, created = _create(base)
+    bid = created.get("id")
+    status, body = http_call("GET", f"{base}/bookings/{bid}")
+    return status == 200 and body.get("id") == bid
+
+
+def _p_patch_update(base, ws):
+    _, created = _create(base)
+    bid = created.get("id")
+    status, body = http_call("PATCH", f"{base}/bookings/{bid}", {"status": "confirmed"})
+    return status == 200 and body.get("status") == "confirmed"
+
+
+def _p_delete(base, ws):
+    _, created = _create(base)
+    bid = created.get("id")
+    status, _ = http_call("DELETE", f"{base}/bookings/{bid}")
+    if status not in (200, 204):
+        return False
+    gone, _ = http_call("GET", f"{base}/bookings/{bid}")
+    return gone == 404
+
+
+def _p_status_default_pending(base, ws):
+    _, created = _create(base)
+    return created.get("status") == "pending"
+
+
+def _p_missing_field_400(base, ws):
+    status, _ = http_call("POST", f"{base}/bookings", {"title": "no start time"})
+    return status == 400
+
+
+def _p_unknown_404(base, ws):
+    status, _ = http_call("GET", f"{base}/bookings/does-not-exist")
+    return status == 404
+
+
+def _p_duration_positive(base, ws):
+    bad = dict(_GOOD, duration_minutes=0)
+    status, _ = http_call("POST", f"{base}/bookings", bad)
+    return status == 400
+
+
+def _p_status_enum(base, ws):
+    bad = dict(_GOOD, status="banana")
+    status, _ = http_call("POST", f"{base}/bookings", bad)
+    return status == 400
+
+
+def _p_cli_parity(base, ws):
+    """The PROMPT requires a CLI that lists via the same logic. Try the common
+    entry points; success = one exits 0 for a `list` command against the app."""
+    port = base.rsplit(":", 1)[-1]
+    env = {**os.environ, "APP_BASE": base, "PORT": port}
+    invocations = (
+        [sys.executable, "-m", "app.cli", "list"],
+        [sys.executable, "-m", "cli", "list"],
+        [sys.executable, "cli.py", "list"],
+        [sys.executable, "-m", "app", "list"],
+    )
+    for argv in invocations:
+        try:
+            proc = subprocess.run(argv, cwd=str(ws), env=env, capture_output=True,
+                                  text=True, timeout=10)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode == 0:
+            return True
+    return False
+
+
+def _p_entry_contract(base, ws):
+    """`python -m app` serves HTTP on $PORT — if any GET answers, it held."""
+    status, _ = http_call("GET", f"{base}/bookings")
+    return status == 200
+
+
+REQUIREMENTS = [
+    {"id": "R-post-create", "description": "POST /bookings creates a booking with a server id", "probe": _p_post_create},
+    {"id": "R-get-list", "description": "GET /bookings lists bookings as a JSON array", "probe": _p_get_list},
+    {"id": "R-get-one", "description": "GET /bookings/{id} fetches one booking", "probe": _p_get_one},
+    {"id": "R-patch-update", "description": "PATCH /bookings/{id} updates fields", "probe": _p_patch_update},
+    {"id": "R-delete", "description": "DELETE /bookings/{id} removes a booking", "probe": _p_delete},
+    {"id": "R-status-default-pending", "description": "a new booking's status defaults to pending", "probe": _p_status_default_pending},
+    {"id": "R-missing-field-400", "description": "create with a missing required field returns 400", "probe": _p_missing_field_400},
+    {"id": "R-unknown-404", "description": "an unknown booking id returns 404", "probe": _p_unknown_404},
+    {"id": "R-duration-positive", "description": "duration_minutes must be a positive integer", "probe": _p_duration_positive},
+    {"id": "R-status-enum", "description": "status must be one of pending/confirmed/cancelled", "probe": _p_status_enum},
+    {"id": "R-cli-parity", "description": "a CLI lists bookings via the same underlying logic", "probe": _p_cli_parity},
+    {"id": "R-entry-contract", "description": "the app runs as `python -m app` serving HTTP on $PORT", "probe": _p_entry_contract},
+]

--- a/benchmark/workload/wm2/checklist.py
+++ b/benchmark/workload/wm2/checklist.py
@@ -1,0 +1,74 @@
+"""WM2 FROZEN requirement checklist — auth + business rules over WM1 CRUD.
+
+One row per NEW requirement introduced in wm2/PROMPT.md (auth, ownership,
+no-double-booking, cancellation window, tenant isolation). Carried WM1 CRUD is
+covered by the regression path; this checklist probes what WM2 adds. Probes are
+self-contained (base, workspace) callables and auth-carrying. NO LLM.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from benchmark.workload._oracle_lib import http_call
+
+_ALICE = {"Authorization": "Bearer test-token-alice"}
+_BOB = {"Authorization": "Bearer test-token-bob"}
+
+
+def _future(hours: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat()
+
+
+def _mk(base, headers=_ALICE, **over):
+    body = {"title": "T", "start_time": _future(48), "duration_minutes": 30}
+    body.update(over)
+    return http_call("POST", f"{base}/bookings", body, headers=headers)
+
+
+def _p_auth_401(base, ws):
+    status, _ = http_call("GET", f"{base}/bookings")  # no token
+    return status == 401
+
+
+def _p_ownership_403(base, ws):
+    status, created = _mk(base, headers=_ALICE)
+    if status not in (200, 201):
+        return False
+    bid = created.get("id")
+    denied, _ = http_call("PATCH", f"{base}/bookings/{bid}", {"status": "confirmed"}, headers=_BOB)
+    return denied == 403
+
+
+def _p_double_booking_409(base, ws):
+    s = _future(72)
+    st1, _ = _mk(base, start_time=s, duration_minutes=60)
+    if st1 not in (200, 201):
+        return False
+    st2, body = _mk(base, start_time=s, duration_minutes=60)  # exact overlap
+    return st2 == 409 and isinstance(body, dict) and "conflict_booking_id" in body
+
+
+def _p_cancellation_window_422(base, ws):
+    status, created = _mk(base, start_time=_future(0))  # starts ~now, <1h away
+    if status not in (200, 201):
+        return False
+    bid = created.get("id")
+    blocked, _ = http_call("PATCH", f"{base}/bookings/{bid}", {"status": "cancelled"}, headers=_ALICE)
+    return blocked == 422
+
+
+def _p_tenant_isolation(base, ws):
+    _mk(base, headers=_ALICE, start_time=_future(96))
+    status, body = http_call("GET", f"{base}/bookings", headers=_BOB)
+    if status != 200 or not isinstance(body, list):
+        return False
+    return all(b.get("owner_id", "bob") == "bob" for b in body)  # bob sees only bob's
+
+
+REQUIREMENTS = [
+    {"id": "R-auth-401", "description": "a request without a valid token returns 401", "probe": _p_auth_401},
+    {"id": "R-ownership-403", "description": "a non-owner PATCH/DELETE returns 403", "probe": _p_ownership_403},
+    {"id": "R-double-booking-409", "description": "an overlapping booking for the same owner returns 409 with conflict_booking_id", "probe": _p_double_booking_409},
+    {"id": "R-cancellation-window-422", "description": "cancelling a booking starting within 1h returns 422", "probe": _p_cancellation_window_422},
+    {"id": "R-tenant-isolation", "description": "GET /bookings returns only the caller's own bookings", "probe": _p_tenant_isolation},
+]

--- a/benchmark/workload/wm3/checklist.py
+++ b/benchmark/workload/wm3/checklist.py
@@ -1,0 +1,65 @@
+"""WM3 FROZEN requirement checklist — the end_time shape break.
+
+Rows for wm3/PROMPT.md's NEW/CHANGED requirements: end_time replaces
+duration_minutes, requests still sending duration_minutes are 400, list omits
+duration_minutes, and the WM2 rules keep holding under the new shape. Auth-carrying,
+self-contained (base, workspace) probes. NO LLM.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from benchmark.workload._oracle_lib import http_call
+
+_ALICE = {"Authorization": "Bearer test-token-alice"}
+
+
+def _future(hours: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat()
+
+
+def _mk(base, **over):
+    start = over.pop("start_time", _future(48))
+    body = {"title": "T", "start_time": start, "end_time": _future(49)}
+    body.update(over)
+    return http_call("POST", f"{base}/bookings", body, headers=_ALICE)
+
+
+def _p_end_time_shape(base, ws):
+    status, created = _mk(base)
+    if status not in (200, 201):
+        return False
+    bid = created.get("id")
+    got, body = http_call("GET", f"{base}/bookings/{bid}", headers=_ALICE)
+    return got == 200 and "end_time" in body
+
+
+def _p_duration_rejected_400(base, ws):
+    body = {"title": "T", "start_time": _future(48), "duration_minutes": 30}
+    status, _ = http_call("POST", f"{base}/bookings", body, headers=_ALICE)
+    return status == 400
+
+
+def _p_list_no_duration(base, ws):
+    _mk(base)
+    status, body = http_call("GET", f"{base}/bookings", headers=_ALICE)
+    if status != 200 or not isinstance(body, list) or not body:
+        return False
+    return all("duration_minutes" not in b and "end_time" in b for b in body)
+
+
+def _p_wm2_overlap_holds(base, ws):
+    s, e = _future(72), _future(73)
+    st1, _ = _mk(base, start_time=s, end_time=e)
+    if st1 not in (200, 201):
+        return False
+    st2, resp = _mk(base, start_time=s, end_time=e)
+    return st2 == 409 and isinstance(resp, dict) and "conflict_booking_id" in resp
+
+
+REQUIREMENTS = [
+    {"id": "R-end-time-shape", "description": "POST/GET use end_time instead of duration_minutes", "probe": _p_end_time_shape},
+    {"id": "R-duration-rejected-400", "description": "a request still sending duration_minutes returns 400", "probe": _p_duration_rejected_400},
+    {"id": "R-list-no-duration", "description": "list responses omit duration_minutes and include end_time", "probe": _p_list_no_duration},
+    {"id": "R-wm2-overlap-holds", "description": "the WM2 double-booking rule still holds under the end_time shape", "probe": _p_wm2_overlap_holds},
+]

--- a/benchmark/workload/wm4/checklist.py
+++ b/benchmark/workload/wm4/checklist.py
@@ -1,0 +1,76 @@
+"""WM4 FROZEN requirement checklist — filtering, pagination, recurring bookings.
+
+Rows for wm4/PROMPT.md's new features over the WM3 (end_time) shape. Auth-carrying,
+self-contained (base, workspace) probes. NO LLM.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from benchmark.workload._oracle_lib import http_call
+
+_ALICE = {"Authorization": "Bearer test-token-alice"}
+
+
+def _future(hours: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat()
+
+
+def _mk(base, **over):
+    body = {"title": "T", "start_time": _future(48), "end_time": _future(49)}
+    body.update(over)
+    return http_call("POST", f"{base}/bookings", body, headers=_ALICE)
+
+
+def _p_filter_status(base, ws):
+    status, body = http_call("GET", f"{base}/bookings?status=confirmed", headers=_ALICE)
+    if status != 200 or not isinstance(body, list):
+        return False
+    return all(b.get("status") == "confirmed" for b in body)
+
+
+def _p_filter_time_window(base, ws):
+    # a from..to window far in the past must return an empty (or intersecting-only) list
+    status, body = http_call(
+        "GET", f"{base}/bookings?from=2000-01-01T00:00:00Z&to=2000-01-02T00:00:00Z", headers=_ALICE)
+    return status == 200 and isinstance(body, list) and len(body) == 0
+
+
+def _p_pagination_limit_offset(base, ws):
+    status, body = http_call("GET", f"{base}/bookings?limit=1&offset=0", headers=_ALICE)
+    return status == 200 and isinstance(body, list) and len(body) <= 1
+
+
+def _p_pagination_invalid_400(base, ws):
+    status, _ = http_call("GET", f"{base}/bookings?limit=-3", headers=_ALICE)
+    return status == 400
+
+
+def _p_recurring_creates_n(base, ws):
+    body = {"title": "R", "start_time": _future(200), "end_time": _future(201), "repeats": 3}
+    status, resp = http_call("POST", f"{base}/bookings/recurring", body, headers=_ALICE)
+    if status not in (200, 201):
+        return False
+    # response should reflect 3 created (a list of 3, or a count)
+    if isinstance(resp, list):
+        return len(resp) == 3
+    return resp.get("created") == 3 or resp.get("count") == 3
+
+
+def _p_recurring_all_or_nothing_409(base, ws):
+    # a recurring set that self-overlaps (repeat interval < booking length) is rejected whole
+    s = _future(400)
+    e = (datetime.fromisoformat(s.replace("Z", "+00:00")) + timedelta(days=14)).isoformat()
+    body = {"title": "R2", "start_time": s, "end_time": e, "repeats": 3}
+    status, _ = http_call("POST", f"{base}/bookings/recurring", body, headers=_ALICE)
+    return status == 409
+
+
+REQUIREMENTS = [
+    {"id": "R-filter-status", "description": "GET /bookings?status= filters by exact status", "probe": _p_filter_status},
+    {"id": "R-filter-time-window", "description": "GET /bookings?from=&to= returns only intersecting bookings", "probe": _p_filter_time_window},
+    {"id": "R-pagination-limit-offset", "description": "GET /bookings honors limit/offset after filtering", "probe": _p_pagination_limit_offset},
+    {"id": "R-pagination-invalid-400", "description": "an invalid limit/offset returns 400", "probe": _p_pagination_invalid_400},
+    {"id": "R-recurring-creates-n", "description": "POST /bookings/recurring with repeats:N creates N bookings", "probe": _p_recurring_creates_n},
+    {"id": "R-recurring-all-or-nothing-409", "description": "a recurring set with an overlapping instance is rejected whole (409)", "probe": _p_recurring_all_or_nothing_409},
+]

--- a/benchmark/workload/wm5/checklist.py
+++ b/benchmark/workload/wm5/checklist.py
@@ -1,0 +1,60 @@
+"""WM5 FROZEN requirement checklist — rooms + per-room overlap.
+
+Rows for wm5/PROMPT.md: required room_id, per-room (not per-owner) overlap,
+the room schedule endpoint. Auth-carrying, self-contained probes. NO LLM.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from benchmark.workload._oracle_lib import http_call
+
+_ALICE = {"Authorization": "Bearer test-token-alice"}
+_BOB = {"Authorization": "Bearer test-token-bob"}
+
+
+def _future(hours: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat()
+
+
+def _mk(base, headers=_ALICE, **over):
+    body = {"title": "T", "start_time": _future(48), "end_time": _future(49), "room_id": "r1"}
+    body.update(over)
+    return http_call("POST", f"{base}/bookings", body, headers=headers)
+
+
+def _p_room_required_400(base, ws):
+    body = {"title": "T", "start_time": _future(48), "end_time": _future(49)}  # no room_id
+    status, _ = http_call("POST", f"{base}/bookings", body, headers=_ALICE)
+    return status == 400
+
+
+def _p_per_room_overlap_409(base, ws):
+    s, e = _future(72), _future(73)
+    st1, _ = _mk(base, headers=_ALICE, start_time=s, end_time=e, room_id="rX")
+    if st1 not in (200, 201):
+        return False
+    # DIFFERENT owner, SAME room, overlapping -> conflict (per-room, cross-owner)
+    st2, resp = _mk(base, headers=_BOB, start_time=s, end_time=e, room_id="rX")
+    return st2 == 409
+
+
+def _p_different_rooms_no_conflict(base, ws):
+    s, e = _future(96), _future(97)
+    st1, _ = _mk(base, start_time=s, end_time=e, room_id="rA")
+    st2, _ = _mk(base, start_time=s, end_time=e, room_id="rB")  # same time, other room
+    return st1 in (200, 201) and st2 in (200, 201)
+
+
+def _p_room_schedule_endpoint(base, ws):
+    _mk(base, room_id="rSched", start_time=_future(120), end_time=_future(121))
+    status, body = http_call("GET", f"{base}/rooms/rSched/schedule", headers=_ALICE)
+    return status == 200 and isinstance(body, list)
+
+
+REQUIREMENTS = [
+    {"id": "R-room-required-400", "description": "a create/update missing room_id returns 400", "probe": _p_room_required_400},
+    {"id": "R-per-room-overlap-409", "description": "two bookings in the same room overlap-conflict regardless of owner (409)", "probe": _p_per_room_overlap_409},
+    {"id": "R-different-rooms-no-conflict", "description": "same-time bookings in different rooms do not conflict", "probe": _p_different_rooms_no_conflict},
+    {"id": "R-room-schedule", "description": "GET /rooms/{id}/schedule returns that room's bookings", "probe": _p_room_schedule_endpoint},
+]

--- a/benchmark/workload/wm6/checklist.py
+++ b/benchmark/workload/wm6/checklist.py
@@ -1,0 +1,73 @@
+"""WM6 FROZEN requirement checklist — scheduling correctness hardening.
+
+Rows for wm6/PROMPT.md: timezone-correct overlap, half-open boundary + zero-length
+400, idempotent create, and input hardening (400 not 500). Auth-carrying,
+self-contained probes. NO LLM.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from benchmark.workload._oracle_lib import http_call
+
+_ALICE = {"Authorization": "Bearer test-token-alice"}
+
+
+def _future(hours: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat()
+
+
+def _mk(base, headers=_ALICE, **over):
+    body = {"title": "T", "start_time": _future(48), "end_time": _future(49), "room_id": "r1"}
+    body.update(over)
+    return http_call("POST", f"{base}/bookings", body, headers=headers)
+
+
+def _p_timezone_correct_overlap(base, ws):
+    # same instant, different offsets -> same room -> conflict
+    a_start = "2026-12-01T10:00:00+02:00"
+    a_end = "2026-12-01T12:00:00+02:00"
+    st1, _ = _mk(base, start_time=a_start, end_time=a_end, room_id="tz")
+    if st1 not in (200, 201):
+        return False
+    b_start = "2026-12-01T08:00:00Z"  # == 10:00+02:00, same instant
+    b_end = "2026-12-01T10:00:00Z"
+    st2, _ = _mk(base, start_time=b_start, end_time=b_end, room_id="tz")
+    return st2 == 409
+
+
+def _p_boundary_half_open(base, ws):
+    # one ends exactly when the other starts -> NO conflict (half-open [start,end))
+    s1, e1 = _future(200), _future(201)
+    st1, _ = _mk(base, start_time=s1, end_time=e1, room_id="bnd")
+    st2, _ = _mk(base, start_time=e1, end_time=_future(202), room_id="bnd")
+    return st1 in (200, 201) and st2 in (200, 201)
+
+
+def _p_zero_length_400(base, ws):
+    s = _future(300)
+    status, _ = _mk(base, start_time=s, end_time=s, room_id="zl")  # zero-length
+    return status == 400
+
+
+def _p_idempotent_create(base, ws):
+    key = {"Idempotency-Key": "wm6-key-1", **_ALICE}
+    body = {"title": "Idem", "start_time": _future(400), "end_time": _future(401), "room_id": "idem"}
+    st1, b1 = http_call("POST", f"{base}/bookings", body, headers=key)
+    st2, b2 = http_call("POST", f"{base}/bookings", body, headers=key)  # retry same key+payload
+    return st1 in (200, 201) and st2 in (200, 201) and b1.get("id") == b2.get("id")
+
+
+def _p_input_hardening_400(base, ws):
+    # a malformed datetime must be 400 with JSON, never 500 / stack trace
+    status, body = _mk(base, start_time="not-a-datetime", room_id="ih")
+    return status == 400 and isinstance(body, dict)
+
+
+REQUIREMENTS = [
+    {"id": "R-timezone-correct-overlap", "description": "overlap compares absolute instants across ISO offsets", "probe": _p_timezone_correct_overlap},
+    {"id": "R-boundary-half-open", "description": "abutting bookings [start,end) do not conflict", "probe": _p_boundary_half_open},
+    {"id": "R-zero-length-400", "description": "a zero-length booking (end==start) returns 400", "probe": _p_zero_length_400},
+    {"id": "R-idempotent-create", "description": "retrying a create with the same Idempotency-Key returns the original booking", "probe": _p_idempotent_create},
+    {"id": "R-input-hardening-400", "description": "malformed input returns 400 JSON, never 500", "probe": _p_input_hardening_400},
+]


### PR DESCRIPTION
## honest-fidelity-meter — a deterministic, self-explaining benchmark meter

Replaces the artifact-blind LLM `spec_fidelity` metric with a deterministic
`requirement_coverage` meter (frozen per-WM requirement checklists + probes),
demotes the LLM judge to an advisory artifact, and makes every score readable.

### Why
The old `spec_fidelity` was scored by an LLM rubric that **never read the built
code** — only `PROMPT.md` + oracle booleans. It was noisy (temp>0 drift) and, in
the comparison set, **5 of 9 records were 0.0** because the flaky judge never
scored them. A fidelity meter that can't see the artifact isn't a fidelity meter.

### What (6 commits)
1. **`d8b86c2` coverage-scorer** — schema v3: `requirement_coverage` + `oracle_pass_rate`
   REQUIRED, `spec_fidelity` retired; frozen `wm{1..6}/checklist.py` probes; the
   judge leaves the metric path; `pilot.py attest` CLI retired.
2. **`3c74457` hermetic-scoring** — `isolated_workspace()` boots a store-reset copy so
   coverage/oracle are reproducible on archived builds and never mutate the source
   (fixes a real store-contamination drift: add/wm2 read 0.8→0.4 with history).
3. **`6c21d80` judge-advisory** — the LLM judge returns as a **source-aware, non-gating**
   `code_quality_annotation` artifact: reads the built app's source, claude-less by
   default (no subprocess on the deterministic path), best-effort, never a metric.
4. **`7e3712f` purge-fix** — re-scoring purges the superseded `judge_scores` sentinel
   (found while persisting the clean arms — records were carrying both keys).
5. **`936706f` coverage-detail** — per-WM `coverage_detail` artifact: one `{id,covered}`
   per requirement, so a `0.20`/`0.80` names **which** requirements failed. Float and
   detail derive from one boot, so they can never disagree.
6. **`507a916` report-diagnostics** — `render_report` surfaces `coverage_detail` +
   `code_quality_annotation` in a per-WM diagnostics table beside the metric grid.

### Final scores (current-contract arms, honest apples-to-apples, n=1, wm1-3)
| arm | fidelity (cov·oracle) | trusted WMs | regr | rot-slope | tokens | cost | **$/trusted-feature** |
|-----|:---:|:---:|:---:|:---:|---:|---:|:---:|
| **spec-kit** | 1.00 · 1.00 | **3/3** | 0.00 | 0.00 | 6.0M | $4.20 | **$1.40** |
| gsd | 0.93 · 0.93 | 2/3 | 0.00 | 0.00 | 3.7M | $3.01 | $1.51 |
| vanilla | 1.00 · 1.00 | 3/3 | 0.00 | 0.00 | 12.7M | $6.25 | $2.08 |
| add | 1.00 · 1.00 | 3/3 | 0.00 | 0.00 | 18.2M | $9.11 | $3.04 |

Per-WM cost: gsd `0.88/1.00/1.13` · spec-kit `1.09/1.78/1.34` · vanilla `1.17/2.20/2.88` · add `3.91/2.76/2.43`.

**Winner (this benchmark): spec-kit** — the only arm that is both fully faithful (3/3
trusted) AND cheapest per delivered feature ($1.40), on the fewest tokens of any
full-fidelity arm. gsd is cheaper in absolute terms ($3.01) but bought that by shipping
an incomplete wm2 — it never implemented the cancellation-window rule
(`R-cancellation-window-422`), now named by `coverage_detail` instead of hidden behind a
mute "0.80". Caveats: n=1 (ordering is signal, decimals are not robust); a narrow 3-WM
greenfield slice; and this workload does not stress what ADD optimizes for (cross-session
context retention, gate discipline) — `add`'s 2.2x cost is the ceremony premium.

The ~45 older runs are **excluded**: they were built against an earlier workload
contract (auth / different endpoints; return 401) — re-scoring them measures
contract drift, not fidelity. The meter being contract-sensitive is the point.

### Trust
Every task ran red→green TDD with a frozen contract and a recorded gate. **212 tests
pass.** `benchmark/` is the harness, not the ADD engine — no engine/seam re-pins.

> Note: milestone goal exit criteria are not yet all met (`goal_not_auto_ready`);
> this PR is the shippable meter work to date.

author: Tin Dang <tindang.ht97@gmail.com>

