### PR TITLE
feat(tooling): advance-fold — steer green build to gate PASS, drop the redundant advance turn

### DIFF
--- a/.claude/skills/add/phases/5-build.md
+++ b/.claude/skills/add/phases/5-build.md
@@ -55,7 +55,7 @@ Never: change a test or the contract; use a package off the allow-list; or push 
 
 ## Next
 
-`python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
+`python3 .add/tooling/add.py gate PASS` (from build — compound-crosses to verify in one call) → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
 
 > Under `autonomy: auto` Build and Verify run together as one evidence-auto-gated run. See `run.md`.

--- a/add-method/skill/add/phases/5-build.md
+++ b/add-method/skill/add/phases/5-build.md
@@ -55,7 +55,7 @@ Never: change a test or the contract; use a package off the allow-list; or push 
 
 ## Next
 
-`python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
+`python3 .add/tooling/add.py gate PASS` (from build — compound-crosses to verify in one call) → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
 
 > Under `autonomy: auto` Build and Verify run together as one evidence-auto-gated run. See `run.md`.

--- a/add-method/src/add_method/_bundled/skill/add/phases/5-build.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/5-build.md
@@ -55,7 +55,7 @@ Never: change a test or the contract; use a package off the allow-list; or push 
 
 ## Next
 
-`python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
+`python3 .add/tooling/add.py gate PASS` (from build — compound-crosses to verify in one call) → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
 
 > Under `autonomy: auto` Build and Verify run together as one evidence-auto-gated run. See `run.md`.

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -6711,6 +6711,12 @@ def _next_command(phase: str, *, contract_frozen: bool = False) -> str:
         return "add.py advance" if contract_frozen else "add.py freeze --by <name>"
     if phase == "tests":
         return "add.py advance --fill <draft>"
+    if phase == "build":
+        # advance-fold (ceremony-turn-cut): a green build steers STRAIGHT to the completing
+        # gate — `gate PASS` compound-ticks build->verify in ONE call (cmd_gate), so a separate
+        # `advance` here is a pure-bookkeeping turn (~85k cache-read) we drop. Trust floor intact:
+        # the gate runs the full verify completion checks; build->verify carries no human seam.
+        return "add.py gate PASS | RISK-ACCEPTED | HARD-STOP   (from build — compound-crosses to verify)"
     return "add.py advance"
 
 

--- a/add-method/src/add_method/_bundled/tooling/engine_pin.py
+++ b/add-method/src/add_method/_bundled/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "a773d868899bb5dc2b162fc6a4bef8d6"  # re-aimed @ status-lean-default (engine-minimalism: bare `status` gates goal/m-goal prose + personas roster + milestone/task rows + per-stream detail behind --all — count/pointer lines instead). prior: 1dd8c1b1… @ help-diet
+ENGINE_MD5 = "8438237d6187843e7de720725c816a64"  # re-aimed @ advance-fold (ceremony-turn-cut: _next_command build-phase steer → `gate PASS` compound-crosses build→verify, drops the redundant pre-gate advance turn). prior: a773d868… @ status-lean-default
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -6711,6 +6711,12 @@ def _next_command(phase: str, *, contract_frozen: bool = False) -> str:
         return "add.py advance" if contract_frozen else "add.py freeze --by <name>"
     if phase == "tests":
         return "add.py advance --fill <draft>"
+    if phase == "build":
+        # advance-fold (ceremony-turn-cut): a green build steers STRAIGHT to the completing
+        # gate — `gate PASS` compound-ticks build->verify in ONE call (cmd_gate), so a separate
+        # `advance` here is a pure-bookkeeping turn (~85k cache-read) we drop. Trust floor intact:
+        # the gate runs the full verify completion checks; build->verify carries no human seam.
+        return "add.py gate PASS | RISK-ACCEPTED | HARD-STOP   (from build — compound-crosses to verify)"
     return "add.py advance"
 
 

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "a773d868899bb5dc2b162fc6a4bef8d6"  # re-aimed @ status-lean-default (engine-minimalism: bare `status` gates goal/m-goal prose + personas roster + milestone/task rows + per-stream detail behind --all — count/pointer lines instead). prior: 1dd8c1b1… @ help-diet
+ENGINE_MD5 = "8438237d6187843e7de720725c816a64"  # re-aimed @ advance-fold (ceremony-turn-cut: _next_command build-phase steer → `gate PASS` compound-crosses build→verify, drops the redundant pre-gate advance turn). prior: a773d868… @ status-lean-default
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/tooling/test_advance_fold_build_gate.py
+++ b/add-method/tooling/test_advance_fold_build_gate.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Red/green for advance-fold (ceremony-turn-cut): the build-phase next verb steers to
+`gate PASS` — which compound-ticks build->verify in ONE call — NOT a redundant separate
+`advance` turn. The real wm1 run made `advance` (build->verify) THEN `gate PASS`; the
+advance was pure bookkeeping the gate already does (cmd_gate compound tick). Killing that
+steer saves one ceremony turn per task (~85k cache-read) with zero trust-floor change.
+
+Run: python3 -m unittest test_advance_fold_build_gate -v
+"""
+import pathlib
+import unittest
+
+import add
+
+# the build guide across all three skill trees (resolved from this file's location)
+_TOOLING = pathlib.Path(__file__).resolve().parent          # add-method/tooling
+_ADDROOT = _TOOLING.parent                                  # add-method
+_REPO = _ADDROOT.parent                                     # repo root
+BUILD_GUIDES = [
+    _ADDROOT / "skill" / "add" / "phases" / "5-build.md",
+    _ADDROOT / "src" / "add_method" / "_bundled" / "skill" / "add" / "phases" / "5-build.md",
+    _REPO / ".claude" / "skills" / "add" / "phases" / "5-build.md",
+]
+
+
+class AdvanceFoldBuildGateTest(unittest.TestCase):
+    def test_build_next_verb_is_gate_not_advance(self):
+        cmd = add._next_command("build")
+        self.assertIn("gate PASS", cmd, "build must steer to the compound gate verb")
+        self.assertNotIn("advance", cmd,
+                         "no redundant advance before gate — compound-ticks crosses build->verify")
+
+    def test_verify_next_verb_unchanged(self):
+        self.assertIn("gate PASS", add._next_command("verify"))
+
+    def test_earlier_phase_verbs_unchanged(self):
+        # the fold touches ONLY the build fallthrough — front phases keep their exact steer
+        self.assertIn("advance --to plan", add._next_command("specify"))
+        self.assertIn("freeze --by", add._next_command("plan"))
+        self.assertIn("add.py advance", add._next_command("plan", contract_frozen=True))
+        self.assertIn("advance --fill", add._next_command("tests"))
+
+    def test_build_guides_steer_to_gate_across_three_trees(self):
+        for g in BUILD_GUIDES:
+            if not g.exists():
+                continue
+            txt = g.read_text(encoding="utf-8")
+            # the Next section names the compound gate from build, not a bare advance->verify
+            self.assertIn("gate PASS", txt, f"{g} must steer build to gate PASS")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## advance-fold — steer green build straight to `gate PASS`, drop the redundant pre-gate advance

**Stacked on #158** (base: `feat/token-anatomy`). The capstone of the measure-first arc: the
[token-cost root-cause investigation](../) proved ADD's excess is **TURNS, not bytes** — ~49% of
its calls are pure ceremony vs 0% for lean arms, and cost is ~quadratic (turns × accumulating
context). The scoped ceremony-turn-cut sweep then found its other levers already shipped
(status-orientation-diet + help-habit-kill merged in call-residuals #154; `advance --to`,
`freeze --cross`, and the build→verify compound-tick all already in the engine).

**The one genuine unfolded turn:** the real wm1 run did `advance` (build→verify) **then**
`gate PASS` — redundant, because `gate PASS` from build already compound-ticks build→verify in one
call (`cmd_gate`). The agent did it because the flow *told* it to: `_next_command("build")` fell
through to `add.py advance`, and `phases/5-build.md` said the same.

**Fix (steer layer, trust floor untouched):**
- `_next_command` build phase → `gate PASS | RISK-ACCEPTED | HARD-STOP  (from build — compound-crosses to verify)` instead of the bare `advance` fallthrough. So `status`/`guide`/footer all steer straight to the gate that already crosses build→verify.
- `phases/5-build.md` Next line → `gate PASS` (×3 skill trees).

Saves **one ceremony turn per task (~85k cache-read)** with **zero gate change** — the gate runs the
full verify completion checks; build→verify carries no human seam.

- new red/green `test_advance_fold_build_gate.py` (4 tests): build verb is the gate not advance; verify + earlier-phase verbs unchanged; guide parity ×3 trees
- ENGINE_MD5 `a773d868`→`8438237d` across all 4 add.py twins; phases skill-pool under budget (slack 394 B); SEAMS anchors intact
- full engine suite: **3642 passed** + 162 subtests

A fresh n≥2 WM1 re-measure (confirming the redundant advance actually disappears) is running.
