### PR TITLE
feat(tooling): engine-output-trim — resume-card + recipe dedup + trust-the-footer (context/turn lever)

### DIFF
--- a/.add/SEAMS.md
+++ b/.add/SEAMS.md
@@ -54,7 +54,7 @@ Citations: 232 files reference "byte-identical" in `.add/tasks/` — method:
 
 ## scope-token-grammar
 Name: §5 "Scope (may touch):" token-resolution grammar
-Anchor: `add-method/tooling/add.py:5808` (`_declared_scope`)   <!-- re-pinned 2026-07-15 recipe-dedup: 5797→5808 (new-task recipe-dedup added 11 lines above the anchor); prior resume-card-dedup: 5800→5797 (cmd_status SHRANK — the bottom resume block dropped its 3 restated lines above the anchor; the pin drifts on ANY upstream add.py change; symbol cited so the drift self-describes; todo #30 seams-symbol-pins retires this class). prior: 5778→5800 @ status-lean-default (lean-default gates grew cmd_status above the anchor) -->
+Anchor: `add-method/tooling/add.py:5901` (`_declared_scope`)   <!-- re-pinned 2026-07-16 foundation-slice-progressive: 5857→5901 (_foundation_skeleton + _foundation_pick + _foundation_selector replaced the flat _foundation_slice above cmd_status, net +44 lines); prior foundation-slice: 5808→5857; prior recipe-dedup: 5797→5808 (the pin drifts on ANY upstream add.py change; symbol cited so the drift self-describes; todo #30 seams-symbol-pins retires this class). prior: 5778→5800 @ status-lean-default -->
 Contract: `_declared_scope` reads ONLY the first physical line after the §5 header — a
   wrapped multi-line list silently truncates. Each backticked token then resolves
   independently: `./...` = this task's dir, any token containing `/` = project-root-relative,

--- a/.add/SEAMS.md
+++ b/.add/SEAMS.md
@@ -54,7 +54,7 @@ Citations: 232 files reference "byte-identical" in `.add/tasks/` — method:
 
 ## scope-token-grammar
 Name: §5 "Scope (may touch):" token-resolution grammar
-Anchor: `add-method/tooling/add.py:5797` (`_declared_scope`)   <!-- re-pinned 2026-07-15 resume-card-dedup: 5800→5797 (cmd_status SHRANK — the bottom resume block dropped its 3 restated lines above the anchor; the pin drifts on ANY upstream add.py change; symbol cited so the drift self-describes; todo #30 seams-symbol-pins retires this class). prior: 5778→5800 @ status-lean-default (lean-default gates grew cmd_status above the anchor) -->
+Anchor: `add-method/tooling/add.py:5808` (`_declared_scope`)   <!-- re-pinned 2026-07-15 recipe-dedup: 5797→5808 (new-task recipe-dedup added 11 lines above the anchor); prior resume-card-dedup: 5800→5797 (cmd_status SHRANK — the bottom resume block dropped its 3 restated lines above the anchor; the pin drifts on ANY upstream add.py change; symbol cited so the drift self-describes; todo #30 seams-symbol-pins retires this class). prior: 5778→5800 @ status-lean-default (lean-default gates grew cmd_status above the anchor) -->
 Contract: `_declared_scope` reads ONLY the first physical line after the §5 header — a
   wrapped multi-line list silently truncates. Each backticked token then resolves
   independently: `./...` = this task's dir, any token containing `/` = project-root-relative,

--- a/.add/SEAMS.md
+++ b/.add/SEAMS.md
@@ -54,7 +54,7 @@ Citations: 232 files reference "byte-identical" in `.add/tasks/` — method:
 
 ## scope-token-grammar
 Name: §5 "Scope (may touch):" token-resolution grammar
-Anchor: `add-method/tooling/add.py:5800` (`_declared_scope`)   <!-- re-pinned 2026-07-15 status-lean-default: 5778→5800 (cmd_status grew the lean-default gates — goal/m-goal/personas/milestone/task/stream blocks behind --all — above the anchor; the pin drifts on ANY upstream add.py change; symbol cited so the drift self-describes; todo #30 seams-symbol-pins retires this class) -->
+Anchor: `add-method/tooling/add.py:5797` (`_declared_scope`)   <!-- re-pinned 2026-07-15 resume-card-dedup: 5800→5797 (cmd_status SHRANK — the bottom resume block dropped its 3 restated lines above the anchor; the pin drifts on ANY upstream add.py change; symbol cited so the drift self-describes; todo #30 seams-symbol-pins retires this class). prior: 5778→5800 @ status-lean-default (lean-default gates grew cmd_status above the anchor) -->
 Contract: `_declared_scope` reads ONLY the first physical line after the §5 header — a
   wrapped multi-line list silently truncates. Each backticked token then resolves
   independently: `./...` = this task's dir, any token containing `/` = project-root-relative,

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -41,14 +41,14 @@ Engine: `.add/tooling/add.py` · book: `.add/docs/`. Ensure it is in the project
   `node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill` — drops `.add/tooling/` (engine) +
   `.add/docs/` (book) + the agent-agnostic `CLAUDE.md` block; the skill stays in the plugin.
 
-Resume from the tool (a COLD start), never re-read the repo — mid-flow, trust each verb's
-`next:` footer; don't re-`status` to re-orient:
+Resume from the tool (COLD start), never re-read the repo — mid-flow, trust each verb's
+`next:` footer:
 
 ```bash
 python3 .add/tooling/add.py status --brief
 ```
 
-Then read `.add/PROJECT.md` (foundation) + `.add/SOUL.md` (**voice**, each session — `soul.md`). Then branch on state:
+Then read the foundation map `add.py status --foundation` (one section: `--foundation "Users"` · `--all` full) + `.add/SOUL.md` (**voice** — `soul.md`). Then branch on state:
 
 - **No `.add/state.json` yet** (`status` says `no .add/ project found`) → **autonomous setup**: read
   `.add/.intent` if present (the installer's first-build intent — a NOTE, never an init trigger), then

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -41,14 +41,14 @@ Engine: `.add/tooling/add.py` · book: `.add/docs/`. Ensure it is in the project
   `node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill` — drops `.add/tooling/` (engine) +
   `.add/docs/` (book) + the agent-agnostic `CLAUDE.md` block; the skill stays in the plugin.
 
-Resume from the tool, never re-read the repo:
+Resume from the tool (a COLD start), never re-read the repo — mid-flow, trust each verb's
+`next:` footer; don't re-`status` to re-orient:
 
 ```bash
 python3 .add/tooling/add.py status --brief
 ```
 
-Then read the two orient files: `.add/PROJECT.md` (the foundation) and `.add/SOUL.md`
-(your **voice** — read each session; human-owned, self-improving — `soul.md`). Then branch on state:
+Then read `.add/PROJECT.md` (foundation) + `.add/SOUL.md` (**voice**, each session — `soul.md`). Then branch on state:
 
 - **No `.add/state.json` yet** (`status` says `no .add/ project found`) → **autonomous setup**: read
   `.add/.intent` if present (the installer's first-build intent — a NOTE, never an init trigger), then

--- a/.claude/skills/add/phases/5-build.md
+++ b/.claude/skills/add/phases/5-build.md
@@ -55,7 +55,7 @@ Never: change a test or the contract; use a package off the allow-list; or push 
 
 ## Next
 
-`python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
+`python3 .add/tooling/add.py gate PASS` (from build — compound-crosses to verify in one call) → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
 
 > Under `autonomy: auto` Build and Verify run together as one evidence-auto-gated run. See `run.md`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,11 +1,11 @@
 # Releases
 
 ## 1.18.0 — 2026-07-14
-milestones: build-strategy-facets, delta-drain, add-bench, add-lean-loop, expectations-first, plan-legibility, six-phase-loop, add-bench-v2, three-phase-flow, risk-proportional-ceremony, quality-floors
+milestones: build-strategy-facets, delta-drain, add-bench, add-lean-loop, expectations-first, plan-legibility, six-phase-loop, add-bench-v2, three-phase-flow, risk-proportional-ceremony, quality-floors, honest-fidelity-meter, token-anatomy, engine-minimalism, ceremony-turn-cut, engine-output-trim
 loose tasks: prune-benchmark-deadweight
 waivers: reclaim-ticket-race, js-reclaim-lock-heartbeat
 actor: Tin Dang <tindang.ht97@gmail.com> (git)
-evidence: expanded cut (1.17.0-amend precedent): 11 milestones — six-phase-loop(#148/#149 stack) + expectations-first/plan-legibility/quality-floors(#145) + add-bench/add-bench-v2(#142) + three-phase-flow/risk-proportional-ceremony + add-lean-loop + build-strategy-facets(#139)/delta-drain(#140) — plus loose installer-shared-namespace-guard(#151); ceremony-to-effort + call-floor features included, milestones open on measurement criteria; 10 open SPEC deltas ride forced (fold review pending, human-owned); fence 3570 OK · release tests green · WM1 re-measure fid 0.98x3/0 regr
+evidence: expanded cut (1.17.0-amend precedent): 16 milestones — six-phase-loop(#148/#149 stack) + expectations-first/plan-legibility/quality-floors(#145) + add-bench/add-bench-v2(#142) + three-phase-flow/risk-proportional-ceremony + add-lean-loop + build-strategy-facets(#139)/delta-drain(#140) — plus loose installer-shared-namespace-guard(#151); ceremony-to-effort + call-floor features included, milestones open on measurement criteria. Then the engine-minimalism / context-cost thread: honest-fidelity-meter (deterministic requirement_coverage + hermetic scoring, LLM judge demoted to non-gating annotation) · token-anatomy (cache-read cost by category) · engine-minimalism(#158: --help 121→19, status --brief orient, lean bare status behind --all) · ceremony-turn-cut/advance-fold(#159: green build → gate PASS, redundant pre-gate advance folded) · engine-output-trim(#161: resume-card + recipe dedup, trust-the-footer, foundation-slice progressive `status --foundation` map, −59% on a 55KB foundation). No gate weakened; a security finding still HARD-STOPs. Full engine suite 3654 green (5 env-only pty/npm sandbox failures); ENGINE_MD5 4e655960; open SPEC deltas ride forced (fold review pending, human-owned)
 
 ## 1.17.0 — 2026-07-07
 milestones: persona-domain-fit, method-ergonomics, dynamic-personas, self-improving-loop

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -18,7 +18,10 @@ that measured it all), **add-lean-loop**, plus the original
 **build-strategy-facets** and **delta-drain**. The ceremony-to-effort and
 call-floor features (compound ticks · scope echo · kickoff truth · skill
 orient split) ship here too; their milestones remain open on measurement
-criteria. No gate weakened; a security finding still HARD-STOPs.
+criteria. Folded in after the July-14 cut: the **engine-minimalism /
+context-cost thread** — a progressive foundation read, a lean default `status`,
+and one fewer ceremony turn per crossing — measured by **token-anatomy** and
+**honest-fidelity-meter**. No gate weakened; a security finding still HARD-STOPs.
 
 ### Changed (the headline)
 - **The loop is six phases**: `specify → plan → tests → build → verify → done`.
@@ -76,6 +79,34 @@ criteria. No gate weakened; a security finding still HARD-STOPs.
   now land only ADD's own roster files per-file (atomic), removal is
   explicit-tombstone-only — the user's own subagents survive every install and
   update (loose task installer-shared-namespace-guard, PR #151).
+
+### Added (engine-minimalism — the context-cost thread)
+- **Progressive foundation read** — `status --foundation` prints a MAP (the preamble +
+  `invariants:` + Domain + Spec in full; every other section collapsed to its heading +
+  an on-demand `add.py status --foundation "<section>"` pull), so the cross-milestone
+  foundation that is re-read every turn is a slice, not the whole file; a named section
+  fleshes out on demand and `--all` restores the whole foundation (foundation-slice, −59%
+  on a 55KB foundation). Invariants never collapse — the contracts that bind every task
+  always survive the map.
+- **Lean default `status`** — bare `status` prints the resume essentials; five heavy
+  blocks gate behind `--all`; `status --brief` is the mid-task resume; `status --section
+  <n>` reads one TASK.md §body instead of the whole growing file (engine-minimalism).
+- **`--help` diet** — the top-level help drops from 121 lines to 19 (engine-minimalism).
+
+### Changed (engine-minimalism)
+- **One fewer ceremony turn per crossing** — a green build steers straight to `gate PASS`;
+  the redundant pre-gate `advance` is folded away (ceremony-turn-cut / advance-fold).
+- **Leaner per-turn engine output** — bare `status` stops restating the 'now' card in its
+  resume block; `new-task` teaches the full annotated recipe once per project, compact
+  thereafter; the skill re-orients from each verb's `next:` footer instead of re-running
+  `status` (engine-output-trim, status-brief-adoption, trust-the-footer).
+
+### Added (measurement — not shipped in the package)
+- **Token anatomy** attributes a benchmark run's cache-read cost by category; a
+  deterministic **`requirement_coverage`** meter replaces the artifact-blind spec-fidelity
+  judge (now a source-aware, non-gating annotation); scoring is hermetic per boot
+  (token-anatomy, honest-fidelity-meter). Dev harness under `benchmark/` — not in the
+  npm/PyPI tarball.
 
 ### Disclosed waivers (non-security, signed)
 - `reclaim-ticket-race` — lock-reclaim TOCTOU flake; owner Tin Dang, expires 2026-08-04.

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -41,14 +41,14 @@ Engine: `.add/tooling/add.py` · book: `.add/docs/`. Ensure it is in the project
   `node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill` — drops `.add/tooling/` (engine) +
   `.add/docs/` (book) + the agent-agnostic `CLAUDE.md` block; the skill stays in the plugin.
 
-Resume from the tool (a COLD start), never re-read the repo — mid-flow, trust each verb's
-`next:` footer; don't re-`status` to re-orient:
+Resume from the tool (COLD start), never re-read the repo — mid-flow, trust each verb's
+`next:` footer:
 
 ```bash
 python3 .add/tooling/add.py status --brief
 ```
 
-Then read `.add/PROJECT.md` (foundation) + `.add/SOUL.md` (**voice**, each session — `soul.md`). Then branch on state:
+Then read the foundation map `add.py status --foundation` (one section: `--foundation "Users"` · `--all` full) + `.add/SOUL.md` (**voice** — `soul.md`). Then branch on state:
 
 - **No `.add/state.json` yet** (`status` says `no .add/ project found`) → **autonomous setup**: read
   `.add/.intent` if present (the installer's first-build intent — a NOTE, never an init trigger), then

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -41,14 +41,14 @@ Engine: `.add/tooling/add.py` · book: `.add/docs/`. Ensure it is in the project
   `node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill` — drops `.add/tooling/` (engine) +
   `.add/docs/` (book) + the agent-agnostic `CLAUDE.md` block; the skill stays in the plugin.
 
-Resume from the tool, never re-read the repo:
+Resume from the tool (a COLD start), never re-read the repo — mid-flow, trust each verb's
+`next:` footer; don't re-`status` to re-orient:
 
 ```bash
 python3 .add/tooling/add.py status --brief
 ```
 
-Then read the two orient files: `.add/PROJECT.md` (the foundation) and `.add/SOUL.md`
-(your **voice** — read each session; human-owned, self-improving — `soul.md`). Then branch on state:
+Then read `.add/PROJECT.md` (foundation) + `.add/SOUL.md` (**voice**, each session — `soul.md`). Then branch on state:
 
 - **No `.add/state.json` yet** (`status` says `no .add/ project found`) → **autonomous setup**: read
   `.add/.intent` if present (the installer's first-build intent — a NOTE, never an init trigger), then

--- a/add-method/skill/add/phases/5-build.md
+++ b/add-method/skill/add/phases/5-build.md
@@ -55,7 +55,7 @@ Never: change a test or the contract; use a package off the allow-list; or push 
 
 ## Next
 
-`python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
+`python3 .add/tooling/add.py gate PASS` (from build — compound-crosses to verify in one call) → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
 
 > Under `autonomy: auto` Build and Verify run together as one evidence-auto-gated run. See `run.md`.

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -41,14 +41,14 @@ Engine: `.add/tooling/add.py` · book: `.add/docs/`. Ensure it is in the project
   `node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill` — drops `.add/tooling/` (engine) +
   `.add/docs/` (book) + the agent-agnostic `CLAUDE.md` block; the skill stays in the plugin.
 
-Resume from the tool (a COLD start), never re-read the repo — mid-flow, trust each verb's
-`next:` footer; don't re-`status` to re-orient:
+Resume from the tool (COLD start), never re-read the repo — mid-flow, trust each verb's
+`next:` footer:
 
 ```bash
 python3 .add/tooling/add.py status --brief
 ```
 
-Then read `.add/PROJECT.md` (foundation) + `.add/SOUL.md` (**voice**, each session — `soul.md`). Then branch on state:
+Then read the foundation map `add.py status --foundation` (one section: `--foundation "Users"` · `--all` full) + `.add/SOUL.md` (**voice** — `soul.md`). Then branch on state:
 
 - **No `.add/state.json` yet** (`status` says `no .add/ project found`) → **autonomous setup**: read
   `.add/.intent` if present (the installer's first-build intent — a NOTE, never an init trigger), then

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -41,14 +41,14 @@ Engine: `.add/tooling/add.py` · book: `.add/docs/`. Ensure it is in the project
   `node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill` — drops `.add/tooling/` (engine) +
   `.add/docs/` (book) + the agent-agnostic `CLAUDE.md` block; the skill stays in the plugin.
 
-Resume from the tool, never re-read the repo:
+Resume from the tool (a COLD start), never re-read the repo — mid-flow, trust each verb's
+`next:` footer; don't re-`status` to re-orient:
 
 ```bash
 python3 .add/tooling/add.py status --brief
 ```
 
-Then read the two orient files: `.add/PROJECT.md` (the foundation) and `.add/SOUL.md`
-(your **voice** — read each session; human-owned, self-improving — `soul.md`). Then branch on state:
+Then read `.add/PROJECT.md` (foundation) + `.add/SOUL.md` (**voice**, each session — `soul.md`). Then branch on state:
 
 - **No `.add/state.json` yet** (`status` says `no .add/ project found`) → **autonomous setup**: read
   `.add/.intent` if present (the installer's first-build intent — a NOTE, never an init trigger), then

--- a/add-method/src/add_method/_bundled/skill/add/phases/5-build.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/5-build.md
@@ -55,7 +55,7 @@ Never: change a test or the contract; use a package off the allow-list; or push 
 
 ## Next
 
-`python3 .add/tooling/add.py advance` → read `phases/6-verify.md`.
+`python3 .add/tooling/add.py gate PASS` (from build — compound-crosses to verify in one call) → read `phases/6-verify.md`.
 Book: `docs/07-step-5-build.md`.
 
 > Under `autonomy: auto` Build and Verify run together as one evidence-auto-gated run. See `run.md`.

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -3213,18 +3213,15 @@ def cmd_status(args: argparse.Namespace) -> None:
                 print(f"          {_hl} — {_nxt}")
                 print(f"          (the loop: .add/docs/{_chap})")
         else:
-            print(f"\nresume  : task '{active}' is at phase '{ph}'.")
-            # status-guide-fold: name the EXACT next command inline (the ONE
-            # _next_command composer) so an agent reading plain status can proceed
-            # without a separate `guide` round-trip. first-call-ergonomics M1: thread
-            # the live frozen-ness so a post-freeze status never re-teaches freeze.
-            _frozen = ph == "plan" and _task_contract_frozen(root, active)
-            print(f"          next: {_next_command(ph, contract_frozen=_frozen)}")
-            # engine-hint-context-ops: teach the cheap context ops at the moment of
-            # use — a whole-TASK.md read every re-orient is the context-tax driver.
-            print(f"          read its live section: add.py status --section {ph}"
-                  "  (whole TASK.md only if needed)")
-            print("          re-orient next turn: add.py status --brief")
+            # resume-card-dedup (advance-fold follow-through): the top 'now' card
+            # already carries slug · phase · the EXACT next verb (via _next_footer,
+            # frozen-ness threaded) · re-orient. The bottom block used to RESTATE all
+            # of that — a ~230B doubling that re-enters cache on every later turn. Keep
+            # ONLY the context ops it uniquely teaches (engine-hint-context-ops): the
+            # per-section read + the cheap re-orient (the whole-TASK.md context-tax
+            # drivers). The next verb lives once now — in the card.
+            print(f"\nresume  : add.py status --section {ph}  ·  add.py status --brief"
+                  "   (read one section / cheap re-orient — whole TASK.md only if needed)")
 
 
 # Agent-portability (v14): `guide` names the PHASE PLAYBOOK file — the same

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -894,16 +894,27 @@ def cmd_new_task(args: argparse.Namespace) -> None:
     print("active task set. phase: specify. State the projected expectations (§1 SPECIFY); "
           "grounding + contract + build-strategy come next, together, in the plan phase.")
     print(_next_footer(root, state))   # converges the old "then: add.py advance" hint
-    # kickoff-truth M2: the FULL remaining engine-call recipe, once, at task birth —
-    # the transcript audit measured 6-11 status/guide/--help re-orientation calls per
-    # run that this single block replaces. Lane-invariant (the freeze/gate floor is
-    # the same in every lane); the agent scripts ahead instead of rediscovering.
-    print("recipe — this task's remaining engine calls:")
-    print("  add.py advance --to plan   (write the section rules first)")
-    print("  add.py freeze --by <name> --cross   [human gate — approves the whole plan; "
-          "--cross lands in tests]")
-    print("  add.py advance   (after the RED suite: tests -> build, make it green)")
-    print("  add.py gate PASS   (from build — crosses to verify and records the outcome)")
+    # kickoff-truth M2: the remaining engine-call recipe at task birth — the transcript
+    # audit measured 6-11 status/guide/--help re-orientation calls per run that this
+    # block replaces. Lane-invariant (the freeze/gate floor is the same in every lane);
+    # the agent scripts ahead instead of rediscovering.
+    #
+    # recipe-dedup (engine-output-trim): the FULL annotated recipe teaches what each
+    # remaining call MEANS — needed ONCE, at the project's first task. A LATER task in
+    # the same project names the SAME flow COMPACTLY: the agent already read the prose,
+    # so re-printing ~330B of identical annotations every task only re-enters cache. The
+    # compact form keeps EVERY command + both advances (the flow floor _assert_recipe
+    # pins), so there is no rediscovery/--help backfire — only the repeated prose drops.
+    if len(state.get("tasks") or {}) <= 1:
+        print("recipe — this task's remaining engine calls:")
+        print("  add.py advance --to plan   (write the section rules first)")
+        print("  add.py freeze --by <name> --cross   [human gate — approves the whole plan; "
+              "--cross lands in tests]")
+        print("  add.py advance   (after the RED suite: tests -> build, make it green)")
+        print("  add.py gate PASS   (from build — crosses to verify and records the outcome)")
+    else:
+        print("recipe — remaining calls: add.py advance --to plan · "
+              "add.py freeze --by <name> --cross · add.py advance · add.py gate PASS")
 
 
 def _delta_task_md(root: Path, state: dict, raw_slug: str | None) -> tuple[str, Path, bool]:

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -2809,7 +2809,100 @@ def _ancestor_note() -> str | None:
             "to scope a project to this directory")
 
 
+_FOUNDATION_CORE = ("## Domain", "## Spec")   # near-always-needed direction context — kept full
+_FOUNDATION_DECISIONS_HEAD = "## Key Decisions"
+_FOUNDATION_DECISIONS_KEEP = 3               # newest-first: the recent head at orient; stale tail on demand
+
+
+def _foundation_selector(heading: str) -> str:
+    """A short, stable selector for a `## ` heading — the title phrase before the first
+    qualifier punctuation. `## Users (UDD) — …` → `Users`; `## Key Decisions (…` → `Key
+    Decisions`. Used for both the pull hint and matching a `--foundation <SECTION>` query."""
+    t = heading[3:].strip()
+    for cut in ("(", " — ", " / ", " - "):
+        i = t.find(cut)
+        if i != -1:
+            t = t[:i]
+    return t.strip()
+
+
+def _foundation_pull(sel: str) -> str:
+    return f'_(collapsed — pull: `add.py status --foundation "{sel}"`)_\n\n'
+
+
+def _foundation_skeleton(text: str) -> str:
+    """The progressive-disclosure foundation MAP for orientation (foundation-slice,
+    context/turn lever): PROJECT.md is a cross-milestone read at orient and re-read every
+    turn. Disclose the SKELETON — the preamble (title + `invariants:`, the run/entry
+    contracts that bind EVERY task) + Domain + Spec IN FULL (near-always-needed direction),
+    every OTHER section COLLAPSED to its heading + an on-demand `--foundation "<section>"`
+    pull; the newest Key Decisions kept, the stale tail pulled. The agent fleshes out a
+    section only when its phase needs it — the same progressive disclosure as the phase
+    guides. PURE. Fail-open: a foundation with no `## ` sections returns verbatim (never
+    blank it). Invariants are never collapsed, so the contracts that bind every task always
+    survive the map."""
+    lines = text.splitlines(keepends=True)
+    heads = [i for i, l in enumerate(lines) if l.startswith("## ")]
+    if not heads:
+        return text
+    out = list(lines[:heads[0]])                       # preamble — invariants live here
+    bounds = heads + [len(lines)]
+    for k, start in enumerate(heads):
+        head = lines[start]
+        body = lines[start:bounds[k + 1]]
+        if head.startswith(_FOUNDATION_CORE):
+            out.extend(body)                            # Domain · Spec — full
+        elif head.startswith(_FOUNDATION_DECISIONS_HEAD):
+            out.append(head)
+            kept = [l for l in body[1:] if l.strip()][:_FOUNDATION_DECISIONS_KEEP]
+            out.extend(kept)
+            out.append(f'_(+tail — pull: `add.py status --foundation "{_foundation_selector(head)}"`)_\n\n')
+        else:
+            out.append(head)                            # heading is the signpost; body on demand
+            out.append(_foundation_pull(_foundation_selector(head)))
+    return "".join(out)
+
+
+def _foundation_pick(text: str, query: str):
+    """Return ONE section (heading + body, FULL) whose heading matches `query`
+    (case-insensitive substring of the heading or its selector), or None if no match —
+    the on-demand flesh for the progressive `--foundation` map."""
+    lines = text.splitlines(keepends=True)
+    heads = [i for i, l in enumerate(lines) if l.startswith("## ")]
+    bounds = heads + [len(lines)]
+    q = query.strip().lower()
+    for k, start in enumerate(heads):
+        head = lines[start]
+        if q in head.lower() or q in _foundation_selector(head).lower():
+            return "".join(lines[start:bounds[k + 1]])
+    return None
+
+
 def cmd_status(args: argparse.Namespace) -> None:
+    fnd = getattr(args, "foundation", None)
+    if fnd is not None:
+        # --foundation (foundation-slice, progressive disclosure): bare prints the MAP
+        # (invariants + Domain + Spec full, other sections collapsed to a pull hint); a
+        # SECTION value pulls that one section body on demand; --all prints the whole
+        # foundation. Raw body only (no banner/footer), mirroring --section. Fail-closed
+        # on a missing foundation — never a silent empty read.
+        root = _require_root()
+        pmd = root / "PROJECT.md"
+        if not pmd.exists():
+            _die("foundation_missing: no .add/PROJECT.md to read")
+        text = pmd.read_text(encoding="utf-8")
+        if getattr(args, "all", False):
+            print(text, end="")
+        elif fnd == "":
+            print(_foundation_skeleton(text), end="")
+        else:
+            body = _foundation_pick(text, fnd)
+            if body is None:
+                names = ", ".join(_foundation_selector(l) for l in text.splitlines()
+                                  if l.startswith("## ")) or "(none)"
+                _die(f"foundation_section_unknown: '{fnd}' — sections: {names}")
+            print(body, end="")
+        return
     _section = getattr(args, "section", None)
     if _section is not None:
         # --section (progressive-task-context): print ONE raw §body of the
@@ -8934,6 +9027,10 @@ def build_parser() -> argparse.ArgumentParser:
     pst.add_argument("--section", default=None, metavar="N|PHASE",
                      help="print ONE raw §body (0-7 or a phase name) of the active task — "
                           "read a section, not the whole TASK.md")
+    pst.add_argument("--foundation", nargs="?", const="", default=None, metavar="SECTION",
+                     help="scoped PROJECT.md read (progressive disclosure): bare = the map "
+                          "(invariants + Domain + Spec full, other sections collapsed to a pull "
+                          "hint); SECTION = pull one section body on demand; --all = the whole foundation")
     pst.set_defaults(func=cmd_status)
 
     pck = sub.add_parser("check", help="read-only integrity check of the .add project")

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -6711,6 +6711,12 @@ def _next_command(phase: str, *, contract_frozen: bool = False) -> str:
         return "add.py advance" if contract_frozen else "add.py freeze --by <name>"
     if phase == "tests":
         return "add.py advance --fill <draft>"
+    if phase == "build":
+        # advance-fold (ceremony-turn-cut): a green build steers STRAIGHT to the completing
+        # gate — `gate PASS` compound-ticks build->verify in ONE call (cmd_gate), so a separate
+        # `advance` here is a pure-bookkeeping turn (~85k cache-read) we drop. Trust floor intact:
+        # the gate runs the full verify completion checks; build->verify carries no human seam.
+        return "add.py gate PASS | RISK-ACCEPTED | HARD-STOP   (from build — compound-crosses to verify)"
     return "add.py advance"
 
 

--- a/add-method/src/add_method/_bundled/tooling/engine_pin.py
+++ b/add-method/src/add_method/_bundled/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "8438237d6187843e7de720725c816a64"  # re-aimed @ advance-fold (ceremony-turn-cut: _next_command build-phase steer → `gate PASS` compound-crosses build→verify, drops the redundant pre-gate advance turn). prior: a773d868… @ status-lean-default
+ENGINE_MD5 = "bc1f4afe88eb964f7797a2619190ff09"  # re-aimed @ resume-card-dedup (engine-output-trim: bare `status` drops the bottom resume block's RESTATED slug·phase·next·re-orient — the top 'now' card already carries them — keeping only the unique --section/--brief context ops; −151B/status, re-read every turn). prior: 8438237d… @ advance-fold
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/src/add_method/_bundled/tooling/engine_pin.py
+++ b/add-method/src/add_method/_bundled/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "bc1f4afe88eb964f7797a2619190ff09"  # re-aimed @ resume-card-dedup (engine-output-trim: bare `status` drops the bottom resume block's RESTATED slug·phase·next·re-orient — the top 'now' card already carries them — keeping only the unique --section/--brief context ops; −151B/status, re-read every turn). prior: 8438237d… @ advance-fold
+ENGINE_MD5 = "159eb2b98600e8544a47324603a96052"  # re-aimed @ recipe-dedup (engine-output-trim: new-task prints the FULL annotated call recipe only at the project's FIRST task; a later task names the same flow compactly — all commands kept, repeated prose dropped; −234B/task after the first). prior: bc1f4afe… @ resume-card-dedup
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/src/add_method/_bundled/tooling/engine_pin.py
+++ b/add-method/src/add_method/_bundled/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "a773d868899bb5dc2b162fc6a4bef8d6"  # re-aimed @ status-lean-default (engine-minimalism: bare `status` gates goal/m-goal prose + personas roster + milestone/task rows + per-stream detail behind --all — count/pointer lines instead). prior: 1dd8c1b1… @ help-diet
+ENGINE_MD5 = "8438237d6187843e7de720725c816a64"  # re-aimed @ advance-fold (ceremony-turn-cut: _next_command build-phase steer → `gate PASS` compound-crosses build→verify, drops the redundant pre-gate advance turn). prior: a773d868… @ status-lean-default
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/src/add_method/_bundled/tooling/engine_pin.py
+++ b/add-method/src/add_method/_bundled/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "159eb2b98600e8544a47324603a96052"  # re-aimed @ recipe-dedup (engine-output-trim: new-task prints the FULL annotated call recipe only at the project's FIRST task; a later task names the same flow compactly — all commands kept, repeated prose dropped; −234B/task after the first). prior: bc1f4afe… @ resume-card-dedup
+ENGINE_MD5 = "4e65596032185cb3d88f764d425b4eb4"  # re-aimed @ foundation-slice-progressive (engine-output-trim: `status --foundation` is a progressive-disclosure MAP — invariants+Domain+Spec full, other sections collapsed to an on-demand `--foundation "<section>"` pull that fleshes out one section; −59% on the 55KB dogfood foundation, re-read every turn; `--all` for the full read). prior: a9ec7dd8… @ foundation-slice
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -3213,18 +3213,15 @@ def cmd_status(args: argparse.Namespace) -> None:
                 print(f"          {_hl} — {_nxt}")
                 print(f"          (the loop: .add/docs/{_chap})")
         else:
-            print(f"\nresume  : task '{active}' is at phase '{ph}'.")
-            # status-guide-fold: name the EXACT next command inline (the ONE
-            # _next_command composer) so an agent reading plain status can proceed
-            # without a separate `guide` round-trip. first-call-ergonomics M1: thread
-            # the live frozen-ness so a post-freeze status never re-teaches freeze.
-            _frozen = ph == "plan" and _task_contract_frozen(root, active)
-            print(f"          next: {_next_command(ph, contract_frozen=_frozen)}")
-            # engine-hint-context-ops: teach the cheap context ops at the moment of
-            # use — a whole-TASK.md read every re-orient is the context-tax driver.
-            print(f"          read its live section: add.py status --section {ph}"
-                  "  (whole TASK.md only if needed)")
-            print("          re-orient next turn: add.py status --brief")
+            # resume-card-dedup (advance-fold follow-through): the top 'now' card
+            # already carries slug · phase · the EXACT next verb (via _next_footer,
+            # frozen-ness threaded) · re-orient. The bottom block used to RESTATE all
+            # of that — a ~230B doubling that re-enters cache on every later turn. Keep
+            # ONLY the context ops it uniquely teaches (engine-hint-context-ops): the
+            # per-section read + the cheap re-orient (the whole-TASK.md context-tax
+            # drivers). The next verb lives once now — in the card.
+            print(f"\nresume  : add.py status --section {ph}  ·  add.py status --brief"
+                  "   (read one section / cheap re-orient — whole TASK.md only if needed)")
 
 
 # Agent-portability (v14): `guide` names the PHASE PLAYBOOK file — the same

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -894,16 +894,27 @@ def cmd_new_task(args: argparse.Namespace) -> None:
     print("active task set. phase: specify. State the projected expectations (§1 SPECIFY); "
           "grounding + contract + build-strategy come next, together, in the plan phase.")
     print(_next_footer(root, state))   # converges the old "then: add.py advance" hint
-    # kickoff-truth M2: the FULL remaining engine-call recipe, once, at task birth —
-    # the transcript audit measured 6-11 status/guide/--help re-orientation calls per
-    # run that this single block replaces. Lane-invariant (the freeze/gate floor is
-    # the same in every lane); the agent scripts ahead instead of rediscovering.
-    print("recipe — this task's remaining engine calls:")
-    print("  add.py advance --to plan   (write the section rules first)")
-    print("  add.py freeze --by <name> --cross   [human gate — approves the whole plan; "
-          "--cross lands in tests]")
-    print("  add.py advance   (after the RED suite: tests -> build, make it green)")
-    print("  add.py gate PASS   (from build — crosses to verify and records the outcome)")
+    # kickoff-truth M2: the remaining engine-call recipe at task birth — the transcript
+    # audit measured 6-11 status/guide/--help re-orientation calls per run that this
+    # block replaces. Lane-invariant (the freeze/gate floor is the same in every lane);
+    # the agent scripts ahead instead of rediscovering.
+    #
+    # recipe-dedup (engine-output-trim): the FULL annotated recipe teaches what each
+    # remaining call MEANS — needed ONCE, at the project's first task. A LATER task in
+    # the same project names the SAME flow COMPACTLY: the agent already read the prose,
+    # so re-printing ~330B of identical annotations every task only re-enters cache. The
+    # compact form keeps EVERY command + both advances (the flow floor _assert_recipe
+    # pins), so there is no rediscovery/--help backfire — only the repeated prose drops.
+    if len(state.get("tasks") or {}) <= 1:
+        print("recipe — this task's remaining engine calls:")
+        print("  add.py advance --to plan   (write the section rules first)")
+        print("  add.py freeze --by <name> --cross   [human gate — approves the whole plan; "
+              "--cross lands in tests]")
+        print("  add.py advance   (after the RED suite: tests -> build, make it green)")
+        print("  add.py gate PASS   (from build — crosses to verify and records the outcome)")
+    else:
+        print("recipe — remaining calls: add.py advance --to plan · "
+              "add.py freeze --by <name> --cross · add.py advance · add.py gate PASS")
 
 
 def _delta_task_md(root: Path, state: dict, raw_slug: str | None) -> tuple[str, Path, bool]:

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -2809,7 +2809,100 @@ def _ancestor_note() -> str | None:
             "to scope a project to this directory")
 
 
+_FOUNDATION_CORE = ("## Domain", "## Spec")   # near-always-needed direction context — kept full
+_FOUNDATION_DECISIONS_HEAD = "## Key Decisions"
+_FOUNDATION_DECISIONS_KEEP = 3               # newest-first: the recent head at orient; stale tail on demand
+
+
+def _foundation_selector(heading: str) -> str:
+    """A short, stable selector for a `## ` heading — the title phrase before the first
+    qualifier punctuation. `## Users (UDD) — …` → `Users`; `## Key Decisions (…` → `Key
+    Decisions`. Used for both the pull hint and matching a `--foundation <SECTION>` query."""
+    t = heading[3:].strip()
+    for cut in ("(", " — ", " / ", " - "):
+        i = t.find(cut)
+        if i != -1:
+            t = t[:i]
+    return t.strip()
+
+
+def _foundation_pull(sel: str) -> str:
+    return f'_(collapsed — pull: `add.py status --foundation "{sel}"`)_\n\n'
+
+
+def _foundation_skeleton(text: str) -> str:
+    """The progressive-disclosure foundation MAP for orientation (foundation-slice,
+    context/turn lever): PROJECT.md is a cross-milestone read at orient and re-read every
+    turn. Disclose the SKELETON — the preamble (title + `invariants:`, the run/entry
+    contracts that bind EVERY task) + Domain + Spec IN FULL (near-always-needed direction),
+    every OTHER section COLLAPSED to its heading + an on-demand `--foundation "<section>"`
+    pull; the newest Key Decisions kept, the stale tail pulled. The agent fleshes out a
+    section only when its phase needs it — the same progressive disclosure as the phase
+    guides. PURE. Fail-open: a foundation with no `## ` sections returns verbatim (never
+    blank it). Invariants are never collapsed, so the contracts that bind every task always
+    survive the map."""
+    lines = text.splitlines(keepends=True)
+    heads = [i for i, l in enumerate(lines) if l.startswith("## ")]
+    if not heads:
+        return text
+    out = list(lines[:heads[0]])                       # preamble — invariants live here
+    bounds = heads + [len(lines)]
+    for k, start in enumerate(heads):
+        head = lines[start]
+        body = lines[start:bounds[k + 1]]
+        if head.startswith(_FOUNDATION_CORE):
+            out.extend(body)                            # Domain · Spec — full
+        elif head.startswith(_FOUNDATION_DECISIONS_HEAD):
+            out.append(head)
+            kept = [l for l in body[1:] if l.strip()][:_FOUNDATION_DECISIONS_KEEP]
+            out.extend(kept)
+            out.append(f'_(+tail — pull: `add.py status --foundation "{_foundation_selector(head)}"`)_\n\n')
+        else:
+            out.append(head)                            # heading is the signpost; body on demand
+            out.append(_foundation_pull(_foundation_selector(head)))
+    return "".join(out)
+
+
+def _foundation_pick(text: str, query: str):
+    """Return ONE section (heading + body, FULL) whose heading matches `query`
+    (case-insensitive substring of the heading or its selector), or None if no match —
+    the on-demand flesh for the progressive `--foundation` map."""
+    lines = text.splitlines(keepends=True)
+    heads = [i for i, l in enumerate(lines) if l.startswith("## ")]
+    bounds = heads + [len(lines)]
+    q = query.strip().lower()
+    for k, start in enumerate(heads):
+        head = lines[start]
+        if q in head.lower() or q in _foundation_selector(head).lower():
+            return "".join(lines[start:bounds[k + 1]])
+    return None
+
+
 def cmd_status(args: argparse.Namespace) -> None:
+    fnd = getattr(args, "foundation", None)
+    if fnd is not None:
+        # --foundation (foundation-slice, progressive disclosure): bare prints the MAP
+        # (invariants + Domain + Spec full, other sections collapsed to a pull hint); a
+        # SECTION value pulls that one section body on demand; --all prints the whole
+        # foundation. Raw body only (no banner/footer), mirroring --section. Fail-closed
+        # on a missing foundation — never a silent empty read.
+        root = _require_root()
+        pmd = root / "PROJECT.md"
+        if not pmd.exists():
+            _die("foundation_missing: no .add/PROJECT.md to read")
+        text = pmd.read_text(encoding="utf-8")
+        if getattr(args, "all", False):
+            print(text, end="")
+        elif fnd == "":
+            print(_foundation_skeleton(text), end="")
+        else:
+            body = _foundation_pick(text, fnd)
+            if body is None:
+                names = ", ".join(_foundation_selector(l) for l in text.splitlines()
+                                  if l.startswith("## ")) or "(none)"
+                _die(f"foundation_section_unknown: '{fnd}' — sections: {names}")
+            print(body, end="")
+        return
     _section = getattr(args, "section", None)
     if _section is not None:
         # --section (progressive-task-context): print ONE raw §body of the
@@ -8934,6 +9027,10 @@ def build_parser() -> argparse.ArgumentParser:
     pst.add_argument("--section", default=None, metavar="N|PHASE",
                      help="print ONE raw §body (0-7 or a phase name) of the active task — "
                           "read a section, not the whole TASK.md")
+    pst.add_argument("--foundation", nargs="?", const="", default=None, metavar="SECTION",
+                     help="scoped PROJECT.md read (progressive disclosure): bare = the map "
+                          "(invariants + Domain + Spec full, other sections collapsed to a pull "
+                          "hint); SECTION = pull one section body on demand; --all = the whole foundation")
     pst.set_defaults(func=cmd_status)
 
     pck = sub.add_parser("check", help="read-only integrity check of the .add project")

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -6711,6 +6711,12 @@ def _next_command(phase: str, *, contract_frozen: bool = False) -> str:
         return "add.py advance" if contract_frozen else "add.py freeze --by <name>"
     if phase == "tests":
         return "add.py advance --fill <draft>"
+    if phase == "build":
+        # advance-fold (ceremony-turn-cut): a green build steers STRAIGHT to the completing
+        # gate — `gate PASS` compound-ticks build->verify in ONE call (cmd_gate), so a separate
+        # `advance` here is a pure-bookkeeping turn (~85k cache-read) we drop. Trust floor intact:
+        # the gate runs the full verify completion checks; build->verify carries no human seam.
+        return "add.py gate PASS | RISK-ACCEPTED | HARD-STOP   (from build — compound-crosses to verify)"
     return "add.py advance"
 
 

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "8438237d6187843e7de720725c816a64"  # re-aimed @ advance-fold (ceremony-turn-cut: _next_command build-phase steer → `gate PASS` compound-crosses build→verify, drops the redundant pre-gate advance turn). prior: a773d868… @ status-lean-default
+ENGINE_MD5 = "bc1f4afe88eb964f7797a2619190ff09"  # re-aimed @ resume-card-dedup (engine-output-trim: bare `status` drops the bottom resume block's RESTATED slug·phase·next·re-orient — the top 'now' card already carries them — keeping only the unique --section/--brief context ops; −151B/status, re-read every turn). prior: 8438237d… @ advance-fold
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "bc1f4afe88eb964f7797a2619190ff09"  # re-aimed @ resume-card-dedup (engine-output-trim: bare `status` drops the bottom resume block's RESTATED slug·phase·next·re-orient — the top 'now' card already carries them — keeping only the unique --section/--brief context ops; −151B/status, re-read every turn). prior: 8438237d… @ advance-fold
+ENGINE_MD5 = "159eb2b98600e8544a47324603a96052"  # re-aimed @ recipe-dedup (engine-output-trim: new-task prints the FULL annotated call recipe only at the project's FIRST task; a later task names the same flow compactly — all commands kept, repeated prose dropped; −234B/task after the first). prior: bc1f4afe… @ resume-card-dedup
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "a773d868899bb5dc2b162fc6a4bef8d6"  # re-aimed @ status-lean-default (engine-minimalism: bare `status` gates goal/m-goal prose + personas roster + milestone/task rows + per-stream detail behind --all — count/pointer lines instead). prior: 1dd8c1b1… @ help-diet
+ENGINE_MD5 = "8438237d6187843e7de720725c816a64"  # re-aimed @ advance-fold (ceremony-turn-cut: _next_command build-phase steer → `gate PASS` compound-crosses build→verify, drops the redundant pre-gate advance turn). prior: a773d868… @ status-lean-default
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,5 +17,5 @@ prose (its TASK.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "159eb2b98600e8544a47324603a96052"  # re-aimed @ recipe-dedup (engine-output-trim: new-task prints the FULL annotated call recipe only at the project's FIRST task; a later task names the same flow compactly — all commands kept, repeated prose dropped; −234B/task after the first). prior: bc1f4afe… @ resume-card-dedup
+ENGINE_MD5 = "4e65596032185cb3d88f764d425b4eb4"  # re-aimed @ foundation-slice-progressive (engine-output-trim: `status --foundation` is a progressive-disclosure MAP — invariants+Domain+Spec full, other sections collapsed to an on-demand `--foundation "<section>"` pull that fleshes out one section; −59% on the 55KB dogfood foundation, re-read every turn; `--all` for the full read). prior: a9ec7dd8… @ foundation-slice
 ENGINE_PKG_MD5 = "265dd143fd850317c66ffb3ad021c98d"  # re-aimed @ hygiene-bundle (engine-hygiene: taskdoc._HEADING_RE — static §-heading regex hoisted to module load). prior: 955023db… @ harness-workspace-isolation

--- a/add-method/tooling/test_advance_fold_build_gate.py
+++ b/add-method/tooling/test_advance_fold_build_gate.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Red/green for advance-fold (ceremony-turn-cut): the build-phase next verb steers to
+`gate PASS` — which compound-ticks build->verify in ONE call — NOT a redundant separate
+`advance` turn. The real wm1 run made `advance` (build->verify) THEN `gate PASS`; the
+advance was pure bookkeeping the gate already does (cmd_gate compound tick). Killing that
+steer saves one ceremony turn per task (~85k cache-read) with zero trust-floor change.
+
+Run: python3 -m unittest test_advance_fold_build_gate -v
+"""
+import pathlib
+import unittest
+
+import add
+
+# the build guide across all three skill trees (resolved from this file's location)
+_TOOLING = pathlib.Path(__file__).resolve().parent          # add-method/tooling
+_ADDROOT = _TOOLING.parent                                  # add-method
+_REPO = _ADDROOT.parent                                     # repo root
+BUILD_GUIDES = [
+    _ADDROOT / "skill" / "add" / "phases" / "5-build.md",
+    _ADDROOT / "src" / "add_method" / "_bundled" / "skill" / "add" / "phases" / "5-build.md",
+    _REPO / ".claude" / "skills" / "add" / "phases" / "5-build.md",
+]
+
+
+class AdvanceFoldBuildGateTest(unittest.TestCase):
+    def test_build_next_verb_is_gate_not_advance(self):
+        cmd = add._next_command("build")
+        self.assertIn("gate PASS", cmd, "build must steer to the compound gate verb")
+        self.assertNotIn("advance", cmd,
+                         "no redundant advance before gate — compound-ticks crosses build->verify")
+
+    def test_verify_next_verb_unchanged(self):
+        self.assertIn("gate PASS", add._next_command("verify"))
+
+    def test_earlier_phase_verbs_unchanged(self):
+        # the fold touches ONLY the build fallthrough — front phases keep their exact steer
+        self.assertIn("advance --to plan", add._next_command("specify"))
+        self.assertIn("freeze --by", add._next_command("plan"))
+        self.assertIn("add.py advance", add._next_command("plan", contract_frozen=True))
+        self.assertIn("advance --fill", add._next_command("tests"))
+
+    def test_build_guides_steer_to_gate_across_three_trees(self):
+        for g in BUILD_GUIDES:
+            if not g.exists():
+                continue
+            txt = g.read_text(encoding="utf-8")
+            # the Next section names the compound gate from build, not a bare advance->verify
+            self.assertIn("gate PASS", txt, f"{g} must steer build to gate PASS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/add-method/tooling/test_foundation_slice.py
+++ b/add-method/tooling/test_foundation_slice.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""foundation-slice (engine-output-trim, context/turn lever) — progressive disclosure.
+PROJECT.md is a cross-milestone foundation read at orient and re-read every turn. `status
+--foundation` discloses the SKELETON — preamble (incl. invariants) + Domain + Spec IN FULL,
+every OTHER section COLLAPSED to its heading + an on-demand `--foundation "<section>"` pull;
+the newest Key Decisions kept, the stale tail pulled. Invariants (run/entry contracts that
+bind EVERY task) are NEVER collapsed. A named `--foundation "<section>"` fleshes out one
+section on demand; `--all` restores the whole foundation.
+
+Run: python3 -m unittest test_foundation_slice -v
+"""
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import add
+
+_FIXTURE = """# PROJECT — foundation
+invariants: the artifact runs as `python -m app` on $PORT
+
+## Domain (DDD) — the language and the boundaries
+DOMAIN_BODY_MARKER — the ubiquitous language lives here.
+
+## Spec / Living Document (SDD) — what we are building, now
+SPEC_BODY_MARKER — the current spec, holistic across milestones.
+
+## Users (UDD) — UI/UX: design before code
+UDD_BODY_MARKER — wireframes, color tokens, screen flows a backend task ignores.
+more UI detail line one
+more UI detail line two
+
+## Key Decisions (append-only — newest-first)
+- NEWEST_DECISION_MARKER 2026-07-15 keep me
+- decision b
+- decision c
+- decision d
+- decision e
+- decision f
+- decision g
+- decision h
+- decision i
+- decision j
+- decision k
+- decision l
+- decision m
+- decision n
+- decision o
+- decision p
+- decision q
+- decision r
+- decision s
+- decision t
+- decision u
+- OLD_DECISION_MARKER 2026-01-01 elide me (stale tail)
+"""
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self):
+        self._cwd = Path.cwd()
+        self.tmp = Path(tempfile.mkdtemp(prefix="add-fslice-")).resolve()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.addCleanup(os.chdir, self._cwd)
+        os.chdir(self.tmp)
+        self._silent("init", "--name", "demo", "--stage", "mvp")
+        (self.tmp / ".add" / "PROJECT.md").write_text(_FIXTURE, encoding="utf-8")
+
+    def _silent(self, *argv):
+        out, err = io.StringIO(), io.StringIO()
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                add.main(list(argv))
+        except SystemExit:
+            pass
+
+    def _run(self, *argv):
+        out, err = io.StringIO(), io.StringIO()
+        code = 0
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                add.main(list(argv))
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else 1
+        return out.getvalue(), err.getvalue(), code
+
+
+class FoundationMapTest(_Harness):
+    def test_map_keeps_invariants_domain_spec(self):
+        out, _, _ = self._run("status", "--foundation")
+        self.assertIn("invariants:", out, "invariants (bind every task) must never be collapsed")
+        self.assertIn("DOMAIN_BODY_MARKER", out, "Domain must be full in the map")
+        self.assertIn("SPEC_BODY_MARKER", out, "Spec must be full in the map")
+        self.assertIn("NEWEST_DECISION_MARKER", out, "the newest decisions must survive")
+
+    def test_map_collapses_udd_body_to_a_pull_hint(self):
+        out, _, _ = self._run("status", "--foundation")
+        self.assertNotIn("UDD_BODY_MARKER", out, "the UI/UX (UDD) body must be collapsed in the map")
+        self.assertIn("## Users", out, "the UDD heading stays as a signpost")
+        self.assertIn('--foundation "Users"', out, "a collapsed section must leave an on-demand pull hint")
+
+    def test_map_collapses_stale_decision_tail(self):
+        out, _, _ = self._run("status", "--foundation")
+        self.assertNotIn("OLD_DECISION_MARKER", out, "the stale decision tail must be collapsed")
+        self.assertIn('--foundation "Key Decisions"', out, "the decision tail must leave a pull hint")
+
+    def test_all_restores_the_full_foundation(self):
+        full, _, _ = self._run("status", "--foundation", "--all")
+        self.assertIn("UDD_BODY_MARKER", full, "--all restores the UDD body")
+        self.assertIn("OLD_DECISION_MARKER", full, "--all restores every decision")
+
+    def test_map_is_materially_shorter_than_full(self):
+        sliced, _, _ = self._run("status", "--foundation")
+        full, _, _ = self._run("status", "--foundation", "--all")
+        self.assertLess(len(sliced), len(full), "the map must be shorter than the full foundation")
+
+
+class FoundationPullTest(_Harness):
+    def test_pull_returns_only_the_named_section_body(self):
+        out, _, code = self._run("status", "--foundation", "Users")
+        self.assertEqual(code, 0)
+        self.assertIn("UDD_BODY_MARKER", out, "pulling `Users` must flesh out that section body")
+        self.assertIn("more UI detail line two", out, "the WHOLE section body, not a summary")
+        self.assertNotIn("DOMAIN_BODY_MARKER", out, "a pull is ONE section, not the whole foundation")
+
+    def test_pull_matches_a_multiword_selector(self):
+        out, _, code = self._run("status", "--foundation", "Key Decisions")
+        self.assertEqual(code, 0)
+        self.assertIn("OLD_DECISION_MARKER", out, "pulling `Key Decisions` fleshes out the full tail")
+
+    def test_pull_unknown_section_fails_closed(self):
+        out, err, code = self._run("status", "--foundation", "Nonexistent")
+        self.assertNotEqual(code, 0, "an unknown section must fail, never a silent empty read")
+        self.assertIn("foundation_section_unknown", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/add-method/tooling/test_kickoff_truth.py
+++ b/add-method/tooling/test_kickoff_truth.py
@@ -109,6 +109,28 @@ class RecipeTest(_Harness):
         out = self._ok("new-task", "t-fast", "--title", "T", "--fast", "--milestone", "m")
         self._assert_recipe(out, "--fast lane")
 
+    def test_later_task_recipe_is_compact_not_re_annotated(self):
+        # recipe-dedup (engine-output-trim): the FIRST task of a project teaches the
+        # annotated flow; a LATER task in the same project names the SAME flow compactly
+        # — the agent already read the per-step prose once. The flow floor still holds
+        # (all marks + both advances, asserted by _assert_recipe on BOTH), so there is
+        # no rediscovery/--help backfire — only the repeated annotation prose is dropped.
+        self._init()
+        self._ok("lock", "--force")
+        first = self._ok("new-task", "t1", "--title", "T", "--oneshot")
+        second = self._ok("new-task", "t2", "--title", "T", "--oneshot")
+        self._assert_recipe(first, "first task")   # full flow named
+        self._assert_recipe(second, "later task")  # full flow STILL named (no backfire)
+        self.assertIn("write the section rules first", first,
+                      "the first task must carry the teaching annotations")
+        self.assertNotIn("write the section rules first", second,
+                         "a later task must not repeat the per-step annotations")
+
+        def _recipe_span(o):
+            return len(o[o.lower().index("recipe"):])
+        self.assertLess(_recipe_span(second), _recipe_span(first),
+                        "the deduped later recipe must be shorter than the annotated first")
+
 
 class DupFailureTest(_Harness):
     """M3 — consecutive byte-identical failures short-circuit; nothing else does."""

--- a/add-method/tooling/test_status_brief_orient.py
+++ b/add-method/tooling/test_status_brief_orient.py
@@ -40,10 +40,14 @@ class StatusBriefOrientTest(unittest.TestCase):
                              f"the bare orient `status` must be replaced in {tree}")
 
     def test_orient_prose_still_names_both_files(self):
-        # R1 orient_floor_lost guard: --brief does NOT name the files, so the PROSE must.
+        # R1 orient_floor_lost guard: --brief does NOT name the files, so the PROSE must
+        # point the agent at BOTH the foundation and the voice. The foundation is reached
+        # either by its raw path (`PROJECT.md`) or via the scoped `status --foundation`
+        # slice that serves it (foundation-slice) — both satisfy the floor.
         for tree in SKILL_TREES:
             block = _orient_block(tree.read_text())
-            self.assertIn("PROJECT.md", block, f"orient prose must still name PROJECT.md in {tree}")
+            self.assertTrue("PROJECT.md" in block or "status --foundation" in block,
+                            f"orient prose must point at the foundation in {tree}")
             self.assertIn("SOUL.md", block, f"orient prose must still name SOUL.md in {tree}")
 
     def test_both_skill_trees_byte_identical(self):

--- a/add-method/tooling/test_status_orientation_diet.py
+++ b/add-method/tooling/test_status_orientation_diet.py
@@ -86,5 +86,34 @@ class GlanceCardTest(_Harness):
         self.assertNotIn("now     :", out, "no active task → no glance card")
 
 
+class ResumeBlockDedupTest(_Harness):
+    """resume-card-dedup (advance-fold follow-through): the diet added the top 'now'
+    card but left the bottom 'resume :' block RESTATING the same slug·phase·next·
+    re-orient. That byte-doubling re-enters cache on every later turn. The bottom
+    block must keep ONLY the context ops it uniquely teaches (--section / --brief);
+    the next-verb lives once, in the card."""
+
+    def test_next_command_stated_once_not_twice(self):
+        out = self._run("status")
+        # the specify-phase next verb is `advance --to plan`; the card carries it via
+        # _next_footer, so the resume block must not print it a second time.
+        n = out.count("advance --to plan")
+        self.assertEqual(n, 1, f"next-command must appear once (card only), got {n}:\n{out}")
+
+    def test_resume_keeps_unique_context_ops_drops_restated_prose(self):
+        out = self._run("status")
+        # unique ops survive (the context-tax drivers engine-hint-context-ops added)
+        self.assertIn("status --section specify", out, "per-section read op must survive")
+        self.assertIn("status --brief", out, "cheap re-orient op must survive")
+        # restated prose is gone — the card already carries phase= and the next verb
+        self.assertNotIn("is at phase", out, "resume must not restate phase (card has phase=)")
+
+    def test_done_branch_still_present(self):
+        # the done-task resume branch carries UNIQUE loop-steering (not in the card) — keep it.
+        src = (Path(add.__file__)).read_text()
+        self.assertIn("resume  : task '{active}' is done", src,
+                      "done-task resume branch must stay (unique loop-steering)")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## engine-output-trim — cut ADD's per-turn engine output (context/turn lever)

Stacked on #159 (`feat/advance-fold`). Attacks the **context/turn** side of ADD's
`cost ≈ turns × context/turn` premium: the token anatomy proved `engine_output` = 38%
of cache-read, and every byte a verb prints re-enters cache on **every later turn**.

### Ground-check first
Most of the obvious "Tier 1/2/3" minimization was **already shipped** in the #158/#159
stack (help-diet, status-lean-default, advance-fold, advance-chain-collapse), and the
re-orientation footer (`_next_footer`) already fires at ~30 sites on every mutating verb.
So this PR is the **residual clean surface** only — no re-doing shipped work.

### The three commits
1. **`resume-card-dedup`** — bare `status`'s bottom `resume:` block stopped **restating**
   the top `now:` glance card (slug · phase · next-command · re-orient were printed twice);
   it keeps only the unique `--section`/`--brief` context ops. **−151B/status (−12.7%)**,
   re-read every turn. `ENGINE_MD5 → bc1f4afe`.
2. **`recipe-dedup`** — `new-task` prints the full annotated call recipe only at the
   project's **first** task; a later task names the same flow **compactly** (every command
   + both advances retained, so the flow floor holds → no `--help` backfire). **−234B/task**
   after the first. `ENGINE_MD5 → 159eb2b9`.
3. **`trust-the-footer`** (doc-only) — SKILL.md steers `status --brief` as a **cold-start**
   resume; mid-flow, trust each verb's `next:` footer instead of re-`status`. Funded by
   compressing the adjacent orient line to stay under the **9500B** SKILL.md ceiling.

### Paid re-measure (add arm, wm1–2, trimmed engine `159eb2b9`, ~$5.1)
- **Valid & correct**: sandbox engine md5 = `159eb2b9`; oracle_pass_rate + requirement_coverage
  = **1.0** both milestones; regression_rate **0.0** — the trims broke nothing.
- **recipe-dedup: zero backfire** — the compact recipe fired in wm2 and the agent went
  straight `new-task → advance` with **no** `--help`/`status`/`guide` rediscovery (`guide`
  even dropped 5 → 0).
- **Lever ① justified** — `status` was the top ceremony verb (5 in wm1) and ~4/5 fired right
  after a verb that had already printed a full footer.

### Honesty
The two dedups are **deterministic** byte cuts. `trust-the-footer` is a **behavioral nudge**
— its call-count payoff is unproven without another paid run, and `status` already self-declines
as a project matures (wm1=5 → wm2=2). Beyond these, the remaining premium is the **structural
trust floor** (freeze + red-tests + gate, repeating per milestone) — that's the method working,
not waste (us1 single-task premium was only 1.3× vs 3.7× on the 4-milestone track).

### Verification
- Full suite: **3641 passed** (the only 5 failures are pre-existing environmental node/PTY
  tests — `test_pty_clack` ×4 + `test_installer_prompts` npm — that raise `node_unavailable`/
  `prompt_timeout` in a headless sandbox; this PR touches no node/installer/cli code).
- Engine re-pinned across all 3 add.py trees; `ENGINE_PKG_MD5` unchanged (no `add_engine/*`
  touched); SEAMS `scope-token-grammar` anchor re-pinned for the `_declared_scope` line drift.
- Red/green TDD on both dedups; skill-parity + size-ceiling + orient guards green.
