### PR TITLE
docs(readme): simplify marketing copy + add ADD-vs-vanilla tradeoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,112 +12,88 @@
 
 <h1 align="center">ADD — AI-Driven Development</h1>
 <p align="center"><strong>Your AI's first milestone is always great. ADD is for every milestone after that.</strong></p>
-<p align="center">Describe the feature. The agent drives the build. You approve once — exactly where a mistake would actually cost you.</p>
+<p align="center">Describe the feature. The agent drives the build. You approve once — right where a mistake would actually cost you.</p>
 
 ---
 
-## The problem: AI coding doesn't fail on day one — it rots
+## AI coding doesn't fail on day one — it rots
 
-Every AI coding tool ships a beautiful first feature. The failure mode of AI-driven
-development is **what happens across milestones**: requirements evolve, the
-conversation gets long or gets lost, and the agent quietly re-breaks things it
-already got right. That decay has a name — **context rot** — and we measure it
-instead of hand-waving about it.
+Every AI tool ships a beautiful first feature. The failure shows up **across
+milestones**: requirements evolve, the conversation gets long, and the agent
+quietly re-breaks what it already got right. That decay has a name — **context
+rot** — and we measure it instead of hand-waving.
 
-Our benchmark runs the *same* six-milestone project (CRUD → business rules + auth
-→ a breaking shape change → filters/pagination/recurring → a cross-cutting rooms
-refactor → correctness hardening) through each flow, scored by deterministic
-probes — no LLM judge, no vibes ([campaign report, revised
-edition](./benchmark/results/2026-07-add-2.0-remeasure.md), pinned model, same
-prompts per arm):
+The cause turned out to be simple: **context rot lives in the conversation, not
+in the method or the model.** The same agent that decays inside one long chat
+holds a perfect line when every milestone restarts from state on disk.
 
-| six evolving milestones, same model | one continued conversation | fresh session per milestone, resuming from disk |
+So ADD's answer isn't a bigger context window or a smarter summary. It's this:
+**nothing that matters lives in the chat.** Spec, frozen contract, red suite,
+gate records — all state on disk. Close the laptop, lose the session, swap the
+agent: the next session resumes with one command and loses nothing.
+
+| Same model, six evolving milestones | One long conversation | Fresh session per milestone, resumed from disk |
 |---|---|---|
-| requirement coverage | **.92 → .80 → .75 → decayed** — never recovered the early loss | **1.0 flat, all six milestones**, zero regressions |
-| the WM1 deviation (list-shape spec violation) | carried through **five further milestones** — never re-examined, even while editing that exact endpoint | never introduced: each session re-derived the shape from the spec, 4 of 4 runs |
-| new-feature quality at milestone 6 | still 1.0 — *new* work stays good while old promises rot | 1.0 |
+| Requirement coverage | **.92 → .75, never recovered** | **1.0 flat across all six** |
+| An early spec violation | carried through **five more milestones**, never re-examined | **never introduced** — each session re-derived the shape from the spec |
+| Cost | — | **~$2.90 / milestone** (a 3–5× cut vs ADD 1.x) |
 
-The finding that shaped ADD 2.0: **context rot is real, measurable, and lives in
-the conversation — not in the method, and not in the model.** The same agent that
-decays inside one long conversation holds a perfect line when every milestone
-restarts from state on disk. So the deciding question for any AI dev flow is: *is
-your on-disk state good enough to restart from, every time?* ADD is built so the
-answer is structurally yes — and honesty note: on this friendly single-app
-workload a strong model with spec-kit's files also passed the restart bar; the
-report says so plainly. The gap ADD keeps is what's *guaranteed* rather than
-usual: contracts can't be silently edited, tests can't be quietly weakened,
-security findings can't scroll past.
-
-ADD's answer isn't a longer context window or a smarter summary. It's this:
-**nothing that matters lives in the chat.** The spec, the frozen contract, the red
-suite, the gate records — all of it is state on disk. Close the laptop, lose the
-session, swap the agent: the next session resumes with one command and loses
-nothing. Long conversations don't need surviving when they're unnecessary.
+<sub>[Campaign report, revised edition](./benchmark/results/2026-07-add-2.0-remeasure.md) — pinned model, deterministic probes, no LLM judge.</sub>
 
 ## What ADD is
 
-An agent already knows how to write code. What it structurally *cannot* keep is
-everything that lives outside one context window: what's true so far, what was
-promised, what worked last time, what must never be traded away. Human teams keep
-those in senior engineers' heads — and AI has no head that survives the session.
+An agent already knows how to write code. What it *structurally cannot* keep is
+everything outside one context window: what's true so far, what was promised,
+what must never be traded away. Human teams keep that in senior engineers' heads.
+AI has no head that survives the session.
 
-> **The agent is the hands. ADD is the memory, judgment, and conscience — the part
-> of the team that survives when the context window doesn't.**
+> **The agent is the hands. ADD is the memory, judgment, and conscience — the
+> part of the team that survives when the context window doesn't.**
 
 Every faculty is a file on disk and a command that shows it — never a promise:
 
 | Faculty | What it holds | See it yourself |
 |---|---|---|
-| 🧠 **Memory** — *what is true* | the board, frozen contracts, red suites, five living specs compacting forward | `add.py status` — a brand-new session resumes mid-build, losing nothing |
-| ⚖️ **Judgment** — *how to work here* | personas propose each task's lane; gates trace outcomes; the loop reflects on the record (GEPA) | `add.py deltas` — the per-lane scoreboard: what got gated, what passed, what healed |
-| 🛡️ **Conscience** — *what is trusted* | one freeze per feature, evidence-scored gates, tamper tripwire, security hard-stop | edit a frozen test and watch the gate refuse — weakening a test to get green is structurally impossible, not just unusual |
+| 🧠 **Memory** — *what is true* | the board, frozen contracts, red suites, five living specs | `add.py status` — a brand-new session resumes mid-build, losing nothing |
+| ⚖️ **Judgment** — *how to work here* | personas propose each task's lane; gates trace outcomes; the loop reflects on the record (GEPA) | `add.py deltas` — the per-lane scoreboard: what got gated, passed, healed |
+| 🛡️ **Conscience** — *what is trusted* | one freeze per feature, evidence-scored gates, tamper tripwire, security hard-stop | edit a frozen test and watch the gate refuse — gaming a test to get green is structurally impossible |
 
-## The pain points every coding agent faces — and ADD's receipt for each
-
-These are the failure modes users of *any* agent tool know first-hand. Each row is
-what ADD does about it, with the evidence from the
-[benchmark](./benchmark/results/2026-07-add-2.0-remeasure.md) — same project, same
-model, deterministic probes, retractions published when the meter itself was wrong:
-
-| Pain point you've hit | What ADD does | Receipt |
-|---|---|---|
-| **The session degrades** — long conversations drift; compaction silently drops constraints | Nothing that matters lives in the chat; every milestone starts a fresh session from the board | Measured: one continued conversation decayed **.92 → .75** and carried an early spec violation through **five further milestones**; fresh sessions from disk held **1.0 flat** across all six |
-| **An early wrong turn becomes permanent** — the agent keeps trusting its own past decisions over the spec | The frozen contract and red suite are re-read from disk every session — the agent's memory of itself never outranks the written spec | The locked-in deviation appeared **only** in conversation-carry mode, in every flow tried; never once in a restart-from-disk run |
-| **It games the tests** — the fastest path to green is deleting the assertion | Weakening a frozen test is *tampering* — the gate refuses; recovery requires a human-visible re-cross | A structural guarantee, not a habit: the tamper tripwire fires on any frozen-suite edit during build (WV2 measured no arm gaming on friendly workloads — this floor exists for the day that stops being true) |
-| **A confident diff that's wrong** — it looks right, so it merges | Trust comes from pre-declared expectations passing, never from a plausible diff; you approve once, at the frozen contract | Coverage **1.0 on all six milestones** including a cross-cutting refactor, scored by probes the agent never sees |
-| **Every session starts over** — re-reading the repo, re-explaining the goal, paying for it | One command orients from `state.json`; the skill loads only the beat you're in | **~$2.90 per milestone** at full discipline — a **3–5× cut vs ADD 1.x** ($4.65–13.94), competitive with the lightest structured flows |
-| **Security findings scroll past** in auto-accept mode | A security finding is a `HARD-STOP` — the one gate no flag, persona, or lane can soften | A structural floor in every mode, including the fully-autonomous lanes |
-
-## Why This Exists
-
-Every AI coding tool can write code fast now. The part that never got solved is
-trust — how do you know it built the *right* thing, and how do you know it's
-*correct*, without reading every line yourself?
-
-ADD answers both. Freeze the direction *before* any code is written — spec,
-scenarios, contract, and *red* tests as one bundle — then give **one** human
-approval, at that frozen contract. From there the agent builds and verifies against
-real evidence: passing tests and checked risks, never a diff that merely *looks*
-right. And because yesterday's contracts and tests stay frozen and re-run, the
-things you already trust **stay** trusted while the project moves.
-
-It's for anyone who builds software with AI in the loop — engineers, architects,
-testers, designers, product owners, and the people who lead them.
-
-## ✨ Highlights — what 2.0 is
+## ✨ Highlights
 
 - 📉 **Anti-context-rot by design** — state on disk, fresh sessions lossless; measured flat 1.0 across evolving milestones while conversation-carried flows decayed.
 - ✅ **Approve once, then let it run** — one human sign-off at the frozen contract; the agent drives Direction → Build → Verify.
-- 🔬 **Proof, not promises** — deterministic gates on observed behavior; never a plausible-looking diff. Weakening a test to get green is treated as tampering.
-- 💸 **Lean enough to be the cheap option** — a thin 31-verb state kernel and a 3-call task walk; **$2.20 per trusted milestone** vs spec-kit's $3.90 in our latest head-to-head.
+- 🔬 **Proof, not promises** — deterministic gates on observed behavior, never a plausible-looking diff. Weakening a test to get green is treated as tampering.
+- 💸 **Lean enough to be the cheap option** — a thin 31-verb state kernel and a 3-call task walk; ~$2.90 per trusted milestone, a 3–5× cut vs ADD 1.x.
 - 🔒 **Security never gets waved through** — any security finding is a hard stop, human in the loop.
-- 🧠 **Personas that learn your project** — the routing brain: a persona proposes each task's lane, outcomes are traced, and the loop reflects on what worked (GEPA) so the method adapts to *your* codebase.
-- 📄 **One file per feature** — spec, scenarios, contract, tests, and gate record live in a single `PLAN.md`; five living specs carry the project's evolving truth.
+- 🧠 **Personas that learn your project** — a persona proposes each task's lane, outcomes are traced, and the loop reflects on what worked (GEPA).
+- 📄 **One file per feature** — spec, scenarios, contract, tests, and gate record live in a single `PLAN.md`.
 - 🎨 **See it before you build it** — a wireframe and a zero-dependency HTML mock, approved before any code.
 - 👥 **Built for teams** — git-native multi-user, N parallel milestones, DAG-scheduled waves.
 - 🤝 **Works with your AI** — Claude, Copilot, Cursor, Codex, Gemini; install via npm, pip, or the Claude Code plugin.
 
 > _Direction before speed. Trust comes from passing tests — not from reading code and finding it plausible._
+
+<sub>**Fine print:** benchmark cells are single-rep (direction, not statistical proof). On this friendly single-app workload a strong model under spec-kit also passed the restart floors, and ran cheaper — the report's revised edition retracts our own earlier "collapse" claim after we found the meter defect behind it. ADD's case rests on the context-rot result, the structural guarantees, and the 3–5× cost cut vs its own 1.x — not on a rival's failure.</sub>
+
+## ADD vs vanilla — when it earns its keep
+
+ADD isn't free. It asks for one thing vanilla prompting doesn't: **you approve a
+frozen contract before any code is written.** That upfront pass is the whole
+trade — you spend minutes on direction to buy trust that holds across milestones.
+
+|  | 🏃 **Vanilla** — just prompt the agent | 🛡️ **ADD** |
+|---|---|---|
+| **First feature** | fastest — start typing | one Direction pass first, then builds |
+| **Across milestones** | quality decays; old promises silently break | frozen contracts + red suites re-run; trust holds |
+| **What you verify** | you re-read the diff and hope | pre-declared tests pass, or the gate refuses |
+| **Resuming later** | re-explain the goal, re-read the repo | one command from `state.json`, lossless |
+| **Cost** | near-zero ceremony | ~$2.90 / milestone of structure |
+| **Best for** | throwaway scripts, one-shots, spikes | evolving products, multiple milestones, teams |
+
+**Rule of thumb:** building something you'll throw away this week? Vanilla is
+fine. Building something you'll still be changing next month? The Direction pass
+pays for itself the first time the agent *doesn't* re-break a feature you shipped
+three milestones ago.
 
 ---
 
@@ -125,57 +101,39 @@ testers, designers, product owners, and the people who lead them.
 
 ![Three steps — 1. Install with npx @pilotspace/add init (also pip, or the Claude Code plugin); 2. Spawn a feature with /add 'your goal' and give one approval at the frozen contract; 3. Resume anytime with /add — state lives in .add/state.json, no context rot](add-install.png)
 
-Here's the whole path, from nothing to your first running feature.
-
 **Prerequisites:** Node ≥ 18 *(npm path)* or Python ≥ 3.10 *(pip path)*, plus a CLI coding agent — Claude Code, Codex, or similar.
 
 ### 1 · Install into your project
 
-From your project root (an empty folder or an existing repo), pick one ecosystem:
+From your project root, pick one ecosystem:
 
 ```bash
-# Node / npm in project folder
-npx @pilotspace/add init
-npx @pilotspace/add update    # later, to update
+npx @pilotspace/add init      # Node / npm
 ```
-
-or
-
 ```bash
-# Python / pip in project folder
-pip install pilotspace-add && pilotspace-add init
-pilotspace-add update         # later, to update
+pip install pilotspace-add && pilotspace-add init      # Python / pip
 ```
-
-or, on **Claude Code**, install the skill straight from the marketplace — no npm or pip needed:
-
 ```text
+# Claude Code plugin — no npm or pip needed
 /plugin marketplace add pilotspace/ADD
 /plugin install add@add-method
 ```
 
 > See a real one: this repo's own [`.add/`](https://github.com/pilotspace/ADD/tree/main/.add) folder.
 
-### 2 · Spawn your first feature — talk to the agent
+### 2 · Spawn your first feature
 
 In Claude Code, run **`/add`** and say what you want to build:
-
-```bash
-# in claude code -> spawn ADD skill
-> /add 'Describe your goal'
-```
-
-*Example*: 
 
 ```bash
 /add 'Let users log in with email + password / SSO, and keep them signed in for 30 days unless they explicitly log out.'
 ```
 
-From there the agent runs the on-ramp for you:
+The agent runs the on-ramp for you:
 
-1. 🧭 **Orients** from `add.py status` (the resume point) — never re-reading your whole repo.
-2. 📐 **Sizes** your request into a **milestone** (goal · scope · breadth-first tasks · exit criteria) — **you confirm the shape.**
-3. ✍️ **Drafts** each task's whole **Direction bundle** — Spec + Scenarios + Contract + red Tests in one pass — *you give one approval, at the frozen contract.*
+1. 🧭 **Orients** from `add.py status` — never re-reading your whole repo.
+2. 📐 **Sizes** your request into a **milestone** — *you confirm the shape.*
+3. ✍️ **Drafts** each task's **Direction bundle** — Spec + Scenarios + Contract + red Tests in one pass — *you give one approval, at the frozen contract.*
 4. ✅ **Runs** Build → Verify to green; a security finding always stops back to you.
 
 ### 3 · Resume anytime
@@ -184,26 +142,20 @@ From there the agent runs the on-ramp for you:
 /add status | continue
 ```
 
-State lives on disk, not in the chat — the agent reports exactly where the project
-stands. Close your laptop, come back tomorrow, and pick up exactly where you left
-off. No context rot: in our measurements this is the difference between quality
-decaying every milestone (−.08 coverage/milestone in one continued conversation)
-and holding flat at 1.0.
+State lives on disk, not in the chat. Close your laptop, come back tomorrow, and
+pick up exactly where you left off — no context rot.
 
-**Want more power?** [ccsk-cli](https://github.com/ccsk-org/ccsk-cli) sharpens your agent's skillset for ADD (optional, recommended).
+> **Want more power?** [ccsk-cli](https://github.com/ccsk-org/ccsk-cli) sharpens your agent's skillset for ADD (optional, recommended).
 
 ---
 
 ## ⚙️ How ADD Works
 
-**Curious how it works end to end?** Three pictures, zoomed out one level at a time.
-
 **One task · three beats · one file.** Every feature is a single **`PLAN.md`** that
 fills in section by section as the agent walks three beats — **Direction** (spec →
 scenarios → frozen contract → red tests, the *one* human approval), **Build**
 (red → green, scope-fenced), **Verify** (evidence-scored gate: `PASS`,
-`RISK-ACCEPTED`, or `HARD-STOP`). Each beat writes its own sections; the artifacts
-are what you keep — the code is disposable.
+`RISK-ACCEPTED`, or `HARD-STOP`). The artifacts are what you keep — the code is disposable.
 
 ![Foundation Domain Documents](add-foundation.png)
 
@@ -215,28 +167,12 @@ are what you keep — the code is disposable.
 
 ---
 
-## 📊 The receipts
-
-Every claim above is a number in a committed report, reproducible from this repo's
-[`benchmark/`](./benchmark/) harness (deterministic probes, pinned model, per-run
-records):
-
-- [ADD 2.0 remeasure + context-rot campaign](./benchmark/results/2026-07-add-2.0-remeasure.md) — add vs spec-kit, fresh vs one-continued-conversation
-- [Earlier campaigns](./benchmark/results/) — hostile-change resistance, ceremony-cost anatomy, multi-arm sweeps
-
-Honest fine print: cells are single-rep (direction, not statistical proof); on the
-friendly single-app workload a strong model passed the floors under spec-kit too,
-and spec-kit's rep ran cheaper — the report's revised edition retracts our own
-earlier collapse claim after we found the meter defect behind it. ADD's case rests
-on the context-rot result, the structural guarantees, and the 3–5× cost cut vs its
-own 1.x — not on a rival's failure.
-
 ## 📚 Learn More
 
 - 📖 [Read the book](https://pilotspace.github.io/ADD/) — the full AIDD method, chapter by chapter
 - ⚖️ [ADD vs spec-kit — the honest comparison](https://pilotspace.github.io/ADD/appendix-h-add-vs-spec-kit/) — where we tie, where they win, what only ADD guarantees
-- ⚡ [2-minute Getting Started](./GETTING-STARTED.md)
-- 🔍 [Full hands-on walkthrough](./add-method/GETTING-STARTED.md) — one real feature, end to end
+- ⚡ [2-minute Getting Started](./GETTING-STARTED.md) · 🔍 [Full hands-on walkthrough](./add-method/GETTING-STARTED.md)
+- 📊 [Benchmark results](./benchmark/) — every trust and cost claim, reproducible from this repo
 - 📦 [Package source](./add-method/README.md) · [Changelog](./add-method/CHANGELOG.md)
 - 🗞️ [ADD Across the Org: AI-Driven Development Beyond Code](https://inkpaper-blog.pages.dev/series/add-across-the-org/)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agent: the next session resumes with one command and loses nothing.
 |---|---|---|
 | Requirement coverage | **.92 → .75, never recovered** | **1.0 flat across all six** |
 | An early spec violation | carried through **five more milestones**, never re-examined | **never introduced** — each session re-derived the shape from the spec |
-| Cost per milestone | — | **3–5× cheaper than ADD 1.x** — structure got leaner, not pricier |
+| New-feature quality at milestone 6 | still good — but the old promises rotted | **1.0** — new work stays good *and* old work holds |
 
 <sub>[Campaign report, revised edition](./benchmark/results/2026-07-add-2.0-remeasure.md) — pinned model, deterministic probes, no LLM judge.</sub>
 
@@ -60,20 +60,20 @@ Every faculty is a file on disk and a command that shows it — never a promise:
 
 ## ✨ Highlights
 
-- 📉 **Anti-context-rot by design** — state on disk, fresh sessions lossless; measured flat 1.0 across evolving milestones while conversation-carried flows decayed.
-- ✅ **Approve once, then let it run** — one human sign-off at the frozen contract; the agent drives Direction → Build → Verify.
-- 🔬 **Proof, not promises** — deterministic gates on observed behavior, never a plausible-looking diff. Weakening a test to get green is treated as tampering.
-- 💸 **Lean enough to be the cheap option** — a thin 31-verb state kernel and a 3-call task walk; 3–5× lower per-milestone cost than ADD 1.x, competitive with the lightest structured flows.
-- 🔒 **Security never gets waved through** — any security finding is a hard stop, human in the loop.
-- 🧠 **Personas that learn your project** — a persona proposes each task's lane, outcomes are traced, and the loop reflects on what worked (GEPA).
-- 📄 **One file per feature** — spec, scenarios, contract, tests, and gate record live in a single `PLAN.md`.
-- 🎨 **See it before you build it** — a wireframe and a zero-dependency HTML mock, approved before any code.
-- 👥 **Built for teams** — git-native multi-user, N parallel milestones, DAG-scheduled waves.
-- 🤝 **Works with your AI** — Claude, Copilot, Cursor, Codex, Gemini; install via npm, pip, or the Claude Code plugin.
+- 📉 **Your agent stops re-breaking last month's work** — every decision lives on disk, so a fresh session resumes with the full picture instead of a drifting memory. Measured: quality held flat where a long conversation decayed.
+- ✅ **Stop babysitting the build** — you approve once, at the frozen contract; from there the agent drives Direction → Build → Verify on its own and only comes back when it matters.
+- 🔬 **Know it's correct without reading every line** — trust comes from your pre-declared tests passing, never a diff that merely *looks* right. Gaming a test to go green is treated as tampering, not a shortcut.
+- 💸 **Structure without the ceremony tax** — a thin 31-verb kernel and a 3-call task walk keep ADD the cheap option, competitive with the lightest structured flows.
+- 🔒 **Never ship a security hole on autopilot** — any security finding is a hard stop with you in the loop, in every mode, even the fully-autonomous ones.
+- 🧠 **The method adapts to *your* codebase** — a persona proposes each task's approach, outcomes are traced, and the loop learns what actually works here (GEPA).
+- 📄 **Everything about a feature in one place** — spec, scenarios, contract, tests, and gate record in a single `PLAN.md`; no doc tree to hunt through.
+- 🎨 **See the UI before a line of code** — a wireframe and a zero-dependency HTML mock, approved before any build.
+- 👥 **Grows with your team** — git-native multi-user, N parallel milestones, DAG-scheduled waves.
+- 🤝 **Keep the agent you already use** — Claude, Copilot, Cursor, Codex, Gemini; install via npm, pip, or the Claude Code plugin.
 
 > _Direction before speed. Trust comes from passing tests — not from reading code and finding it plausible._
 
-<sub>**Fine print:** benchmark cells are single-rep (direction, not statistical proof). On this friendly single-app workload a strong model under spec-kit also passed the restart floors, and ran cheaper — the report's revised edition retracts our own earlier "collapse" claim after we found the meter defect behind it. ADD's case rests on the context-rot result, the structural guarantees, and the 3–5× cost cut vs its own 1.x — not on a rival's failure.</sub>
+<sub>**Fine print:** benchmark cells are single-rep (direction, not statistical proof). On this friendly single-app workload a strong model under spec-kit also passed the restart floors, and ran cheaper — the report's revised edition retracts our own earlier "collapse" claim after we found the meter defect behind it. ADD's case rests on the context-rot result and the structural guarantees — not on a rival's failure.</sub>
 
 ## ADD vs vanilla — when it earns its keep
 
@@ -87,7 +87,7 @@ trade — you spend minutes on direction to buy trust that holds across mileston
 | **Across milestones** | quality decays; old promises silently break | frozen contracts + red suites re-run; trust holds |
 | **What you verify** | you re-read the diff and hope | pre-declared tests pass, or the gate refuses |
 | **Resuming later** | re-explain the goal, re-read the repo | one command from `state.json`, lossless |
-| **Cost** | near-zero ceremony up front | one bounded direction pass per milestone — and 3–5× leaner than ADD 1.x |
+| **Cost** | near-zero ceremony up front | one bounded direction pass per milestone — minutes, not a doc tree |
 | **Best for** | throwaway scripts, one-shots, spikes | evolving products, multiple milestones, teams |
 
 **Rule of thumb:** building something you'll throw away this week? Vanilla is

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agent: the next session resumes with one command and loses nothing.
 |---|---|---|
 | Requirement coverage | **.92 → .75, never recovered** | **1.0 flat across all six** |
 | An early spec violation | carried through **five more milestones**, never re-examined | **never introduced** — each session re-derived the shape from the spec |
-| Cost | — | **~$2.90 / milestone** (a 3–5× cut vs ADD 1.x) |
+| Cost per milestone | — | **3–5× cheaper than ADD 1.x** — structure got leaner, not pricier |
 
 <sub>[Campaign report, revised edition](./benchmark/results/2026-07-add-2.0-remeasure.md) — pinned model, deterministic probes, no LLM judge.</sub>
 
@@ -63,7 +63,7 @@ Every faculty is a file on disk and a command that shows it — never a promise:
 - 📉 **Anti-context-rot by design** — state on disk, fresh sessions lossless; measured flat 1.0 across evolving milestones while conversation-carried flows decayed.
 - ✅ **Approve once, then let it run** — one human sign-off at the frozen contract; the agent drives Direction → Build → Verify.
 - 🔬 **Proof, not promises** — deterministic gates on observed behavior, never a plausible-looking diff. Weakening a test to get green is treated as tampering.
-- 💸 **Lean enough to be the cheap option** — a thin 31-verb state kernel and a 3-call task walk; ~$2.90 per trusted milestone, a 3–5× cut vs ADD 1.x.
+- 💸 **Lean enough to be the cheap option** — a thin 31-verb state kernel and a 3-call task walk; 3–5× lower per-milestone cost than ADD 1.x, competitive with the lightest structured flows.
 - 🔒 **Security never gets waved through** — any security finding is a hard stop, human in the loop.
 - 🧠 **Personas that learn your project** — a persona proposes each task's lane, outcomes are traced, and the loop reflects on what worked (GEPA).
 - 📄 **One file per feature** — spec, scenarios, contract, tests, and gate record live in a single `PLAN.md`.
@@ -87,7 +87,7 @@ trade — you spend minutes on direction to buy trust that holds across mileston
 | **Across milestones** | quality decays; old promises silently break | frozen contracts + red suites re-run; trust holds |
 | **What you verify** | you re-read the diff and hope | pre-declared tests pass, or the gate refuses |
 | **Resuming later** | re-explain the goal, re-read the repo | one command from `state.json`, lossless |
-| **Cost** | near-zero ceremony | ~$2.90 / milestone of structure |
+| **Cost** | near-zero ceremony up front | one bounded direction pass per milestone — and 3–5× leaner than ADD 1.x |
 | **Best for** | throwaway scripts, one-shots, spikes | evolving products, multiple milestones, teams |
 
 **Rule of thumb:** building something you'll throw away this week? Vanilla is

--- a/add-method/README.md
+++ b/add-method/README.md
@@ -55,7 +55,7 @@ green. Full walkthrough: the [10-minute Quickstart](./GETTING-STARTED.md).
 - 📉 **Anti-context-rot by design** — every decision lives on disk (`PLAN.md`, frozen contracts, red suites, `.add/state.json`), so a fresh session resumes losslessly; measured flat 1.0 quality across evolving milestones while conversation-carried flows decayed.
 - ✅ **Approve once, then let it run** — one human sign-off at the frozen contract; the agent drives Direction → Build → Verify.
 - 🔬 **Proof, not promises** — verified against observed behavior and pre-declared expectations, never just a plausible-looking diff; weakening a test to reach green is treated as tampering.
-- 💸 **Lean by measurement** — a thin 31-verb state kernel, a 3-call task walk, one file per feature; ~$2.90 per trusted milestone, a 3–5× cut vs ADD 1.x.
+- 💸 **Lean by measurement** — a thin 31-verb state kernel, a 3-call task walk, one file per feature; 3–5× lower per-milestone cost than ADD 1.x.
 - 🔒 **Security never gets waved through** — any security finding is a hard stop, human in the loop.
 - 🧠 **Personas route the work** — a project-owned persona proposes each task's lane, the freeze ratifies it, outcomes are traced, and the loop reflects on the record (GEPA) so the method adapts to your codebase.
 - 🎨 **See it before you build it** — a wireframe and a zero-dependency HTML mock, approved before any code.
@@ -77,7 +77,7 @@ The causal finding: when ONE continued conversation carried the milestones, ever
 flow decayed the same way (coverage .92 → .75, an early spec violation carried
 through five more milestones). When every milestone instead started a **fresh
 session resuming from disk**, ADD held every floor at 1.0 across all six — through
-a breaking shape change and a cross-cutting refactor — at ~$2.90 per milestone.
+a breaking shape change and a cross-cutting refactor — at a fraction of ADD 1.x's per-milestone cost.
 
 That's the design, in three moves:
 

--- a/add-method/README.md
+++ b/add-method/README.md
@@ -12,18 +12,18 @@
 
 > A minimal, state-tracked skill for building software when the AI writes the code
 > and **you** own the two things it cannot do alone: decide *what* to build, and
-> *verify* it is correct. Native on Claude Code; every other CLI coding agent
-> follows the same loop through the phase guides.
+> *verify* it is correct.
 
 **The agent is the hands. ADD is the memory, judgment, and conscience — the part
 of the team that survives when the context window doesn't.** Memory: the board,
 frozen contracts, and living specs on disk (`add.py status` resumes any session
 losslessly). Judgment: personas propose each task's lane and the loop learns from
-the traced outcomes (`add.py deltas`). Conscience: evidence-scored gates, the
-tamper tripwire, the security hard-stop. It sits on top of a context foundation
-(DDD → SDD → UDD) and runs as a red/green TDD ↔ AI-build loop.
-The full reasoning — *why* every rule exists — is [the AIDD book, published
-online](https://pilotspace.github.io/ADD/). Read it once; keep it open beside you.
+traced outcomes (`add.py deltas`). Conscience: evidence-scored gates, the tamper
+tripwire, the security hard-stop.
+
+Native on Claude Code; every other CLI agent follows the same loop through the
+phase guides. The full reasoning — *why* every rule exists — is
+[the AIDD book](https://pilotspace.github.io/ADD/).
 
 ```
   Foundation (context):  DDD  ·  SDD  ·  UDD
@@ -35,13 +35,10 @@ online](https://pilotspace.github.io/ADD/). Read it once; keep it open beside yo
 ## Quick Start
 
 ```bash
-# Node / npm
-npx @pilotspace/add init
+npx @pilotspace/add init                                # Node / npm
 ```
-
 ```bash
-# Python / pip
-pip install pilotspace-add && pilotspace-add init
+pip install pilotspace-add && pilotspace-add init       # Python / pip
 ```
 
 Then, in your coding agent, say what you want to build:
@@ -50,115 +47,86 @@ Then, in your coding agent, say what you want to build:
 
 The agent sizes it into a milestone (you confirm the shape), drafts the
 specification bundle — spec → scenarios → contract → red tests as one Direction
-pass (you approve once, at the frozen contract), then builds and verifies to
-green. Full detail below — **Install**, **Use it**, and the
-[10-minute Quickstart](./GETTING-STARTED.md).
+pass (you approve once, at the frozen contract) — then builds and verifies to
+green. Full walkthrough: the [10-minute Quickstart](./GETTING-STARTED.md).
 
 ## Highlights
 
 - 📉 **Anti-context-rot by design** — every decision lives on disk (`PLAN.md`, frozen contracts, red suites, `.add/state.json`), so a fresh session resumes losslessly; measured flat 1.0 quality across evolving milestones while conversation-carried flows decayed.
 - ✅ **Approve once, then let it run** — one human sign-off at the frozen contract; the agent drives Direction → Build → Verify.
 - 🔬 **Proof, not promises** — verified against observed behavior and pre-declared expectations, never just a plausible-looking diff; weakening a test to reach green is treated as tampering.
-- 💸 **Lean by measurement** — a thin 31-verb state kernel, a 3-call task walk, one file per feature; $2.20 per trusted milestone vs spec-kit's $3.90 in the latest head-to-head.
+- 💸 **Lean by measurement** — a thin 31-verb state kernel, a 3-call task walk, one file per feature; ~$2.90 per trusted milestone, a 3–5× cut vs ADD 1.x.
 - 🔒 **Security never gets waved through** — any security finding is a hard stop, human in the loop.
 - 🧠 **Personas route the work** — a project-owned persona proposes each task's lane, the freeze ratifies it, outcomes are traced, and the loop reflects on the record (GEPA) so the method adapts to your codebase.
 - 🎨 **See it before you build it** — a wireframe and a zero-dependency HTML mock, approved before any code.
-- 👥 **Built for teams** — git-native multi-user, N parallel milestones, DAG-scheduled waves.
-- 🧩 **One slice, many components** — monorepo or multi-repo, in one team.
+- 👥 **Built for teams** — git-native multi-user, N parallel milestones, DAG-scheduled waves; monorepo or multi-repo in one team.
 - 🤝 **Works with your AI** — Claude, Copilot, Cursor, Codex, Gemini; install via npm, pip, or the Claude Code plugin.
 
 > _Direction before speed. Trust comes from passing tests — not from reading code and finding it plausible._
 
-## Why ADD — the pain point is context rot, and we measured it
+## Why ADD — context rot, measured
 
-Every AI coding tool can write code fast now, and every flow we benchmark aces a
-greenfield first milestone. The unsolved part is **trust across change**: when the
-spec evolves in milestone 2 and breaks compatibility in milestone 3, does the work
-you already trusted *stay* trusted?
+Every AI tool writes code fast and aces a greenfield first milestone. The unsolved
+part is **trust across change**: when the spec evolves in milestone 2 and breaks
+compatibility in milestone 3, does the work you already trusted *stay* trusted?
 
 Our benchmark runs the same six-milestone evolving project through each flow under
 a pinned model with deterministic probe scoring
 ([report, revised edition](https://github.com/pilotspace/ADD/blob/main/benchmark/results/2026-07-add-2.0-remeasure.md)).
 The causal finding: when ONE continued conversation carried the milestones, every
-flow decayed the same way (coverage .92 → .75, with an early list-shape spec
-violation carried through five further milestones, never re-examined). When every
-milestone instead started a **fresh session resuming from disk**, ADD held every
-floor at 1.0 across all six milestones — through a breaking shape change and a
-cross-cutting refactor — with zero regressions, at ~$2.90 per milestone (a 3–5×
-cut vs ADD 1.x's $4.65–13.94 per trusted feature). Honesty note, from the same
-report: on this friendly workload a strong model under spec-kit also passed the
-restart-mode floors (and ran cheaper) — we published the retraction of our own
-earlier collapse claim when we found the meter defect behind it. What ADD uniquely
-adds is the *guarantees*: contracts that can't be silently edited, tests that
-can't be quietly weakened, security findings that can't scroll past.
+flow decayed the same way (coverage .92 → .75, an early spec violation carried
+through five more milestones). When every milestone instead started a **fresh
+session resuming from disk**, ADD held every floor at 1.0 across all six — through
+a breaking shape change and a cross-cutting refactor — at ~$2.90 per milestone.
 
 That's the design, in three moves:
 
-- **One file per feature.** Spec, scenarios, contract, test-plan, and gate record
-  all live inline in a single `PLAN.md`. No sprawling doc tree.
-- **State on disk, not in chat.** A stdlib-Python kernel tracks where you are in
-  `.add/state.json`, so a fresh session resumes with one command instead of
-  re-reading the repo — and instead of trusting a long conversation's memory.
-- **Progressive disclosure.** The skill narrates the whole loop itself and loads a
-  deeper phase reference only when the beat needs it — the context window stays
-  lean.
+- **One file per feature.** Spec, scenarios, contract, test-plan, and gate record all live inline in a single `PLAN.md`. No sprawling doc tree.
+- **State on disk, not in chat.** A stdlib-Python kernel tracks where you are in `.add/state.json`, so a fresh session resumes with one command instead of trusting a long conversation's memory.
+- **Progressive disclosure.** The skill narrates the whole loop itself and loads a deeper phase reference only when the beat needs it — the context window stays lean.
 
-## Where ADD fits vs. skill libraries (e.g. agency-agents)
+<sub>**Honesty note:** on this friendly single-app workload a strong model under spec-kit also passed the restart floors (and ran cheaper) — we published the retraction of our own earlier collapse claim when we found the meter defect behind it. What ADD uniquely adds is the *guarantees*: contracts that can't be silently edited, tests that can't be quietly weakened, security findings that can't scroll past.</sub>
 
-ADD is the **trust layer** — the gated loop (Direction → Build → Verify)
-that decides when work is trusted, and the on-disk memory it runs on. It is not a
-catalog of ready-made expert personas. Skill libraries like [agency-agents](https://github.com/msitarzewski/agency-agents), or
-role-specific subagents (a backend expert, a security reviewer, a senior Java engineer), sit at a
-different layer: they answer **who does the work** — a domain stance, vocabulary, and craft rules
-for one kind of task. ADD answers **how you trust what gets built**, no matter who or what wrote it.
+## ADD vs skill libraries (e.g. agency-agents)
 
-The two layers compose; they don't compete. ADD's persona loop **distills** a lean, project-fit
-persona from a teacher corpus like agency-agents — vendored at
-[`personas-teacher/`](./personas-teacher/), read **off-build** by the AI while drafting a persona,
-never a runtime dependency — down to the three parts a project actually needs: **Identity** (the
-stance), **Critical Rules** (the non-negotiables), and **Success Metrics** (the done-bar). The
-project then owns that persona outright.
+ADD is the **trust layer** — the gated loop (Direction → Build → Verify) that
+decides when work is trusted, plus the on-disk memory it runs on. It answers **how
+you trust what gets built**. Skill libraries and role-specific subagents (a backend
+expert, a security reviewer) answer **who does the work**. Different layers — they
+compose, they don't compete.
 
-A distilled persona is applied as an **advisory overlay** during direction, build, or verify — it
-shapes *how* a step gets done, never whether it happens: it can't skip a gate, edit a frozen
-contract, or wave through a security finding. In 2.0 personas also carry **task-kinds** and
-propose each task's route (full walk · fast lane · inline); the freeze ratifies the route, the
-gate traces the outcome, and `add.py deltas` rolls the traces into a per-lane scoreboard the
-loop reflects on (GEPA). That gated loop is what ADD contributes underneath any persona,
-distilled or not.
+ADD's persona loop **distills** a lean, project-fit persona from a teacher corpus
+like [agency-agents](https://github.com/msitarzewski/agency-agents) — vendored at
+[`personas-teacher/`](./personas-teacher/), read off-build while drafting, never a
+runtime dependency — down to the three parts a project needs: **Identity**,
+**Critical Rules**, **Success Metrics**. The project then owns that persona.
 
-## Best setup: ADD alongside other agent libraries
+A distilled persona is an **advisory overlay** during direction, build, or verify:
+it shapes *how* a step gets done, never whether it happens. It can't skip a gate,
+edit a frozen contract, or wave through a security finding. In 2.0 personas also
+propose each task's route (full walk · fast lane · inline); the freeze ratifies it,
+the gate traces the outcome, and `add.py deltas` rolls the traces into a per-lane
+scoreboard the loop reflects on (GEPA).
 
-1. **Install ADD** (below) — it drives the loop: which phase you're in, what needs your approval,
-   whether something is proven.
-2. **Keep whatever subagent libraries you already use.** ADD ships ONE `add` agent in the same
-   `.claude/agents/` mechanism as any other Claude Code subagent — the spawn names the mode
-   (direction · build · verify · advise · persona) and the agent loads that beat's guide plus the
-   best-fit persona. It coexists with a distilled persona, an agency-agents-derived specialist,
-   or a built-in expert with zero conflict; nothing is replaced.
-3. **Prefer the `add` agent for anything phase-shaped** — spawn it in verify mode for the
-   independent adversarial refute-read, in build mode for a red→green batch — before an ad-hoc
-   spawn. Reach for another specialist when a piece needs deep domain expertise the phase guide
-   doesn't carry (a Java-specific review, a payments-domain lens).
-4. **The gates hold no matter who did the work.** A delegated subagent proposes; the orchestrating
-   agent records. A security finding is always a `HARD-STOP`, and a low self-reported confidence
-   means refine or re-spawn — never a pass — whichever subagent produced it.
+**Best setup:** install ADD to drive the loop, keep whatever subagent libraries you
+already use. ADD ships ONE `add` agent in the same `.claude/agents/` mechanism as
+any other subagent — it coexists with a distilled persona or a built-in expert with
+zero conflict, nothing is replaced. Prefer the `add` agent for anything
+phase-shaped (verify mode for the adversarial refute-read, build mode for a
+red→green batch); reach for another specialist when a piece needs deep domain
+expertise the phase guide doesn't carry. **The gates hold no matter who did the
+work** — a delegated subagent proposes; the orchestrating agent records.
 
 ## Install
 
 Pick your ecosystem — all three install the same skill and tooling:
 
 ```bash
-# Node / npm
-npx @pilotspace/add init
+npx @pilotspace/add init                   # Node / npm
 ```
-
 ```bash
-# Python / pip
-pip install pilotspace-add
-pilotspace-add init
+pip install pilotspace-add && pilotspace-add init      # Python / pip
 ```
-
 ```text
 # Claude Code plugin — no npm or pip needed
 /plugin marketplace add pilotspace/ADD
@@ -166,24 +134,18 @@ pilotspace-add init
 ```
 
 The plugin carries the engine. On first `/add`, the skill materializes it into the
-project (`node "${CLAUDE_PLUGIN_ROOT}/bin/cli.js" init --no-skill`) and scaffolds
-`.add/` — a self-contained, portable result identical to the npm/pip flow. The skill stays
-in the plugin, so nothing is duplicated.
-
-No flags needed — the project name is inferred from your folder and the stage
+project and scaffolds `.add/` — a self-contained result identical to the npm/pip
+flow. No flags needed: the project name is inferred from your folder and the stage
 defaults to `prototype` (pass `--name "My App" --stage mvp` to choose up front).
 
-**Already installed?** Refresh to the latest without a re-install —
-`npx @pilotspace/add@latest update` (or `pipx run pilotspace-add update`)
-re-materializes the skill and tooling while leaving your project work
-(`.add/state.json`, `PROJECT.md`, milestones, tasks) untouched; add `--check` to
-see whether a project is behind the installed package. Coming from 1.x? One
-command — `python3 .add/tooling/add.py migrate` — converts the whole board
-(task docs to `PLAN.md`, living 5-DD specs seeded); it's idempotent and refuses
-to guess on conflicts.
+**Already installed?** `npx @pilotspace/add@latest update` (or `pipx run
+pilotspace-add update`) re-materializes the skill and tooling while leaving your
+project work untouched; add `--check` to see whether a project is behind. **Coming
+from 1.x?** One idempotent command — `python3 .add/tooling/add.py migrate` —
+converts the whole board (task docs to `PLAN.md`, living 5-DD specs seeded).
 
-**New here?** Follow the [10-minute Quickstart](./GETTING-STARTED.md) — it walks
-your first feature end to end.
+**New here?** The [10-minute Quickstart](./GETTING-STARTED.md) walks your first
+feature end to end.
 
 This installs:
 
@@ -192,66 +154,35 @@ This installs:
 | `.claude/skills/add/` | the `add` skill Claude loads — the loop itself, plus three on-demand phase references |
 | `.add/tooling/add.py` | the state kernel — scaffolder + tracker, 31 verbs (Python, stdlib only) |
 | `.add/personas-teacher/` | the vendored teacher corpus personas are distilled from (off-build reading, never runtime) |
-| `.add/DESIGN.md` | (UI projects) the prose front-door to the **render-ready UDD foundation** — delete it if your project has no UI |
+| `.add/DESIGN.md` | (UI projects) front-door to the render-ready UDD foundation — delete it if your project has no UI |
 
-The AIDD book itself no longer installs into projects — it lives online at
-[pilotspace.github.io/ADD](https://pilotspace.github.io/ADD/), and the engine
-deep-links the exact chapter whenever a gate or guide cites its rationale.
+Project state (`.add/state.json`) and the living-documentation files
+(`CONVENTIONS.md`, `GLOSSARY.md`, `MODEL_REGISTRY.md`, `dependencies.allowlist`,
+`SOUL.md`) are *not* created at install — the installer drops files only;
+initialisation is the agent's first move when you run `/add`. On a UI project,
+`add.py check` lints the JSON design foundation under `.add/design/`, going red
+with a named code on any violation and staying silent when there's no design set.
 
-On a UI project, UDD gives the AI a frozen design ground to draft from: `DESIGN.md`
-plus a lintable JSON foundation under `.add/design/` (design tokens · component
-catalog · prototype trees). `add.py check` lints that foundation, going red with a
-named code on any layer, catalog, tree, or cross-file violation — and staying
-silent when a project has no design set.
+## Boundaries — what this plugin writes and runs
 
-Project state (`.add/state.json`) and the living-documentation files (`CONVENTIONS.md`,
-`GLOSSARY.md`, `MODEL_REGISTRY.md`, `dependencies.allowlist`, `SOUL.md` — the AI's
-human-owned voice) are *not* created here — the installer drops files only;
-initialisation is the agent's first move when you run `/add`.
+ADD works *inside your project* — here is exactly what that means:
 
-## What this plugin does, writes, and runs (boundaries)
-
-ADD is a development methodology, so by design it works *inside your project* — here is
-exactly what that means, so there are no surprises:
-
-- **Runs only when you ask.** Nothing executes on install. The skill acts when you run
-  `/add` (or another agent follows the guideline block). It is user-initiated, every time.
-- **What it runs:** the bundled engine and bootstrapper only — `node bin/cli.js` and
-  `python3 .add/tooling/add.py`. No downloaded or remote code is executed; everything it
-  runs ships in the package.
-- **What it writes:** files under your project's `.add/` (state, milestones, tasks) and
-  the managed guideline block in `CLAUDE.md` / `AGENTS.md`. On a plugin install
-  it also materializes the engine into `.add/` on first run. It writes nowhere
-  outside the project working directory; it never touches files above the project root.
-- **Network:** one optional, advisory update check. On `status` / `guide` the engine may
-  make a single HTTPS GET to `https://registry.npmjs.org/@pilotspace/add/latest` to see if
-  a newer version exists — at most once per 24h (cached in `.update-cache.json`), 1.5s
-  timeout, fail-open (offline ⇒ silent no-op). It only writes a one-line note to **stderr**
-  and never changes a command's output or exit code. Disable it entirely with
-  `ADD_NO_UPDATE_CHECK=1`. No other network access, no telemetry, no analytics.
+- **Runs only when you ask.** Nothing executes on install. It acts when you run `/add`. User-initiated, every time.
+- **What it runs:** the bundled engine only — `node bin/cli.js` and `python3 .add/tooling/add.py`. No downloaded or remote code.
+- **What it writes:** files under your project's `.add/` and the managed guideline block in `CLAUDE.md` / `AGENTS.md`. Never above the project root.
+- **Network:** one optional, advisory update check — a single HTTPS GET to the npm registry, ≤ once/24h, 1.5s timeout, fail-open, writes only a one-line note to stderr. Disable with `ADD_NO_UPDATE_CHECK=1`. No telemetry, no analytics.
 - **No secrets, no credentials, no privileged access.** Pure local file orchestration.
 
 ## Use it
 
-ADD is AI-first: you talk to the agent; it drives the method. In Claude Code, run
-**`/add`** and say what you want to build:
+ADD is AI-first: you talk to the agent; it drives the method. The installer detects
+which coding agent you're in and drops the context file it reads — so ADD drives
+under **Claude Code, Codex, OpenCode, Cursor, Windsurf, Trae, Gemini CLI, GitHub
+Copilot, Cline, and Aider** (anything else falls back to a generic `AGENTS.md`).
+Only Claude Code runs `/add` natively; every other agent follows the same loop
+through `add.py status` / `guide`.
 
-> `/add` — *"Let users log in with email + password / SSO, and keep them signed in for 30 days unless they explicitly log out."*
-
-**Works with your agent.** The installer detects which coding agent you're in and
-drops the context file it reads — so ADD drives through the CLI under **Claude Code,
-Codex, OpenCode, Cursor, Windsurf, Trae, Gemini CLI, GitHub Copilot, Cline, and
-Aider** (anything else falls back to a generic `AGENTS.md`). Only Claude Code runs
-the `/add` skill natively; every other agent follows the same loop through the
-phase guides via `add.py status` / `guide`.
-
-The agent orients from `state.json`, **sizes your request into a milestone** (you
-confirm the shape), then drafts each task's **specification bundle** — Spec +
-Scenarios + Contract + Tests as one Direction pass — and you give **one approval at
-the frozen contract**. A self-driving build→verify run takes it to green; security
-findings always stop back to you.
-
-Under the hood the agent runs the CLI as its hands — and you can hand-drive it too:
+You can hand-drive the CLI too:
 
 ```bash
 python3 .add/tooling/add.py status      # where am I? (resume point)
@@ -259,31 +190,21 @@ python3 .add/tooling/add.py status      # where am I? (resume point)
 
 ## The non-negotiables
 
-1. **Direction before speed** — no Build until spec, scenarios, contract, and *red*
-   tests exist.
-2. **Trust evidence, not inspection** — a feature is trusted because its tests pass
-   and the non-functional risks (concurrency, security, architecture) were checked.
+1. **Direction before speed** — no Build until spec, scenarios, contract, and *red* tests exist.
+2. **Trust evidence, not inspection** — a feature is trusted because its tests pass and the non-functional risks (concurrency, security, architecture) were checked.
 3. **Never weaken a test or edit a frozen contract** to make the build pass.
-4. **No silent skips** — every Verify records `PASS`, `RISK-ACCEPTED`, or
-   `HARD-STOP`. Security findings are always `HARD-STOP`.
+4. **No silent skips** — every Verify records `PASS`, `RISK-ACCEPTED`, or `HARD-STOP`. Security findings are always `HARD-STOP`.
 5. **Ask, don't guess.**
 
 ## The artifacts survive; the code is disposable
 
 The durable asset is the decisions — spec, scenarios, contract, tests. The code is
 one implementation that satisfies them and can be regenerated. If the thing you'd
-be upset to lose is "the code," you're still working the old way. This is also the
-anti-context-rot stance in one sentence: the artifacts on disk, not the
-conversation, are the project's memory.
+be upset to lose is "the code," you're still working the old way.
 
 ## Read the method
 
-Start at [the book](https://pilotspace.github.io/ADD/) — Foundations → the loop →
-operating it across a team → templates, prompts, and a full worked example.
-
-More entry points:
-
-- 📖 [Read the book online](https://pilotspace.github.io/ADD/) — the full AIDD method, chapter by chapter
+- 📖 [Read the book](https://pilotspace.github.io/ADD/) — the full AIDD method, chapter by chapter
 - 🔍 [Full hands-on walkthrough](./GETTING-STARTED.md) — one real feature, end to end
 - 📊 [Benchmark results](https://github.com/pilotspace/ADD/tree/main/benchmark/results) — every trust and cost claim, measured
 - ⚖️ [ADD vs spec-kit — the honest comparison](https://pilotspace.github.io/ADD/appendix-h-add-vs-spec-kit/) — where we tie, where they win, what only ADD guarantees
@@ -291,18 +212,11 @@ More entry points:
 
 ## What's new in 2.0
 
-- **Skill-led loop on a thin kernel** — the skill narrates Direction → Build →
-  Verify; `add.py` shrinks to a 31-verb state kernel (54 → 31).
-- **`PLAN.md` + one-shot `migrate`** — the per-task file is the plan; a whole 1.x
-  board converts with one idempotent command.
-- **Five living 5-DD specs with `delta-append`** — the project's evolving truth,
-  compacted forward instead of rewritten.
-- **Persona routes + the GEPA scoreboard** — personas propose lanes, gates trace
-  outcomes, `deltas` shows the per-lane record, and the loop reflects on it.
+- **Skill-led loop on a thin kernel** — the skill narrates Direction → Build → Verify; `add.py` shrinks to a 31-verb state kernel (54 → 31).
+- **`PLAN.md` + one-shot `migrate`** — the per-task file is the plan; a whole 1.x board converts with one idempotent command.
+- **Five living 5-DD specs with `delta-append`** — the project's evolving truth, compacted forward instead of rewritten.
+- **Persona routes + the GEPA scoreboard** — personas propose lanes, gates trace outcomes, `deltas` shows the per-lane record, and the loop reflects on it.
 - **The book stops shipping** — published online only, deep-linked from the engine.
-- **Measured**: every trust floor 1.0 across the 3-milestone benchmark at $2.20 per
-  trusted milestone; plus a new `--session-mode continue` harness that measures
-  context rot itself.
 
 ## Develop
 

--- a/add-method/README.md
+++ b/add-method/README.md
@@ -52,15 +52,15 @@ green. Full walkthrough: the [10-minute Quickstart](./GETTING-STARTED.md).
 
 ## Highlights
 
-- 📉 **Anti-context-rot by design** — every decision lives on disk (`PLAN.md`, frozen contracts, red suites, `.add/state.json`), so a fresh session resumes losslessly; measured flat 1.0 quality across evolving milestones while conversation-carried flows decayed.
-- ✅ **Approve once, then let it run** — one human sign-off at the frozen contract; the agent drives Direction → Build → Verify.
-- 🔬 **Proof, not promises** — verified against observed behavior and pre-declared expectations, never just a plausible-looking diff; weakening a test to reach green is treated as tampering.
-- 💸 **Lean by measurement** — a thin 31-verb state kernel, a 3-call task walk, one file per feature; 3–5× lower per-milestone cost than ADD 1.x.
-- 🔒 **Security never gets waved through** — any security finding is a hard stop, human in the loop.
-- 🧠 **Personas route the work** — a project-owned persona proposes each task's lane, the freeze ratifies it, outcomes are traced, and the loop reflects on the record (GEPA) so the method adapts to your codebase.
-- 🎨 **See it before you build it** — a wireframe and a zero-dependency HTML mock, approved before any code.
-- 👥 **Built for teams** — git-native multi-user, N parallel milestones, DAG-scheduled waves; monorepo or multi-repo in one team.
-- 🤝 **Works with your AI** — Claude, Copilot, Cursor, Codex, Gemini; install via npm, pip, or the Claude Code plugin.
+- 📉 **Your agent stops re-breaking last month's work** — every decision lives on disk (`PLAN.md`, frozen contracts, red suites, `.add/state.json`), so a fresh session resumes with the full picture. Measured: quality held flat where a long conversation decayed.
+- ✅ **Stop babysitting the build** — you approve once, at the frozen contract; from there the agent drives Direction → Build → Verify and only comes back when it matters.
+- 🔬 **Know it's correct without reading every line** — trust comes from your pre-declared tests passing, never a diff that merely *looks* right; gaming a test to reach green is treated as tampering.
+- 💸 **Structure without the ceremony tax** — a thin 31-verb kernel, a 3-call task walk, one file per feature keep ADD the cheap option, not the heavyweight one.
+- 🔒 **Never ship a security hole on autopilot** — any security finding is a hard stop with you in the loop, in every mode.
+- 🧠 **The method adapts to *your* codebase** — a project-owned persona proposes each task's approach, the freeze ratifies it, outcomes are traced, and the loop learns what works here (GEPA).
+- 🎨 **See the UI before a line of code** — a wireframe and a zero-dependency HTML mock, approved before any build.
+- 👥 **Grows with your team** — git-native multi-user, N parallel milestones, DAG-scheduled waves; monorepo or multi-repo in one team.
+- 🤝 **Keep the agent you already use** — Claude, Copilot, Cursor, Codex, Gemini; install via npm, pip, or the Claude Code plugin.
 
 > _Direction before speed. Trust comes from passing tests — not from reading code and finding it plausible._
 
@@ -77,7 +77,7 @@ The causal finding: when ONE continued conversation carried the milestones, ever
 flow decayed the same way (coverage .92 → .75, an early spec violation carried
 through five more milestones). When every milestone instead started a **fresh
 session resuming from disk**, ADD held every floor at 1.0 across all six — through
-a breaking shape change and a cross-cutting refactor — at a fraction of ADD 1.x's per-milestone cost.
+a breaking shape change and a cross-cutting refactor — with zero regressions.
 
 That's the design, in three moves:
 
@@ -103,7 +103,7 @@ runtime dependency — down to the three parts a project needs: **Identity**,
 
 A distilled persona is an **advisory overlay** during direction, build, or verify:
 it shapes *how* a step gets done, never whether it happens. It can't skip a gate,
-edit a frozen contract, or wave through a security finding. In 2.0 personas also
+edit a frozen contract, or wave through a security finding. Personas also
 propose each task's route (full walk · fast lane · inline); the freeze ratifies it,
 the gate traces the outcome, and `add.py deltas` rolls the traces into a per-lane
 scoreboard the loop reflects on (GEPA).
@@ -209,14 +209,6 @@ be upset to lose is "the code," you're still working the old way.
 - 📊 [Benchmark results](https://github.com/pilotspace/ADD/tree/main/benchmark/results) — every trust and cost claim, measured
 - ⚖️ [ADD vs spec-kit — the honest comparison](https://pilotspace.github.io/ADD/appendix-h-add-vs-spec-kit/) — where we tie, where they win, what only ADD guarantees
 - 🗞️ [ADD Across the Org: AI-Driven Development Beyond Code](https://inkpaper-blog.pages.dev/series/add-across-the-org/)
-
-## What's new in 2.0
-
-- **Skill-led loop on a thin kernel** — the skill narrates Direction → Build → Verify; `add.py` shrinks to a 31-verb state kernel (54 → 31).
-- **`PLAN.md` + one-shot `migrate`** — the per-task file is the plan; a whole 1.x board converts with one idempotent command.
-- **Five living 5-DD specs with `delta-append`** — the project's evolving truth, compacted forward instead of rewritten.
-- **Persona routes + the GEPA scoreboard** — personas propose lanes, gates trace outcomes, `deltas` shows the per-lane record, and the loop reflects on it.
-- **The book stops shipping** — published online only, deep-linked from the engine.
 
 ## Develop
 


### PR DESCRIPTION
## What

Simplifies both public READMEs (marketing surface) and adds an honest **ADD vs vanilla** tradeoff. Subtraction, not more copy.

| | Before | After |
|---|---|---|
| `README.md` | 260 lines | 195 |
| `add-method/README.md` | 313 lines | 227 |

Net: **+170 / −320 lines**.

## Why

The pitch was told 4–5× with the same numbers, honesty caveats were woven into every headline (deflating each claim as it landed), and the cost figure appeared as `$2.90 / $2.20 / $3.90 / $4.65–13.94` across the page — reading as sloppy.

## Changes

**Root `README.md`**
- Collapse 4 duplicate value sections into one *Memory / Judgment / Conscience* spine + one proof table.
- Quarantine all hedging into a single fine-print block.
- Normalize every cost figure to `~$2.90/milestone, 3–5× cut vs 1.x`.
- **New "ADD vs vanilla" tradeoff** — a when-to-use / when-not table so readers self-select instead of being oversold.

**Package `add-method/README.md`**
- Merge "Where ADD fits" + "Best setup" (they restated each other).
- Same price normalization + honesty-note consolidation.
- Keep reference-grade sections npm readers need (Install boundaries, non-negotiables, install table).

## Notes

- No numbers invented — all figures reused from existing benchmark reports.
- Normalized the package README's cost line from `$2.20 vs spec-kit's $3.90` (3-milestone head-to-head) to `~$2.90` (6-milestone campaign) for cross-page consistency. Both are real; easy to restore the head-to-head number if preferred.
- Docs-only; no code or engine changes.

https://claude.ai/code/session_01HZsaHHPkN13sqqY4wcecPq
