### PR TITLE
docs(skill): prompting-fidelity pass — stop-conditions, repro-first refute, one-draft direction

### DIFF
--- a/.claude/agents/add-advisor.md
+++ b/.claude/agents/add-advisor.md
@@ -19,8 +19,10 @@ beat keeps moving. Personas carry the expertise; you carry independent, first-pr
   options and RETURN A DECISION with its rationale. This is delegated judgement — binding for
   the beat — not one more opinion to hold open.
 - **refute** — an adversarial read of a drafted artifact (bundle · earned-green · verdict):
-  try to BREAK it. Name the input/state that makes it wrong. Default to "not yet proven" when
-  uncertain — your job is to catch the plausible-but-wrong before the human or the gate does.
+  try to BREAK it. Your PRIMARY output is the concrete input/state/interleaving that makes it wrong —
+  values, file, line; not a category, not a bare verdict. A "looks fine" with no attempted repro is
+  not a refute; if a real attempt finds none, concede it holds and say so. Default to "not yet proven"
+  when uncertain — catch the plausible-but-wrong before the human or the gate does.
 
 Every mode serves EVERY beat — the spawn names the beat + mode, and you calibrate to it:
 **direction** (propose the bundle plan · refute the draft so the human freezes the stronger

--- a/.claude/agents/add-worker.md
+++ b/.claude/agents/add-worker.md
@@ -29,6 +29,8 @@ Read YOUR mode's guide from the project's skill tree (`.claude/skills/add/phases
 spawn — the orchestrator reads only SKILL.md and does not pre-read it for you.
 
 ## 2 · Become the persona (FIRST — before any task-specific instruction)
+The §3 Boundary below is the floor this persona cannot lower — it binds BEFORE the persona's voice
+can soften it; a persona is advisory, the boundary is not. Now become the persona:
 Select from `.add/personas/` by frontmatter alone (name · vibe · flow · task-kinds ·
 use-when · not-when): prefer a persona whose `flow:` names your mode's surface
 (direction→design · build→build · verify→verify) AND whose `task-kinds:` covers the

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -69,10 +69,10 @@ confirms. Unsharp intent? **Interview before you size** (`intake.md`). A milesto
 
 Every task is three beats (seven steps, folded), three engine calls, ONE human decision:
 
-1. **DIRECTION** — load the domain-fit persona (seed via add-worker persona-mode if none), then draft
-   the whole bundle top-to-bottom in PLAN.md: §1 rules + ranked ⚠ flag (co-specify) ·
-   §2 scenarios · §3 PLAN (grounding → frozen contract shape → build-strategy + Scope + Target) · §4 red suite
-   (run it — red for the RIGHT reason; fill each bullet's `covers:` clause key). Then the ONE approval,
+1. **DIRECTION** — load the domain-fit persona (seed via add-worker persona-mode if none), then compose
+   the whole bundle in ONE silent draft — §1–§3 + §5-scope, no per-section narration; §4 then runs red — in PLAN.md: §1 rules + ranked ⚠ flag (co-specify) ·
+   §2 scenarios (optional gherkin — §4 is canonical) · §3 PLAN (grounding → frozen contract shape → build-strategy + Scope + Target) ·
+   §4 red suite — one test per Must & per Reject (a Must/Reject encoded in neither §2 nor §4 = §1 not understood — stop); run red for the RIGHT reason; fill each `covers:` key. Then the ONE approval,
    presented lowest-confidence-first: `add.py freeze` (a setup session's baseline `lock` IS this approval).
 2. **BUILD** — code in `src/` until every red is green; change no test, no frozen contract; stay
    inside the §3 Scope. A test OUTSIDE your suite failing? `add.py locate` names the owning node, the
@@ -118,7 +118,7 @@ confirmable delta the human confirms rewrites `SOUL.md` (the human is the only w
 
 ## Command cookbook — copy a line; `-h` only off-menu
 
-`add.py` = `python3 .add/tooling/add.py`; lines 2–4 = the 3-call walk (`advance --fill <draft>` = step-wise).
+`add.py` = `python3 .add/tooling/add.py`; lines 2–4 = the 3 calls — default is ONE composed draft then bare `advance`/`freeze`; `advance --fill <draft>` = step-wise, only for a large/uncertain task.
 
 ```bash
 add.py status --brief        # resume · status --section <n|phase> = §body · --foundation · --json

--- a/.claude/skills/add/phases/build.md
+++ b/.claude/skills/add/phases/build.md
@@ -76,4 +76,4 @@ verify residue → a SPEC delta.
 Routing: `ddd`→domain · `sdd`→system · `udd`→experience · `tdd`→quality · `add`→method — each
 lands in-flight in its living spec via `add.py delta-append <dd>` (grammar: `deltas.md`). A
 HOW-an-agent-behaves lesson → a persona, not the shared pile. Deltas prepend newest-first;
-the spec diff is the receipt. Self-score before emitting (the confidence six dimensions; < 0.9 → refine).
+the spec diff is the receipt. Self-score before emitting (the confidence six dimensions; name the weakest, refine).

--- a/.claude/skills/add/phases/direction.md
+++ b/.claude/skills/add/phases/direction.md
@@ -1,7 +1,9 @@
 # Direction — the whole specification bundle (setup · rules · plan · red suite) to the ONE freeze
 
-Every task drafts §1–§4 top-to-bottom, then ONE human approval crosses it into build:
-`add.py freeze --by <name> --cross`. This file is the reference depth for that span —
+Every task COMPOSES §1–§3 + §5-scope in ONE silent draft — a single write, no "moving on to §N"
+narration — then §4 runs red and ONE human approval crosses it into build:
+`add.py freeze --by <name> --cross`. The only mandatory breaks in the draft are running the §4 red
+suite (a tool action, not prose) and the freeze. This file is the reference depth for that span —
 SKILL.md carries the loop; read the section you're stuck in, not the file.
 
 ---
@@ -141,7 +143,8 @@ the design-definition loop (`design.md`).
   `⚠ <assumption> — lowest confidence because <why>; if wrong: <cost>`.
 </output_format>
 
-§2 makes every rule checkable — one scenario per Must and per Reject:
+Every Must and Reject must be checkable — canonically as a §4 test (its `covers:` tag); §2 gherkin is
+an OPTIONAL readable projection, added only when a human needs prose cases at the freeze, never as ceremony:
 
 ```gherkin
 Scenario: <short name>
@@ -159,8 +162,8 @@ one per applicable case, or rule it out on purpose. Every Then is specific and o
 - [ ] Framings weighed noted; every required behavior stated; every rejection has a named error code.
 - [ ] Assumptions ordered lowest-confidence first; the 1–2 `⚠` flags carry why + cost — or an honest
       "none material" that still names the single biggest risk (never a blank "none").
-- [ ] §2: one scenario per Must and per Reject; every rejection asserts what stays unchanged; edge
-      cases covered or ruled out on purpose.
+- [ ] Every Must and Reject is encoded — a §4 test (canonical) or an optional §2 gherkin scenario;
+      every rejection asserts what stays unchanged; edge cases covered or ruled out on purpose.
 </exit_gate>
 
 ---
@@ -247,6 +250,8 @@ mode on any task). Coding kinds keep the executable red suite above.
 
 §4's `Tests live in:` line is machine-read — declare paths as backticked tokens on that line: with
 no local `tests/`, `add.py report` counts test functions at the declared paths (FIRST such line only).
+REPLACE the template's `./tests/` placeholder in place — never append a SECOND `Tests live in:` line:
+the report reads the FIRST, so a stale default left above your real path silently wins.
 `./…` → this task dir · a token with `/` → the project root · a bare name → a
 sibling of the previous token's dir. A directory counts its `*.py` files
 (non-recursive); a `.py` file counts itself. Resolved files dedupe; declared counts
@@ -278,9 +283,13 @@ it 0–1 on six dimensions: **Completeness** (every rule/scenario/rejection cove
 (understood without you in the room?) · **Practicality** (implementable against the real code?) ·
 **Optimization** (correctness/simplicity/cost balanced — no gold-plating, no corner cut?) ·
 **Edge cases** (failure modes, concurrency, empty/oversized inputs named?) · **Self-evaluation**
-(does it carry its own refine step?). Any dimension **< 0.9** → refine, then re-score. The lowest
-dimension is what you surface ⚠-first at the freeze; persistently low on risky scope →
-*recommend* lowering autonomy (the level stays the human's call).
+(does it carry its own refine step?). Rank the six worst→best (a model ranks far more reliably than
+it calibrates an absolute), then NAME the one concrete deficiency in your weakest dimension — a
+missing scenario, an unhandled input, not a number — and fix THAT before presenting; re-rank after.
+The lowest dimension is what you surface ⚠-first at the freeze; persistently low on risky scope →
+*recommend* lowering autonomy (the level stays the human's call). The self-score is a **weak signal**:
+the load-bearing correctness check is the adversarial refute-read (`phases/verify.md`) — the
+plausible-but-wrong a self-score waves through is exactly what the refute exists to catch.
 The hard rule: **advisory, never a gate** — it never auto-passes a verify, never substitutes for evidence or the
 human decision, and a self-asserted score is never recorded as something the human "agreed to".
 

--- a/.claude/skills/add/phases/verify.md
+++ b/.claude/skills/add/phases/verify.md
@@ -36,7 +36,7 @@ Record in the §6 **Deep checks** block — an unfilled one is a **shallow verif
 
 ## Part four — was the green earned?
 
-A green suite proves tests pass — not that the build EARNED them. Three judgment cheats pass the unchanged suite: src overfit to the test fixtures (special-cased to literal inputs), vacuous asserts (green against an empty implementation), and real logic stubbed away — all invisible to the mechanical tamper tripwire. Score them with an adversarial refute-read: an independent reviewer — the engine never spawns one — prompted to argue the green was NOT earned. A confirmed earned-green failure is HARD-STOP-class: never auto-passed, never RISK-ACCEPTED — a first cheat enters the bounded self-heal loop (run.md). Under `auto`, **record the verdict** in §6's `### Refute-read verdict` block — an unrecorded verdict leaves the auto-PASS untraceable (the human spot-audit is the backstop).
+A green suite proves tests pass — not that the build EARNED them. Three judgment cheats pass the unchanged suite: src overfit to the test fixtures (special-cased to literal inputs), vacuous asserts (green against an empty implementation), and real logic stubbed away — all invisible to the mechanical tamper tripwire. Score them with an adversarial refute-read: an independent reviewer — the engine never spawns one — prompted to argue the green was NOT earned. Its PRIMARY output is a concrete falsifying input — the fixture value, interleaving, or caller that makes the green wrong (file · line · values), not a verdict; a "looks fine" with no attempted repro is not a refute, and if a real attempt finds none it concedes the green holds and says so. A confirmed earned-green failure is HARD-STOP-class: never auto-passed, never RISK-ACCEPTED — a first cheat enters the bounded self-heal loop (run.md). Under `auto`, **record the verdict** in §6's `### Refute-read verdict` block — an unrecorded verdict leaves the auto-PASS untraceable (the human spot-audit is the backstop).
 
 ## Record exactly one outcome (no silent pass)
 
@@ -44,7 +44,7 @@ Render this gate from the card: banner → ARC → SUMMARY → FLAGS → EVIDENC
 (`gate-udd.md` = the full template + examples, read at most once per session), and reconcile FLAGS
 with `add.py report --decide`'s open-item count. Right-size the render to the risk: `sensitivity: mechanical`
 tasks use the compact form — banner → SUMMARY → EVIDENCE → APPROVE; `security` / `data` /
-`architecture` always get the full card. **Human-led: render before `gate` and record `Reported: yes` in §6, never self-stamp.**
+`architecture` always get the full card. Audience by mode: under `conservative` the card renders to the human before the gate; under `autonomy: auto` (no reachable human) you WRITE it to the §6/trace record as the accountable artifact and proceed — you render, you don't wait. **Human-led: render before `gate` and record `Reported: yes` in §6, never self-stamp.**
 
 | Outcome | When |
 |---------|------|

--- a/add-method/agents/add-advisor.md
+++ b/add-method/agents/add-advisor.md
@@ -19,8 +19,10 @@ beat keeps moving. Personas carry the expertise; you carry independent, first-pr
   options and RETURN A DECISION with its rationale. This is delegated judgement — binding for
   the beat — not one more opinion to hold open.
 - **refute** — an adversarial read of a drafted artifact (bundle · earned-green · verdict):
-  try to BREAK it. Name the input/state that makes it wrong. Default to "not yet proven" when
-  uncertain — your job is to catch the plausible-but-wrong before the human or the gate does.
+  try to BREAK it. Your PRIMARY output is the concrete input/state/interleaving that makes it wrong —
+  values, file, line; not a category, not a bare verdict. A "looks fine" with no attempted repro is
+  not a refute; if a real attempt finds none, concede it holds and say so. Default to "not yet proven"
+  when uncertain — catch the plausible-but-wrong before the human or the gate does.
 
 Every mode serves EVERY beat — the spawn names the beat + mode, and you calibrate to it:
 **direction** (propose the bundle plan · refute the draft so the human freezes the stronger

--- a/add-method/agents/add-worker.md
+++ b/add-method/agents/add-worker.md
@@ -29,6 +29,8 @@ Read YOUR mode's guide from the project's skill tree (`.claude/skills/add/phases
 spawn — the orchestrator reads only SKILL.md and does not pre-read it for you.
 
 ## 2 · Become the persona (FIRST — before any task-specific instruction)
+The §3 Boundary below is the floor this persona cannot lower — it binds BEFORE the persona's voice
+can soften it; a persona is advisory, the boundary is not. Now become the persona:
 Select from `.add/personas/` by frontmatter alone (name · vibe · flow · task-kinds ·
 use-when · not-when): prefer a persona whose `flow:` names your mode's surface
 (direction→design · build→build · verify→verify) AND whose `task-kinds:` covers the

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -69,10 +69,10 @@ confirms. Unsharp intent? **Interview before you size** (`intake.md`). A milesto
 
 Every task is three beats (seven steps, folded), three engine calls, ONE human decision:
 
-1. **DIRECTION** — load the domain-fit persona (seed via add-worker persona-mode if none), then draft
-   the whole bundle top-to-bottom in PLAN.md: §1 rules + ranked ⚠ flag (co-specify) ·
-   §2 scenarios · §3 PLAN (grounding → frozen contract shape → build-strategy + Scope + Target) · §4 red suite
-   (run it — red for the RIGHT reason; fill each bullet's `covers:` clause key). Then the ONE approval,
+1. **DIRECTION** — load the domain-fit persona (seed via add-worker persona-mode if none), then compose
+   the whole bundle in ONE silent draft — §1–§3 + §5-scope, no per-section narration; §4 then runs red — in PLAN.md: §1 rules + ranked ⚠ flag (co-specify) ·
+   §2 scenarios (optional gherkin — §4 is canonical) · §3 PLAN (grounding → frozen contract shape → build-strategy + Scope + Target) ·
+   §4 red suite — one test per Must & per Reject (a Must/Reject encoded in neither §2 nor §4 = §1 not understood — stop); run red for the RIGHT reason; fill each `covers:` key. Then the ONE approval,
    presented lowest-confidence-first: `add.py freeze` (a setup session's baseline `lock` IS this approval).
 2. **BUILD** — code in `src/` until every red is green; change no test, no frozen contract; stay
    inside the §3 Scope. A test OUTSIDE your suite failing? `add.py locate` names the owning node, the
@@ -118,7 +118,7 @@ confirmable delta the human confirms rewrites `SOUL.md` (the human is the only w
 
 ## Command cookbook — copy a line; `-h` only off-menu
 
-`add.py` = `python3 .add/tooling/add.py`; lines 2–4 = the 3-call walk (`advance --fill <draft>` = step-wise).
+`add.py` = `python3 .add/tooling/add.py`; lines 2–4 = the 3 calls — default is ONE composed draft then bare `advance`/`freeze`; `advance --fill <draft>` = step-wise, only for a large/uncertain task.
 
 ```bash
 add.py status --brief        # resume · status --section <n|phase> = §body · --foundation · --json

--- a/add-method/skill/add/phases/build.md
+++ b/add-method/skill/add/phases/build.md
@@ -76,4 +76,4 @@ verify residue → a SPEC delta.
 Routing: `ddd`→domain · `sdd`→system · `udd`→experience · `tdd`→quality · `add`→method — each
 lands in-flight in its living spec via `add.py delta-append <dd>` (grammar: `deltas.md`). A
 HOW-an-agent-behaves lesson → a persona, not the shared pile. Deltas prepend newest-first;
-the spec diff is the receipt. Self-score before emitting (the confidence six dimensions; < 0.9 → refine).
+the spec diff is the receipt. Self-score before emitting (the confidence six dimensions; name the weakest, refine).

--- a/add-method/skill/add/phases/direction.md
+++ b/add-method/skill/add/phases/direction.md
@@ -1,7 +1,9 @@
 # Direction — the whole specification bundle (setup · rules · plan · red suite) to the ONE freeze
 
-Every task drafts §1–§4 top-to-bottom, then ONE human approval crosses it into build:
-`add.py freeze --by <name> --cross`. This file is the reference depth for that span —
+Every task COMPOSES §1–§3 + §5-scope in ONE silent draft — a single write, no "moving on to §N"
+narration — then §4 runs red and ONE human approval crosses it into build:
+`add.py freeze --by <name> --cross`. The only mandatory breaks in the draft are running the §4 red
+suite (a tool action, not prose) and the freeze. This file is the reference depth for that span —
 SKILL.md carries the loop; read the section you're stuck in, not the file.
 
 ---
@@ -141,7 +143,8 @@ the design-definition loop (`design.md`).
   `⚠ <assumption> — lowest confidence because <why>; if wrong: <cost>`.
 </output_format>
 
-§2 makes every rule checkable — one scenario per Must and per Reject:
+Every Must and Reject must be checkable — canonically as a §4 test (its `covers:` tag); §2 gherkin is
+an OPTIONAL readable projection, added only when a human needs prose cases at the freeze, never as ceremony:
 
 ```gherkin
 Scenario: <short name>
@@ -159,8 +162,8 @@ one per applicable case, or rule it out on purpose. Every Then is specific and o
 - [ ] Framings weighed noted; every required behavior stated; every rejection has a named error code.
 - [ ] Assumptions ordered lowest-confidence first; the 1–2 `⚠` flags carry why + cost — or an honest
       "none material" that still names the single biggest risk (never a blank "none").
-- [ ] §2: one scenario per Must and per Reject; every rejection asserts what stays unchanged; edge
-      cases covered or ruled out on purpose.
+- [ ] Every Must and Reject is encoded — a §4 test (canonical) or an optional §2 gherkin scenario;
+      every rejection asserts what stays unchanged; edge cases covered or ruled out on purpose.
 </exit_gate>
 
 ---
@@ -247,6 +250,8 @@ mode on any task). Coding kinds keep the executable red suite above.
 
 §4's `Tests live in:` line is machine-read — declare paths as backticked tokens on that line: with
 no local `tests/`, `add.py report` counts test functions at the declared paths (FIRST such line only).
+REPLACE the template's `./tests/` placeholder in place — never append a SECOND `Tests live in:` line:
+the report reads the FIRST, so a stale default left above your real path silently wins.
 `./…` → this task dir · a token with `/` → the project root · a bare name → a
 sibling of the previous token's dir. A directory counts its `*.py` files
 (non-recursive); a `.py` file counts itself. Resolved files dedupe; declared counts
@@ -278,9 +283,13 @@ it 0–1 on six dimensions: **Completeness** (every rule/scenario/rejection cove
 (understood without you in the room?) · **Practicality** (implementable against the real code?) ·
 **Optimization** (correctness/simplicity/cost balanced — no gold-plating, no corner cut?) ·
 **Edge cases** (failure modes, concurrency, empty/oversized inputs named?) · **Self-evaluation**
-(does it carry its own refine step?). Any dimension **< 0.9** → refine, then re-score. The lowest
-dimension is what you surface ⚠-first at the freeze; persistently low on risky scope →
-*recommend* lowering autonomy (the level stays the human's call).
+(does it carry its own refine step?). Rank the six worst→best (a model ranks far more reliably than
+it calibrates an absolute), then NAME the one concrete deficiency in your weakest dimension — a
+missing scenario, an unhandled input, not a number — and fix THAT before presenting; re-rank after.
+The lowest dimension is what you surface ⚠-first at the freeze; persistently low on risky scope →
+*recommend* lowering autonomy (the level stays the human's call). The self-score is a **weak signal**:
+the load-bearing correctness check is the adversarial refute-read (`phases/verify.md`) — the
+plausible-but-wrong a self-score waves through is exactly what the refute exists to catch.
 The hard rule: **advisory, never a gate** — it never auto-passes a verify, never substitutes for evidence or the
 human decision, and a self-asserted score is never recorded as something the human "agreed to".
 

--- a/add-method/skill/add/phases/verify.md
+++ b/add-method/skill/add/phases/verify.md
@@ -36,7 +36,7 @@ Record in the §6 **Deep checks** block — an unfilled one is a **shallow verif
 
 ## Part four — was the green earned?
 
-A green suite proves tests pass — not that the build EARNED them. Three judgment cheats pass the unchanged suite: src overfit to the test fixtures (special-cased to literal inputs), vacuous asserts (green against an empty implementation), and real logic stubbed away — all invisible to the mechanical tamper tripwire. Score them with an adversarial refute-read: an independent reviewer — the engine never spawns one — prompted to argue the green was NOT earned. A confirmed earned-green failure is HARD-STOP-class: never auto-passed, never RISK-ACCEPTED — a first cheat enters the bounded self-heal loop (run.md). Under `auto`, **record the verdict** in §6's `### Refute-read verdict` block — an unrecorded verdict leaves the auto-PASS untraceable (the human spot-audit is the backstop).
+A green suite proves tests pass — not that the build EARNED them. Three judgment cheats pass the unchanged suite: src overfit to the test fixtures (special-cased to literal inputs), vacuous asserts (green against an empty implementation), and real logic stubbed away — all invisible to the mechanical tamper tripwire. Score them with an adversarial refute-read: an independent reviewer — the engine never spawns one — prompted to argue the green was NOT earned. Its PRIMARY output is a concrete falsifying input — the fixture value, interleaving, or caller that makes the green wrong (file · line · values), not a verdict; a "looks fine" with no attempted repro is not a refute, and if a real attempt finds none it concedes the green holds and says so. A confirmed earned-green failure is HARD-STOP-class: never auto-passed, never RISK-ACCEPTED — a first cheat enters the bounded self-heal loop (run.md). Under `auto`, **record the verdict** in §6's `### Refute-read verdict` block — an unrecorded verdict leaves the auto-PASS untraceable (the human spot-audit is the backstop).
 
 ## Record exactly one outcome (no silent pass)
 
@@ -44,7 +44,7 @@ Render this gate from the card: banner → ARC → SUMMARY → FLAGS → EVIDENC
 (`gate-udd.md` = the full template + examples, read at most once per session), and reconcile FLAGS
 with `add.py report --decide`'s open-item count. Right-size the render to the risk: `sensitivity: mechanical`
 tasks use the compact form — banner → SUMMARY → EVIDENCE → APPROVE; `security` / `data` /
-`architecture` always get the full card. **Human-led: render before `gate` and record `Reported: yes` in §6, never self-stamp.**
+`architecture` always get the full card. Audience by mode: under `conservative` the card renders to the human before the gate; under `autonomy: auto` (no reachable human) you WRITE it to the §6/trace record as the accountable artifact and proceed — you render, you don't wait. **Human-led: render before `gate` and record `Reported: yes` in §6, never self-stamp.**
 
 | Outcome | When |
 |---------|------|

--- a/add-method/src/add_method/_bundled/agents/add-advisor.md
+++ b/add-method/src/add_method/_bundled/agents/add-advisor.md
@@ -19,8 +19,10 @@ beat keeps moving. Personas carry the expertise; you carry independent, first-pr
   options and RETURN A DECISION with its rationale. This is delegated judgement — binding for
   the beat — not one more opinion to hold open.
 - **refute** — an adversarial read of a drafted artifact (bundle · earned-green · verdict):
-  try to BREAK it. Name the input/state that makes it wrong. Default to "not yet proven" when
-  uncertain — your job is to catch the plausible-but-wrong before the human or the gate does.
+  try to BREAK it. Your PRIMARY output is the concrete input/state/interleaving that makes it wrong —
+  values, file, line; not a category, not a bare verdict. A "looks fine" with no attempted repro is
+  not a refute; if a real attempt finds none, concede it holds and say so. Default to "not yet proven"
+  when uncertain — catch the plausible-but-wrong before the human or the gate does.
 
 Every mode serves EVERY beat — the spawn names the beat + mode, and you calibrate to it:
 **direction** (propose the bundle plan · refute the draft so the human freezes the stronger

--- a/add-method/src/add_method/_bundled/agents/add-worker.md
+++ b/add-method/src/add_method/_bundled/agents/add-worker.md
@@ -29,6 +29,8 @@ Read YOUR mode's guide from the project's skill tree (`.claude/skills/add/phases
 spawn — the orchestrator reads only SKILL.md and does not pre-read it for you.
 
 ## 2 · Become the persona (FIRST — before any task-specific instruction)
+The §3 Boundary below is the floor this persona cannot lower — it binds BEFORE the persona's voice
+can soften it; a persona is advisory, the boundary is not. Now become the persona:
 Select from `.add/personas/` by frontmatter alone (name · vibe · flow · task-kinds ·
 use-when · not-when): prefer a persona whose `flow:` names your mode's surface
 (direction→design · build→build · verify→verify) AND whose `task-kinds:` covers the

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -69,10 +69,10 @@ confirms. Unsharp intent? **Interview before you size** (`intake.md`). A milesto
 
 Every task is three beats (seven steps, folded), three engine calls, ONE human decision:
 
-1. **DIRECTION** — load the domain-fit persona (seed via add-worker persona-mode if none), then draft
-   the whole bundle top-to-bottom in PLAN.md: §1 rules + ranked ⚠ flag (co-specify) ·
-   §2 scenarios · §3 PLAN (grounding → frozen contract shape → build-strategy + Scope + Target) · §4 red suite
-   (run it — red for the RIGHT reason; fill each bullet's `covers:` clause key). Then the ONE approval,
+1. **DIRECTION** — load the domain-fit persona (seed via add-worker persona-mode if none), then compose
+   the whole bundle in ONE silent draft — §1–§3 + §5-scope, no per-section narration; §4 then runs red — in PLAN.md: §1 rules + ranked ⚠ flag (co-specify) ·
+   §2 scenarios (optional gherkin — §4 is canonical) · §3 PLAN (grounding → frozen contract shape → build-strategy + Scope + Target) ·
+   §4 red suite — one test per Must & per Reject (a Must/Reject encoded in neither §2 nor §4 = §1 not understood — stop); run red for the RIGHT reason; fill each `covers:` key. Then the ONE approval,
    presented lowest-confidence-first: `add.py freeze` (a setup session's baseline `lock` IS this approval).
 2. **BUILD** — code in `src/` until every red is green; change no test, no frozen contract; stay
    inside the §3 Scope. A test OUTSIDE your suite failing? `add.py locate` names the owning node, the
@@ -118,7 +118,7 @@ confirmable delta the human confirms rewrites `SOUL.md` (the human is the only w
 
 ## Command cookbook — copy a line; `-h` only off-menu
 
-`add.py` = `python3 .add/tooling/add.py`; lines 2–4 = the 3-call walk (`advance --fill <draft>` = step-wise).
+`add.py` = `python3 .add/tooling/add.py`; lines 2–4 = the 3 calls — default is ONE composed draft then bare `advance`/`freeze`; `advance --fill <draft>` = step-wise, only for a large/uncertain task.
 
 ```bash
 add.py status --brief        # resume · status --section <n|phase> = §body · --foundation · --json

--- a/add-method/src/add_method/_bundled/skill/add/phases/build.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/build.md
@@ -76,4 +76,4 @@ verify residue → a SPEC delta.
 Routing: `ddd`→domain · `sdd`→system · `udd`→experience · `tdd`→quality · `add`→method — each
 lands in-flight in its living spec via `add.py delta-append <dd>` (grammar: `deltas.md`). A
 HOW-an-agent-behaves lesson → a persona, not the shared pile. Deltas prepend newest-first;
-the spec diff is the receipt. Self-score before emitting (the confidence six dimensions; < 0.9 → refine).
+the spec diff is the receipt. Self-score before emitting (the confidence six dimensions; name the weakest, refine).

--- a/add-method/src/add_method/_bundled/skill/add/phases/direction.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/direction.md
@@ -1,7 +1,9 @@
 # Direction — the whole specification bundle (setup · rules · plan · red suite) to the ONE freeze
 
-Every task drafts §1–§4 top-to-bottom, then ONE human approval crosses it into build:
-`add.py freeze --by <name> --cross`. This file is the reference depth for that span —
+Every task COMPOSES §1–§3 + §5-scope in ONE silent draft — a single write, no "moving on to §N"
+narration — then §4 runs red and ONE human approval crosses it into build:
+`add.py freeze --by <name> --cross`. The only mandatory breaks in the draft are running the §4 red
+suite (a tool action, not prose) and the freeze. This file is the reference depth for that span —
 SKILL.md carries the loop; read the section you're stuck in, not the file.
 
 ---
@@ -141,7 +143,8 @@ the design-definition loop (`design.md`).
   `⚠ <assumption> — lowest confidence because <why>; if wrong: <cost>`.
 </output_format>
 
-§2 makes every rule checkable — one scenario per Must and per Reject:
+Every Must and Reject must be checkable — canonically as a §4 test (its `covers:` tag); §2 gherkin is
+an OPTIONAL readable projection, added only when a human needs prose cases at the freeze, never as ceremony:
 
 ```gherkin
 Scenario: <short name>
@@ -159,8 +162,8 @@ one per applicable case, or rule it out on purpose. Every Then is specific and o
 - [ ] Framings weighed noted; every required behavior stated; every rejection has a named error code.
 - [ ] Assumptions ordered lowest-confidence first; the 1–2 `⚠` flags carry why + cost — or an honest
       "none material" that still names the single biggest risk (never a blank "none").
-- [ ] §2: one scenario per Must and per Reject; every rejection asserts what stays unchanged; edge
-      cases covered or ruled out on purpose.
+- [ ] Every Must and Reject is encoded — a §4 test (canonical) or an optional §2 gherkin scenario;
+      every rejection asserts what stays unchanged; edge cases covered or ruled out on purpose.
 </exit_gate>
 
 ---
@@ -247,6 +250,8 @@ mode on any task). Coding kinds keep the executable red suite above.
 
 §4's `Tests live in:` line is machine-read — declare paths as backticked tokens on that line: with
 no local `tests/`, `add.py report` counts test functions at the declared paths (FIRST such line only).
+REPLACE the template's `./tests/` placeholder in place — never append a SECOND `Tests live in:` line:
+the report reads the FIRST, so a stale default left above your real path silently wins.
 `./…` → this task dir · a token with `/` → the project root · a bare name → a
 sibling of the previous token's dir. A directory counts its `*.py` files
 (non-recursive); a `.py` file counts itself. Resolved files dedupe; declared counts
@@ -278,9 +283,13 @@ it 0–1 on six dimensions: **Completeness** (every rule/scenario/rejection cove
 (understood without you in the room?) · **Practicality** (implementable against the real code?) ·
 **Optimization** (correctness/simplicity/cost balanced — no gold-plating, no corner cut?) ·
 **Edge cases** (failure modes, concurrency, empty/oversized inputs named?) · **Self-evaluation**
-(does it carry its own refine step?). Any dimension **< 0.9** → refine, then re-score. The lowest
-dimension is what you surface ⚠-first at the freeze; persistently low on risky scope →
-*recommend* lowering autonomy (the level stays the human's call).
+(does it carry its own refine step?). Rank the six worst→best (a model ranks far more reliably than
+it calibrates an absolute), then NAME the one concrete deficiency in your weakest dimension — a
+missing scenario, an unhandled input, not a number — and fix THAT before presenting; re-rank after.
+The lowest dimension is what you surface ⚠-first at the freeze; persistently low on risky scope →
+*recommend* lowering autonomy (the level stays the human's call). The self-score is a **weak signal**:
+the load-bearing correctness check is the adversarial refute-read (`phases/verify.md`) — the
+plausible-but-wrong a self-score waves through is exactly what the refute exists to catch.
 The hard rule: **advisory, never a gate** — it never auto-passes a verify, never substitutes for evidence or the
 human decision, and a self-asserted score is never recorded as something the human "agreed to".
 

--- a/add-method/src/add_method/_bundled/skill/add/phases/verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/verify.md
@@ -36,7 +36,7 @@ Record in the §6 **Deep checks** block — an unfilled one is a **shallow verif
 
 ## Part four — was the green earned?
 
-A green suite proves tests pass — not that the build EARNED them. Three judgment cheats pass the unchanged suite: src overfit to the test fixtures (special-cased to literal inputs), vacuous asserts (green against an empty implementation), and real logic stubbed away — all invisible to the mechanical tamper tripwire. Score them with an adversarial refute-read: an independent reviewer — the engine never spawns one — prompted to argue the green was NOT earned. A confirmed earned-green failure is HARD-STOP-class: never auto-passed, never RISK-ACCEPTED — a first cheat enters the bounded self-heal loop (run.md). Under `auto`, **record the verdict** in §6's `### Refute-read verdict` block — an unrecorded verdict leaves the auto-PASS untraceable (the human spot-audit is the backstop).
+A green suite proves tests pass — not that the build EARNED them. Three judgment cheats pass the unchanged suite: src overfit to the test fixtures (special-cased to literal inputs), vacuous asserts (green against an empty implementation), and real logic stubbed away — all invisible to the mechanical tamper tripwire. Score them with an adversarial refute-read: an independent reviewer — the engine never spawns one — prompted to argue the green was NOT earned. Its PRIMARY output is a concrete falsifying input — the fixture value, interleaving, or caller that makes the green wrong (file · line · values), not a verdict; a "looks fine" with no attempted repro is not a refute, and if a real attempt finds none it concedes the green holds and says so. A confirmed earned-green failure is HARD-STOP-class: never auto-passed, never RISK-ACCEPTED — a first cheat enters the bounded self-heal loop (run.md). Under `auto`, **record the verdict** in §6's `### Refute-read verdict` block — an unrecorded verdict leaves the auto-PASS untraceable (the human spot-audit is the backstop).
 
 ## Record exactly one outcome (no silent pass)
 
@@ -44,7 +44,7 @@ Render this gate from the card: banner → ARC → SUMMARY → FLAGS → EVIDENC
 (`gate-udd.md` = the full template + examples, read at most once per session), and reconcile FLAGS
 with `add.py report --decide`'s open-item count. Right-size the render to the risk: `sensitivity: mechanical`
 tasks use the compact form — banner → SUMMARY → EVIDENCE → APPROVE; `security` / `data` /
-`architecture` always get the full card. **Human-led: render before `gate` and record `Reported: yes` in §6, never self-stamp.**
+`architecture` always get the full card. Audience by mode: under `conservative` the card renders to the human before the gate; under `autonomy: auto` (no reachable human) you WRITE it to the §6/trace record as the accountable artifact and proceed — you render, you don't wait. **Human-led: render before `gate` and record `Reported: yes` in §6, never self-stamp.**
 
 | Outcome | When |
 |---------|------|


### PR DESCRIPTION
## What

A prompting-fidelity pass over the ADD skill + roster prompts — seven edits closing observed failure modes, applied directly and propagated **byte-identical across all three synced trees** (canonical · `_bundled` · `.claude`).

## The edits

1. **§2/§4 stop-condition** (`SKILL.md`, `direction.md`) — a Must/Reject encoded in *neither* §2 nor §4 = §1 not understood, **stop**. Closes the empty-scenarios failure. §2 gherkin is now explicitly **optional** — §4 `test_plan` is canonical, matching the engine's own §2-tag-OR-§4-`covers` coverage rule. Reconciles a pre-existing template/guide contradiction.
2. **Self-score demoted** (`direction.md`, `build.md`) — rank the six worst→best + name one concrete deficiency, not an absolute `0.9` gate a model can't calibrate; marked a **weak signal** vs the load-bearing adversarial refute-read.
3. **Repro-first refute** (`verify.md`, `add-advisor.md`) — the refute's **primary output is a concrete falsifying input** (file · line · values), not a verdict.
4. **Safety-primacy** (`add-worker.md`) — the §3 Boundary binds **before** the persona's voice can soften it.
5. **Render audience under `autonomy: auto`** (`verify.md`) — with no reachable human, the card is written to the §6/trace record as the accountable artifact, not waited on.
6. **One composed draft** (`SKILL.md`, `direction.md`) — compose §1–§3 + §5-scope in a **single silent write**, no per-section narration; the only mandatory breaks are running §4 red and the freeze. Ends the turn-by-turn PLAN-fill walk.
7. **Replace-not-append nudge** (`direction.md`) — the `Tests live in:` report reads the FIRST line only, so a stale `./tests/` default above the real path silently wins.

## Verification

Preserves all phrase-pins (earned-green rubric, `Reported: yes`, declare-grammar doc) and **3-tree byte-parity**. Targeted pin/parity/grammar guards green; **full corpus 2236/0**.

No engine (`add.py`) change — guide/prompt prose only.
