### PR TITLE
build(release): cut 2.2.0 — fable reasoning discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Every faculty is a file on disk and a command that shows it — never a promise:
 - 💸 **Structure without the ceremony tax** — a thin 31-verb kernel and a 3-call task walk keep ADD the cheap option, competitive with the lightest structured flows.
 - 🔒 **Never ship a security hole on autopilot** — any security finding is a hard stop with you in the loop, in every mode, even the fully-autonomous ones.
 - 🧠 **The method adapts to *your* codebase** — a persona proposes each task's approach, outcomes are traced, and the loop learns what actually works here (GEPA).
+- 🧭 **The agent reasons before it drafts** — a built-in reasoning floor makes it restate your goal in your words, tag what it *checked* versus what it *remembers*, and run a cheap kill-test on its own plan — catching the fluent-but-wrong that reads fine in a diff. Fluent ≠ true.
 - 📄 **Everything about a feature in one place** — spec, scenarios, contract, tests, and gate record in a single `PLAN.md`; no doc tree to hunt through.
 - 🎨 **See the UI before a line of code** — a wireframe and a zero-dependency HTML mock, approved before any build.
 - 👥 **Grows with your team** — git-native multi-user, N parallel milestones, DAG-scheduled waves.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 2.2.0 — 2026-07-22
+milestones: (thin-engine-loop still open — this cut ships its landed method-prose tasks)
+loose tasks: fable-floor-reasoning, fable-thinking-reference (the fable reasoning discipline — Fluent≠true + Five Moves + Floor + constraint loop in direction.md; claim grammar + GROUND observation-over-memory in add-advisor)
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: recorded by hand — the release engine retired in the 2.0 kernel-trim (playbook-guided cut). PR #168 merged to main (fable Floor reasoning pass, distilled inline), CI green. Prompt-only, propagated byte-identical across the three synced skill trees; `add.py` == ENGINE_MD5 unchanged; `test_fable_floor` + `test_tree_parity` green. Version sources ×5 in lockstep; tag v2.2.0 human-ordered.
+
 ## 2.1.0 — 2026-07-22
 milestones: (thin-engine-loop still open — this cut ships its landed feature tasks)
 loose tasks: round-visible-runs, foundation-split, plus the feat/advisor-roster + feat/adaptive-flow follow-on commits (two-agent roster · persona-author v11 + seeding · flexible TDD · SKILL cookbook · README copy)

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — a minimal, state-tracked skill: one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [2.2.0] — 2026-07-22
+
+Minor: the Direction beat gains a **fable reasoning discipline** — a prompt-only
+pass that makes the agent derive from the task in front of it instead of a fluent
+template, distilled from the fable-thinking protocol. No engine change.
+
+- **fable reasoning discipline** — `phases/direction.md` opens with the lens for
+  the whole bundle: **Fluent ≠ true** (a draft's polish tracks its token count,
+  not its evidence), the **Five Moves** (FRAME · GROUND · REASON · ATTACK ·
+  DELIVER) each mapped to the beat that already applies it, and two pre-answer
+  checks the fluent draft skips — the **Floor** (restate the Goal in the human's
+  world, then sweep the Leftovers: every supplied invariant and the BARE runtime)
+  and the **constraint loop** (expand → verify mechanically → repair the §3 tag
+  census · §5 scope tokens · §4 `covers:` keys · REDS refs before the freeze).
+- **claim grammar** — `add-advisor`'s §6 Return tags every factual assertion by
+  how it's known: `[OBSERVED]` (checked live this session) · `[DERIVED]` ·
+  `[PRIOR]` (memory, may be stale) · `[ASSUMED]`; a bare claim reads as OBSERVED,
+  so a guess never rides in unmarked. **GROUND** makes the same rule structural:
+  a recalled file/flag/symbol is `[PRIOR]` until re-confirmed against the live tree.
+- Prompt-only, propagated byte-identical across the three synced skill trees;
+  `add.py` == ENGINE_MD5 unchanged. Pinned by `test_fable_floor.py`.
+
 ## [2.1.0] — 2026-07-22
 
 Minor: the two-agent roster matures and the persona author learns from real

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — a minimal, state-tracked skill: one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "2.1.0"
+version = "2.2.0"
 description = "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session. Installs the ADD skill and tooling into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/add-method/tooling/test_release_2_2_0.py
+++ b/add-method/tooling/test_release_2_2_0.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 2.1.0 release readiness.
+"""Red/green tests for the 2.2.0 release readiness.
 
-Minor cut: two-agent roster (add-worker + add-advisor, every-beat advising +
-mid-flight support fan-out) · persona-author skill v11 (numbers-you'd-defend ·
-per-flow stance · seeding) · flexible TDD (§4 acceptance checks for non-coding
-kinds) · round-visible runs (uncapped observational verify→build rounds) ·
-foundation-split (the dogfood 1.x→2.0 foundation migration worked example).
+Minor cut: the fable reasoning discipline — a prompt-only Direction pass distilled
+from the fable-thinking protocol. `phases/direction.md` opens with Fluent≠true +
+the Five Moves + the pre-freeze Floor + the output-shape constraint loop;
+`add-advisor`'s §6 Return carries claim grammar (OBSERVED/DERIVED/PRIOR/ASSUMED)
+and GROUND makes observation-over-memory structural. No engine change.
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 2.1.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 2.2.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
-The live-version-agreement asserts migrated FORWARD from test_release_2_0_0
+The live-version-agreement asserts migrated FORWARD from test_release_2_1_0
 (release-gate pattern: exactly ONE suite pins the current version).
 Run:
-    python3 -m unittest test_release_2_1_0 -v
+    python3 -m unittest test_release_2_2_0 -v
 """
 import json
 import re
@@ -24,18 +24,18 @@ PKG = HERE.parent                       # add-method/
 
 CHANGELOG = PKG / "CHANGELOG.md"
 
-VERSION = "2.1.0"
-PRIOR_VERSIONS = ("2.0.0", "1.18.0", "1.17.0", "1.16.1", "1.16.0", "1.15.0", "1.14.0",
-                  "1.13.0", "1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.3",
-                  "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0",
-                  "1.2.0", "1.1.0", "1.0.0")
-# the headline changes the 2.1.0 notes must name
-FEATURE_ANCHORS = ("add-worker", "add-advisor", "persona-author", "flexible TDD",
-                   "acceptance checks", "round", "foundation-split")
+VERSION = "2.2.0"
+PRIOR_VERSIONS = ("2.1.0", "2.0.0", "1.18.0", "1.17.0", "1.16.1", "1.16.0", "1.15.0",
+                  "1.14.0", "1.13.0", "1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0",
+                  "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0", "1.4.0",
+                  "1.3.0", "1.2.0", "1.1.0", "1.0.0")
+# the headline changes the 2.2.0 notes must name
+FEATURE_ANCHORS = ("reasoning discipline", "Fluent", "Five Moves", "Floor",
+                   "constraint loop", "claim grammar", "GROUND")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_2_1_0_entry(self):
+    def test_changelog_has_2_2_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -44,23 +44,13 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"2.1.0 entry must name: {anchor}")
-
-    def test_minor_names_its_retirements(self):
-        # two `!`-marked commits ride this minor (the `add` agent · the static
-        # persona template); the entry must carry an explicit Retired block so
-        # the supersessions are named, not silent.
-        entry = CHANGELOG.read_text(encoding="utf-8").split(
-            f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
-        self.assertIn("Retired", entry, "the retirements must be named")
-        for ret in ("`add` roster agent", "persona template"):
-            self.assertIn(ret, entry, f"the Retired block must cover: {ret}")
+            self.assertIn(anchor, entry, f"2.2.0 entry must name: {anchor}")
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    """The version sources move in lockstep (migrated forward from 2.0.0)."""
+    """The version sources move in lockstep (migrated forward from 2.1.0)."""
 
-    def test_versions_agree_at_2_1_0(self):
+    def test_versions_agree_at_2_2_0(self):
         pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
         py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
                        (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)


### PR DESCRIPTION
## build(release): cut 2.2.0 — fable reasoning discipline

Minor cut shipping the **fable Floor reasoning pass** (already merged as #168), now released across the five version sources.

### What ships
- **fable reasoning discipline** — `phases/direction.md` opens with the lens for the whole bundle: **Fluent ≠ true**, the **Five Moves** (FRAME · GROUND · REASON · ATTACK · DELIVER) each mapped to the beat that applies it, the pre-freeze **Floor** (restate the Goal + sweep the Leftovers), and the output-shape **constraint loop** (§3 tag census · §5 scope tokens · §4 `covers:` · REDS).
- **claim grammar** — `add-advisor` §6 Return tags every assertion `[OBSERVED]`/`[DERIVED]`/`[PRIOR]`/`[ASSUMED]`; **GROUND** makes observation-over-memory structural.

### Release bookkeeping
- Version ×5 → `2.2.0` (package.json · pyproject.toml · plugin.json · package-lock ×2 · `__version__`).
- CHANGELOG `[2.2.0]` — no Retired block (no `!` supersessions).
- RELEASES.md ledger entry backfilled by hand (release engine retired in 2.0).
- Release test forward-migrated: `test_release_2_1_0` → `test_release_2_2_0` (exactly one suite pins the current version).
- README Highlights: new *"the agent reasons before it drafts"* bullet.

### Verification
- Full tooling suite **2243/0** (228s, exit 0) · `add.py check` **426/0** · `test_release_2_2_0` + `test_fable_floor` + `test_tree_parity` green.
- Prompt-only, byte-identical across the three synced skill trees; `add.py` == ENGINE_MD5 unchanged.

Tag `v2.2.0` on merge triggers `publish.yml` (npm + PyPI).
