### PR TITLE
chore(release): cut 2.4.0 — persona-as-PM strategy loop + fold completion

### DIFF
--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "status | init | continue | --todo <text> | [describe new short g
 license: MIT
 metadata:
   author: add
-  version: "2.3.0"
+  version: "2.4.0"
 ---
 
 # ADD — memory · judgment · conscience (the agent is the hands)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 2.4.0 — 2026-07-24
+milestones: strategy-intake (personas as ADD's adaptive PM brain — the persona-framed strategy.md DISCUSS→OPTIMIZE→CONVERGE loop filling the `## Strategy` slot · add-advisor refute at CONVERGE · risk-proportional depth ladder · persona-at-intake · report→persona-owned gate · UDD experience-driven redefine — closed 8/8)
+loose tasks: scenarios-fold residuals completion (#174) · shipped-surface CI sweep (#175) · dependabot bumps (setup-python 6→7 #173, setup-node 6→7 #162, @clack/prompts 1.6→1.7 #143)
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: recorded by hand — the release engine retired in the 2.0 kernel-trim (playbook-guided cut). PRs #174 #175 #176 #177 merged to main, CI green (Tooling py3.10+3.12). ZERO engine change across the strategy trio (ENGINE_MD5 unchanged — the engine records the `## Strategy` slot + gate, never drives the loop); prompt-only, propagated byte-identical across the three synced skill trees + three agent trees. Full `tooling/` suite 2309 green at the cut; release test forward-migrated 2.3.0→2.4.0 (test_release_2_4_0, one suite pins current). Version sources ×5 + SKILL.md ×3 in lockstep; tag v2.4.0 human-ordered.
+
 ## 2.2.0 — 2026-07-22
 milestones: (thin-engine-loop still open — this cut ships its landed method-prose tasks)
 loose tasks: fable-floor-reasoning, fable-thinking-reference (the fable reasoning discipline — Fluent≠true + Five Moves + Floor + constraint loop in direction.md; claim grammar + GROUND observation-over-memory in add-advisor)

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — a minimal, state-tracked skill: one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [2.4.0] — 2026-07-24
+
+Minor: the **strategy-intake** milestone closes — a fitting **persona** becomes ADD's
+adaptive project-management brain — plus the follow-on cleanup that completes the 2.3.0
+**scenarios fold** and adds a CI sweep of every shipped surface. All changes are
+skill/agent-surface prose; **zero engine change** (the engine records the `## Strategy`
+slot and the gate, never drives the loop or gates on the strategy).
+
+### Persona-as-PM strategy loop — `strategy.md` (new guide)
+- **DISCUSS → OPTIMIZE → CONVERGE** — a new `strategy.md` guide drives a persona-framed
+  loop that fills a milestone's `## Strategy` slot with a sequenced, optimized task DAG,
+  converging on the *existing* six-dimension confidence self-score (no new bar invented).
+- **`add-advisor` refute at CONVERGE** — a high-uncertainty milestone spawns the advisor
+  in refute mode to break the strategy before it's recorded; advisory (it cannot block),
+  reusing the existing refute mode. The advisor's `direction` beat now names a milestone
+  strategy as a refutable artifact alongside a task bundle.
+- **risk-proportional depth ladder** — one legible rule: micro/`--tiny` skips the loop at
+  zero added per-turn cost · multi-task low-uncertainty runs the loop · high-uncertainty
+  adds the refute. It is the skill's judgment, never an engine gate; strategy stays SOFT
+  and security stays HARD-STOP.
+- **persona-at-intake** — `intake.md` now loads the **fitting persona** before it sizes a
+  request (match-else-seed, advisory), so the persona that owns the intake report also
+  shapes the sizing.
+
+### Fold completion + shipped-surface sweep
+- the **scenarios fold** finishes — four remaining shipped residuals of the §2→§4 retirement
+  are fixed, each defect class pinned by a new guard.
+- a **shipped-surface** CI sweep derives the published file set from the packaging manifests
+  and fails on any dead chapter/section reference across every shipped surface.
+- CI/deps: `actions/setup-python` 6→7, `actions/setup-node` 6→7, `@clack/prompts` 1.6.0→1.7.0.
+
 ## [2.3.0] — 2026-07-24
 
 Minor: three waves — a **signal graph** view over the task DAG, the **§2

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — a minimal, state-tracked skill: one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "2.3.0"
+version = "2.4.0"
 description = "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session. Installs the ADD skill and tooling into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "status | init | continue | --todo <text> | [describe new short g
 license: MIT
 metadata:
   author: add
-  version: "2.3.0"
+  version: "2.4.0"
 ---
 
 # ADD — memory · judgment · conscience (the agent is the hands)

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "2.3.0"
+__version__ = "2.4.0"

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "status | init | continue | --todo <text> | [describe new short g
 license: MIT
 metadata:
   author: add
-  version: "2.3.0"
+  version: "2.4.0"
 ---
 
 # ADD — memory · judgment · conscience (the agent is the hands)

--- a/add-method/tooling/test_release_2_4_0.py
+++ b/add-method/tooling/test_release_2_4_0.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 2.3.0 release readiness.
+"""Red/green tests for the 2.4.0 release readiness.
 
-Minor cut: three waves — the signal graph view (unified signal node,
-`graph --signals`/`--html`, exit-criteria as delivered-by nodes, atomicity
-signal), the §2 Scenarios fold into §4, and the call-lean pass (freeze-flag
-slot, scope-first freeze refusal, scope-walk prunes for venv/*.egg-info,
-honest deterministic requirement_coverage). Engine changes are additive.
+Minor cut: the strategy-intake milestone closes — a fitting persona becomes ADD's
+adaptive PM brain (the new strategy.md DISCUSS→OPTIMIZE→CONVERGE loop filling the
+`## Strategy` slot, the add-advisor refute at CONVERGE, the risk-proportional depth
+ladder, and intake loading the fitting persona before it sizes) — plus the follow-on
+that completes the §2→§4 scenarios fold and adds a shipped-surface CI sweep. All
+changes are skill/agent-surface prose; the engine is unchanged (additive/zero).
 
-In-repo readiness only — the live-registry halves (npm/PyPI serving 2.3.0) are
+In-repo readiness only — the live-registry halves (npm/PyPI serving 2.4.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
-The live-version-agreement asserts migrated FORWARD from test_release_2_2_0
+The live-version-agreement asserts migrated FORWARD from test_release_2_3_0
 (release-gate pattern: exactly ONE suite pins the current version).
 Run:
-    python3 -m unittest test_release_2_3_0 -v
+    python3 -m unittest test_release_2_4_0 -v
 """
 import json
 import re
@@ -24,19 +25,18 @@ PKG = HERE.parent                       # add-method/
 
 CHANGELOG = PKG / "CHANGELOG.md"
 
-VERSION = "2.3.0"
-PRIOR_VERSIONS = ("2.2.0", "2.1.0", "2.0.0", "1.18.0", "1.17.0", "1.16.1", "1.16.0",
-                  "1.15.0", "1.14.0", "1.13.0", "1.12.0", "1.11.0", "1.10.0", "1.9.0",
-                  "1.8.0", "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0",
+VERSION = "2.4.0"
+PRIOR_VERSIONS = ("2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.18.0", "1.17.0", "1.16.1",
+                  "1.16.0", "1.15.0", "1.14.0", "1.13.0", "1.12.0", "1.11.0", "1.10.0",
+                  "1.9.0", "1.8.0", "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0",
                   "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")
-# the headline changes the 2.3.0 notes must name
-FEATURE_ANCHORS = ("signal graph", "graph --signals", "graph --html",
-                   "freeze-flag slot", "scope-first freeze", "scope-walk prunes",
-                   "requirement_coverage", "SCENARIOS")
+# the headline changes the 2.4.0 notes must name
+FEATURE_ANCHORS = ("strategy loop", "DISCUSS", "CONVERGE", "risk-proportional",
+                   "add-advisor", "fitting persona", "shipped-surface")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_2_3_0_entry(self):
+    def test_changelog_has_2_4_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -45,13 +45,13 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"2.3.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"2.4.0 entry must name: {anchor}")
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    """The version sources move in lockstep (migrated forward from 2.2.0)."""
+    """The version sources move in lockstep (migrated forward from 2.3.0)."""
 
-    def test_versions_agree_at_2_3_0(self):
+    def test_versions_agree_at_2_4_0(self):
         pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
         py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
                        (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)
@@ -77,6 +77,19 @@ class ReleaseShapeTest(unittest.TestCase):
         lock = json.loads((PKG / "package-lock.json").read_text(encoding="utf-8"))
         self.assertEqual(lock["version"], VERSION)
         self.assertEqual(lock["packages"][""]["version"], VERSION)
+
+    def test_skill_frontmatter_version_in_sync(self):
+        # the three skill trees carry the version in SKILL.md frontmatter; the CI
+        # mirror-gap meta-test fails publish if they drift. Assert all three at VERSION.
+        trees = (
+            PKG / "skill" / "add" / "SKILL.md",
+            PKG / "src" / "add_method" / "_bundled" / "skill" / "add" / "SKILL.md",
+            PKG.parent / ".claude" / "skills" / "add" / "SKILL.md",
+        )
+        for f in trees:
+            m = re.search(r'(?m)^\s*version:\s*"([^"]+)"', f.read_text(encoding="utf-8"))
+            self.assertIsNotNone(m, f"no version frontmatter in {f}")
+            self.assertEqual(m.group(1), VERSION, f"{f} version must be {VERSION}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Release 2.4.0

Bundles this session's merged work into the **2.4.0** minor cut. All version sources are in lockstep; **no outward-facing publish happens on merge** — the tag push + npm/PyPI publish are the human-run final step.

### What's in the cut
- **strategy-intake** milestone (#177 + #176) — a fitting persona becomes ADD's adaptive PM brain: the new `strategy.md` DISCUSS→OPTIMIZE→CONVERGE loop fills a milestone's `## Strategy` slot, the `add-advisor` refutes a high-uncertainty strategy at CONVERGE, a risk-proportional depth ladder scales the loop (micro/`--tiny` skips at zero cost), and intake loads the fitting persona before it sizes. **Zero engine change.**
- **scenarios-fold residuals** completion (#174) + **shipped-surface CI sweep** (#175).
- dependabot: setup-python 6→7 (#173), setup-node 6→7 (#162), @clack/prompts 1.6.0→1.7.0 (#143).

### Version lockstep (bumped 2.3.0 → 2.4.0)
`package.json` · `package-lock.json` (×2) · `pyproject.toml` · `.claude-plugin/plugin.json` · `src/add_method/__init__.py` · **`SKILL.md` frontmatter across all 3 skill trees** (the CI mirror-gap meta-test).

### Release-gate
- Release test **forward-migrated** 2.3.0 → 2.4.0 (`test_release_2_4_0` — the one suite pinning the current version) and gained a SKILL.md ×3-tree version-sync check. 6/6 green.
- `CHANGELOG.md` [2.4.0] + `RELEASES.md` 2.4.0 recorded.
- Full `tooling/` suite green — **2310 tests**.

### After merge (human-run, per release.md)
1. tag `v2.4.0` on the merge commit + push → triggers the `publish.yml` npm + PyPI trusted-publish.
2. GitHub release from the CHANGELOG [2.4.0] section.