### PR TITLE
chore(release): cut 2.5.0 — persona template completeness + method-persona seeding

### DIFF
--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "status | init | continue | --todo <text> | [describe new short g
 license: MIT
 metadata:
   author: add
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # ADD — memory · judgment · conscience (the agent is the hands)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,13 @@
 # Releases
 
+## 2.5.0 — 2026-07-25
+milestones: persona-template-completeness (the persona template as one coherent artifact — four legs with a bar each · `## Escalation` optional+routable · book reconciled with the load set the surfaces actually read · three planner personas at task/milestone/release altitude · the 12 orphaned preset templates retired — closed 4/4, 5/5 criteria)
+loose tasks: seed-method-personas (#182 — init/migrate SEED the three method-lens planners via `_seed_persona_file`, never-clobber, load-proven against the rendered `status --all` roster and both built artifacts) · SKILL.md persona-seeding ladder (select → fold → author; generic fallback never blocks) · lock-reclaim-hardening closed+archived with its exit criterion finally written
+waivers: none
+actor: Tin Dang <tindang.ht97@gmail.com> (git)
+evidence: recorded by hand — the release engine retired in the 2.0 kernel-trim (playbook-guided cut). PRs #181 + #182 merged to main, CI green (Tooling py3.10+3.12). ENGINE CHANGE (additive, first since 2.0): `init`/`migrate` gain a seeding call; ENGINE_MD5 -> 54aff8b8, ENGINE_PKG_MD5 -> c635ca53, both recomputed live and `add.py` byte-identical across all four tooling trees. Full `tooling/` suite 2327 green at the cut; `add.py check` 0 failed; `wording_lint` 0 findings; release test forward-migrated 2.4.0->2.5.0 (test_release_2_5_0, one suite pins current). Version sources x5 + SKILL.md x3 in lockstep; tag v2.5.0 human-ordered.
+HONESTY NOTES: (a) the 12 retired presets had been shipping in every artifact since e29ddac4 out of a stale gitignored build cache — caught only by building and unzipping the wheel + npm tarball, never by the green suite, so M5 of the seeding task reads the ARTIFACTS not the source tree. (b) PR #182's first push was CI-red on a pinned skip count invisible on macOS (a @skipUnless class skips per method; the count was hand-maintained in TWO places including the meta-test guarding it) — both now derived from source. (c) a vacuous test was found in this very work, pasted after `if __name__` and never collected; found by refute-read, not by the suite.
+
 ## 2.4.0 — 2026-07-24
 milestones: strategy-intake (personas as ADD's adaptive PM brain — the persona-framed strategy.md DISCUSS→OPTIMIZE→CONVERGE loop filling the `## Strategy` slot · add-advisor refute at CONVERGE · risk-proportional depth ladder · persona-at-intake · report→persona-owned gate · UDD experience-driven redefine — closed 8/8)
 loose tasks: scenarios-fold residuals completion (#174) · shipped-surface CI sweep (#175) · dependabot bumps (setup-python 6→7 #173, setup-node 6→7 #162, @clack/prompts 1.6→1.7 #143) · lock-reclaim-hardening (#179 — the stale-reclaim inode-reuse concurrency fix that blocked this very publish; both twins)

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — a minimal, state-tracked skill: one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [2.5.0] — 2026-07-25
+
+Minor: the **persona** system becomes a coherent artifact. The template guidance names
+**four legs** with a quality bar each, gains an optional **Escalation** section, and — for the
+first time — ADD **seeds** three planner personas into a new project instead of leaving every
+roster empty. The twelve orphaned **preset** persona templates stop shipping. Engine change is
+additive: `init` and `migrate` gain a seeding call; nothing else in the loop moves.
+
+### Added
+
+- **Three method-lens planners, seeded at `init` and `migrate`** — `task-planner` (inside one
+  frozen contract), `milestone-planner` (ordering tasks into a DAG), `release-planner` (what
+  makes a cut). A fresh project now reports a three-persona roster instead of
+  `personas: unseeded`, so the persona ladder can *select* or *fold* rather than always *author*.
+- **`## Escalation`** — an optional, routable persona section for stop-conditions: the point a
+  lens hands the decision up, distinct from an always-do rule and from a guilty-until-proven
+  smell. A retrospective can file `persona:<slug> · escalation` and the fold transcribes it.
+- **The four legs** — Role (`## Identity`) · Rules (`## Critical Rules`) · Standards
+  (`## Default Requirement` + `## Success Metrics`) · Process (`## Abilities` + `## Playbook`),
+  each with the bar it must clear. `## Abilities` gains an explicit load contract.
+- **A worked architect example** carrying `## Escalation`, alongside the I/O and design examples.
+
+### Changed
+
+- **`SKILL.md` seeds a persona when none fits** — the DIRECTION beat names where the roster comes
+  from (`status --all`) and the **select → fold → author** ladder, and states the generic fallback
+  that never blocks and never lowers a gate. Both rules previously lived only in an agent file the
+  orchestrator does not read.
+- **The persona chapter** now describes the load set the surfaces actually read, and states plainly
+  that **the engine never edits a persona** — a fold is always a human's or the AI's transcription.
+- **Seeding never clobbers.** `_seed_persona_file` mirrors the `_seed_spec_file` survivor idiom:
+  an existing (possibly edited) persona is returned untouched; seeding fills gaps, never rewrites.
+
+### Removed
+
+- **The 12 preset persona templates.** They shipped in every npm tarball and pip wheel for months
+  after the mechanism that read them was retired — authoritative-looking and dead. `software-architect`
+  was promoted to a worked example; the rest are gone. The line that stops a repeat is written into
+  the persona contract: ship a persona only if it is a **method lens** (one that reasons about ADD's
+  own artifacts), never a **domain lens** (security, data, UX).
+
+### Fixed
+
+- **A pinned CI skip count that no local run could see.** A `@skipUnless` class skips per method, and
+  the count was hand-maintained in two places — including the meta-test guarding the pin. Both now
+  derive from source.
+
 ## [2.4.0] — 2026-07-24
 
 Minor: the **strategy-intake** milestone closes — a fitting **persona** becomes ADD's

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — a minimal, state-tracked skill: one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "2.4.0"
+version = "2.5.0"
 description = "ADD (AI-Driven Development) 2.0. The agent is the hands; ADD is the memory, judgment, and conscience — one freeze per feature, trust from passing tests, state on disk so context rot never survives a new session. Installs the ADD skill and tooling into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "status | init | continue | --todo <text> | [describe new short g
 license: MIT
 metadata:
   author: add
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # ADD — memory · judgment · conscience (the agent is the hands)

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "2.4.0"
+__version__ = "2.5.0"

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "status | init | continue | --todo <text> | [describe new short g
 license: MIT
 metadata:
   author: add
-  version: "2.4.0"
+  version: "2.5.0"
 ---
 
 # ADD — memory · judgment · conscience (the agent is the hands)

--- a/add-method/tooling/test_release_2_5_0.py
+++ b/add-method/tooling/test_release_2_5_0.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
-"""Red/green tests for the 2.4.0 release readiness.
+"""Red/green tests for the 2.5.0 release readiness.
 
-Minor cut: the strategy-intake milestone closes — a fitting persona becomes ADD's
-adaptive PM brain (the new strategy.md DISCUSS→OPTIMIZE→CONVERGE loop filling the
-`## Strategy` slot, the add-advisor refute at CONVERGE, the risk-proportional depth
-ladder, and intake loading the fitting persona before it sizes) — plus the follow-on
-that completes the §2→§4 scenarios fold and adds a shipped-surface CI sweep. All
-changes are skill/agent-surface prose; the engine is unchanged (additive/zero).
+Minor cut: the persona system becomes a coherent artifact — the template guidance names
+four legs with a bar each, gains an optional Escalation section, and ADD SEEDS three
+method-lens planner personas at init/migrate instead of leaving every roster empty. The
+12 orphaned preset templates stop shipping. Engine change is additive (a seeding call in
+init and migrate); both engine pins are re-aimed accordingly.
 
 In-repo readiness only — the live-registry halves (npm/PyPI serving 2.4.0) are
 verify-gate EVIDENCE gathered after the human-gated tag push, never unit tests.
-The live-version-agreement asserts migrated FORWARD from test_release_2_3_0
+The live-version-agreement asserts migrated FORWARD from test_release_2_4_0
 (release-gate pattern: exactly ONE suite pins the current version).
 Run:
-    python3 -m unittest test_release_2_4_0 -v
+    python3 -m unittest test_release_2_5_0 -v
 """
 import json
 import re
@@ -25,18 +24,18 @@ PKG = HERE.parent                       # add-method/
 
 CHANGELOG = PKG / "CHANGELOG.md"
 
-VERSION = "2.4.0"
-PRIOR_VERSIONS = ("2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.18.0", "1.17.0", "1.16.1",
+VERSION = "2.5.0"
+PRIOR_VERSIONS = ("2.4.0", "2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.18.0", "1.17.0", "1.16.1",
                   "1.16.0", "1.15.0", "1.14.0", "1.13.0", "1.12.0", "1.11.0", "1.10.0",
                   "1.9.0", "1.8.0", "1.7.3", "1.7.2", "1.7.1", "1.7.0", "1.6.0", "1.5.0",
                   "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0")
 # the headline changes the 2.4.0 notes must name
-FEATURE_ANCHORS = ("strategy loop", "DISCUSS", "CONVERGE", "risk-proportional",
-                   "add-advisor", "fitting persona", "shipped-surface")
+FEATURE_ANCHORS = ("four legs", "Escalation", "method lens", "domain lens",
+                   "seed", "planner", "preset", "never clobber")
 
 
 class ChangelogTest(unittest.TestCase):
-    def test_changelog_has_2_4_0_entry(self):
+    def test_changelog_has_2_5_0_entry(self):
         self.assertTrue(CHANGELOG.is_file(), "CHANGELOG.md missing")
         text = CHANGELOG.read_text(encoding="utf-8")
         self.assertIn(f"## [{VERSION}]", text)
@@ -45,13 +44,13 @@ class ChangelogTest(unittest.TestCase):
                           f"the {prior} lineage entry must survive the bump")
         entry = text.split(f"## [{VERSION}]", 1)[1].split("## [", 1)[0]
         for anchor in FEATURE_ANCHORS:
-            self.assertIn(anchor, entry, f"2.4.0 entry must name: {anchor}")
+            self.assertIn(anchor, entry, f"2.5.0 entry must name: {anchor}")
 
 
 class ReleaseShapeTest(unittest.TestCase):
-    """The version sources move in lockstep (migrated forward from 2.3.0)."""
+    """The version sources move in lockstep (migrated forward from 2.4.0)."""
 
-    def test_versions_agree_at_2_4_0(self):
+    def test_versions_agree_at_2_5_0(self):
         pkg = json.loads((PKG / "package.json").read_text(encoding="utf-8"))["version"]
         py = re.search(r'(?m)^version\s*=\s*"([^"]+)"',
                        (PKG / "pyproject.toml").read_text(encoding="utf-8")).group(1)


### PR DESCRIPTION
## The cut

Nine version sources in lockstep — package.json · pyproject.toml · `__init__.py` · plugin.json · package-lock.json (×2) · SKILL.md (×3). Audited equal at `2.5.0`.

## What ships

- **Three method-lens planner personas seeded** at `init`/`migrate`, never-clobber — a fresh project reports a roster instead of `personas: unseeded`
- **The persona template as one artifact** — four legs with a bar each, optional routable `## Escalation`, the book reconciled with the load set the surfaces actually read
- **The 12 orphaned presets stop shipping**; the method-lens vs domain-lens criterion that replaces them is written into the persona contract and test-enforced
- **SKILL.md select → fold → author ladder**, with a fallback that never blocks and never lowers a gate

## Engine

First engine change since 2.0, and additive: `init` and `migrate` gain a seeding call. Both pins re-aimed and recomputed live; `add.py` byte-identical across all four tooling trees.

## Verified at the cut

- full suite **2327 OK** · `wording_lint` **0 findings** · `add.py check` **292 passed / 0 failed**
- release-test lineage forward-migrated 2.4.0 → 2.5.0 (one suite pins the current version)
- stale `add-method/build/` removed — the cache where the retired presets hid in shipped artifacts for months while every source tree looked clean

## Recorded honestly

RELEASES.md logs this session's three failures, not just its wins: the artifact-vs-source blindness, a pinned CI skip count invisible on macOS, and a vacuous test found by refute-read rather than by the suite.

## Not done here

**Tag `v2.5.0` is human-ordered and NOT pushed by this PR.** Pushing it publishes to npm and PyPI.