### PR TITLE
fix(benchmark): give the CLI probe the bare runtime running_app already uses

### DIFF
--- a/benchmark/tests/test_hermetic_probe_provenance.py
+++ b/benchmark/tests/test_hermetic_probe_provenance.py
@@ -7,49 +7,103 @@ covered=True on a completely empty workspace, inflating `requirement_coverage` b
 1/12 for every run scored on that machine — and asymmetrically, since the leaked
 workspace belonged to one arm.
 
-The isolated_workspace copy could not catch this: an editable install is on sys.path
-for every Python process on the machine, so there is nothing to copy away from. The
-only durable defence is provenance — the probe proves the entry point it ran lives
-under `ws` before it is allowed to score.
+The repo had ALREADY diagnosed and cured this class on 2026-07-18: `running_app`
+boots the app under `-E -s -S`, the bare declared runtime. `_p_cli_parity` spawns its
+own subprocess and never got the same flags, so it stayed the single path that
+bypassed the fix. These tests pin BOTH layers, because the first version of this file
+pinned only the second and was quietly vacuous:
+
+  1. the bare-runtime flags — the real cure, and the repo's own idiom
+  2. the entry-point provenance check — belt to those braces
+
+NOTE ON TEST DESIGN: a PYTHONPATH-based leak is invisible once `-E` is set, so a test
+that plants a leak that way and then calls the probe would pass even with every guard
+removed. Each test below either exercises a guard directly or plants the leak through
+a channel the guard under test can actually see.
 """
 from __future__ import annotations
 
+import os
 import pathlib
+import subprocess
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
-from benchmark.workload.wm1.checklist import _p_cli_parity
+from benchmark.workload.wm1 import checklist
+from benchmark.workload.wm1.checklist import _BARE, _entry_exists, _p_cli_parity
 
 
-def _leak(tmp_path: pathlib.Path) -> pathlib.Path:
-    """A CLI that exits 0, importable from OUTSIDE the workspace under test."""
-    pkg = tmp_path / "leak" / "app"
-    pkg.mkdir(parents=True)
+def _write_cli(root: pathlib.Path) -> None:
+    pkg = root / "app"
+    pkg.mkdir(parents=True, exist_ok=True)
     (pkg / "__init__.py").write_text("", encoding="utf-8")
     (pkg / "cli.py").write_text("import sys; print('[]'); sys.exit(0)\n", encoding="utf-8")
-    return tmp_path / "leak"
+
+
+class TestBareRuntime:
+    """Layer 1 — the cure `running_app` already uses, applied to the CLI probe."""
+
+    def test_probe_spawns_under_the_bare_runtime(self):
+        # The flags ARE the fix; if they are ever dropped the leak returns silently,
+        # so pin them rather than trusting the comment above them.
+        assert _BARE == ("-E", "-s", "-S")
+
+    def test_bare_runtime_blocks_a_foreign_app(self, tmp_path):
+        # The property, proven end-to-end: an app importable from OUTSIDE the
+        # workspace cannot satisfy the probe. This is the mechanism that made the
+        # empty-workspace pass possible in the first place.
+        _write_cli(tmp_path / "leak")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        env = {**os.environ, "PYTHONPATH": str(tmp_path / "leak")}
+        rc = subprocess.run([sys.executable, *_BARE, "-m", "app.cli", "list"],
+                            cwd=ws, env=env, capture_output=True, text=True).returncode
+        assert rc != 0, "bare runtime let a foreign app satisfy an empty workspace"
+
+    def test_probe_matches_running_app_isolation(self):
+        # Both spawn paths must agree. They drifted once, and that drift IS the bug:
+        # the app boot was hardened and the CLI probe was not.
+        lib = (pathlib.Path(checklist.__file__).parents[1] / "_oracle_lib.py"
+               ).read_text(encoding="utf-8")
+        assert '"-E", "-s", "-S"' in lib, \
+            "running_app no longer uses the bare runtime — the two spawn paths drifted"
 
 
 class TestProbeProvenance:
-    def test_empty_workspace_scores_false_despite_an_importable_app(self, tmp_path,
-                                                                   monkeypatch):
-        # THE REGRESSION. An empty workspace built nothing, so it satisfies nothing —
-        # no state of the surrounding machine may change that verdict.
+    """Layer 2 — exercised DIRECTLY, so these cannot pass with the guard removed."""
+
+    def test_empty_workspace_owns_no_entry_point(self, tmp_path):
         ws = tmp_path / "ws"
         ws.mkdir()
-        monkeypatch.setenv("PYTHONPATH", str(_leak(tmp_path)))
-        assert _p_cli_parity("http://127.0.0.1:1", ws) is False, \
-            "probe scored an empty workspace — a leaked install can satisfy it"
+        for module in ("app.cli", "cli", "app.__main__"):
+            assert _entry_exists(ws, module) is False, f"{module} claimed by an empty ws"
 
-    def test_workspace_owned_cli_still_scores_true(self, tmp_path, monkeypatch):
-        # The guard must not cost the probe its real signal: an app that genuinely
-        # ships the CLI in its own workspace still scores, leak present or not.
+    def test_every_legitimate_cli_shape_is_recognised(self, tmp_path):
+        # The guard must not cost the probe its real signal. These are the four
+        # shapes the invocation table actually supports.
+        shapes = {
+            "app/cli.py": "app.cli",
+            "app/cli/__init__.py": "app.cli",
+            "cli.py": "cli",
+            "app/__main__.py": "app.__main__",
+        }
+        for rel, module in shapes.items():
+            ws = tmp_path / rel.replace("/", "_")
+            f = ws / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("", encoding="utf-8")
+            assert _entry_exists(ws, module) is True, f"guard rejected {rel}"
+
+    def test_empty_workspace_never_scores(self, tmp_path):
+        # THE REGRESSION, stated as the property that actually matters: an empty
+        # workspace built nothing, so it satisfies nothing.
         ws = tmp_path / "ws"
-        pkg = ws / "app"
-        pkg.mkdir(parents=True)
-        (pkg / "__init__.py").write_text("", encoding="utf-8")
-        (pkg / "cli.py").write_text("import sys; print('[]'); sys.exit(0)\n", encoding="utf-8")
-        monkeypatch.setenv("PYTHONPATH", str(_leak(tmp_path)))
+        ws.mkdir()
+        assert _p_cli_parity("http://127.0.0.1:1", ws) is False
+
+    def test_workspace_owned_cli_still_scores(self, tmp_path):
+        ws = tmp_path / "ws"
+        _write_cli(ws)
         assert _p_cli_parity("http://127.0.0.1:1", ws) is True, \
-            "provenance guard rejected a CLI the workspace really owns"
+            "guard rejected a CLI the workspace really owns"

--- a/benchmark/workload/wm1/checklist.py
+++ b/benchmark/workload/wm1/checklist.py
@@ -89,14 +89,26 @@ def _p_status_enum(base, ws):
     return status == 400
 
 
-def _entry_exists(ws: pathlib.Path, module: str) -> bool:
-    """True iff `module` resolves to a file the WORKSPACE UNDER TEST owns.
+# The BARE declared runtime, identical to `running_app`'s app boot: -E ignores
+# PYTHONPATH, -s the user site, -S site-packages. cwd (the workspace) stays
+# importable — the only place an app may legitimately come from.
+#
+# `running_app` grew these flags on 2026-07-18 after a campaign agent
+# `pip install -e`'d its app into the GLOBAL site-packages and empty-workspace
+# boots silently imported someone else's build. This probe spawns its OWN
+# subprocess and was never given the same treatment, so it stayed the one path
+# that bypassed that fix — and it duly scored covered=True on an empty workspace
+# for every run on a contaminated machine. Same defect, same cure, one place it
+# was missed.
+_BARE = ("-E", "-s", "-S")
 
-    Provenance, not availability. A benchmark run once left `pip install -e .` of its
-    own workspace in the machine's site-packages, so `-m app.cli` resolved to a
-    PREVIOUS RUN's app and this probe scored True on an empty directory. An editable
-    install sits on sys.path for every process on the machine, so copying the
-    workspace cannot isolate it — the probe has to prove what it ran.
+
+def _entry_exists(ws: pathlib.Path, module: str) -> bool:
+    """True iff `module`'s source lives in the WORKSPACE UNDER TEST.
+
+    Belt to `_BARE`'s braces: the flags stop a FOREIGN module from being imported,
+    this stops us from spawning at all when the workspace never shipped the entry
+    point. Cheap, and it keeps the probe honest if the flags are ever loosened.
     """
     rel = pathlib.Path(*module.split("."))
     return (ws / rel.with_suffix(".py")).is_file() or (ws / rel / "__init__.py").is_file()
@@ -104,16 +116,17 @@ def _entry_exists(ws: pathlib.Path, module: str) -> bool:
 
 def _p_cli_parity(base, ws):
     """The PROMPT requires a CLI that lists via the same logic. Try the common
-    entry points; success = one WHOSE CODE LIVES IN `ws` exits 0 for `list`."""
+    entry points under the BARE runtime; success = one WHOSE CODE LIVES IN `ws`
+    exits 0 for `list`."""
     ws = pathlib.Path(ws)
     port = base.rsplit(":", 1)[-1]
     env = {**os.environ, "APP_BASE": base, "PORT": port}
     # (argv, the module whose source must exist in `ws` for this run to be OURS)
     invocations = (
-        ([sys.executable, "-m", "app.cli", "list"], "app.cli"),
-        ([sys.executable, "-m", "cli", "list"], "cli"),
-        ([sys.executable, "cli.py", "list"], "cli"),
-        ([sys.executable, "-m", "app", "list"], "app.__main__"),
+        ([sys.executable, *_BARE, "-m", "app.cli", "list"], "app.cli"),
+        ([sys.executable, *_BARE, "-m", "cli", "list"], "cli"),
+        ([sys.executable, *_BARE, "cli.py", "list"], "cli"),
+        ([sys.executable, *_BARE, "-m", "app", "list"], "app.__main__"),
     )
     for argv, module in invocations:
         if not _entry_exists(ws, module):


### PR DESCRIPTION
## Correction to #184

#184 fixed `R-cli-parity` scoring `covered=True` on an empty workspace, on the
reading that hermetic scoring had **no** defence against a leaked editable
install and therefore needed a new provenance mechanism.

That reading was wrong. The defence existed, and had since **2026-07-18**:

```python
# -E -s -S = the entry contract's BARE runtime: ignore PYTHONPATH, user
# site, and site-packages. Live defect 2026-07-18: a campaign agent
# `pip install -e`'d its app into the GLOBAL site-packages, so an
# empty-workspace boot silently imported that foreign app and probes
# scored someone else's build.
proc = subprocess.Popen([sys.executable, "-E", "-s", "-S", "-m", "app"], ...)
```

`_p_cli_parity` spawns its **own** subprocess and never received those flags. It
was the single path that bypassed an existing fix — which is exactly why it, and
only it, scored an empty workspace. Same defect, same cure, one place it was
missed. Not a new class.

## What changes

- `-E -s -S` applied to all four CLI invocations, matching `running_app`.
- `_entry_exists` **kept** as the cheaper outer guard (don't spawn at all when
  the workspace never shipped the entry point), but demoted in the comments from
  "the fix" to what it actually is.
- A drift test asserting both spawn paths still agree, since their drift was the
  bug.

## The tests in #184 were vacuous

They planted the leak via `PYTHONPATH`, then called the probe. But `-E` makes a
`PYTHONPATH` leak invisible — so **every one of them would have passed with all
guards removed.** Verified, not assumed.

The mechanism that proves a guard has to be one the guard can actually see. Each
test now either exercises a guard directly or plants the leak through a visible
channel, and both layers are mutation-checked:

| mutation | result |
|---|---|
| `_BARE = ()` | 2 tests fail |
| `_entry_exists -> True` | 1 test fails |

## Verification

`benchmark/tests`: **286 passed**.

## Why this was missed

I found it only while reading `running_app` to design a bootable fixture for the
next task — not from the suite, which was green throughout. Filed as a delta:
before inventing a mechanism for a defect, check how the repo already cured that
class. The irony is not lost that this is the same vacuous-pass class the
ambiguity track was built to detect.
