### PR TITLE
fix(benchmark): amb1 reading probes asserted residency and field names, so 6/6 runs scored "neither"

### DIFF
--- a/benchmark/tests/test_amb1_meters.py
+++ b/benchmark/tests/test_amb1_meters.py
@@ -41,6 +41,12 @@ from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 RESOLUTION = "{resolution}"          # "waitlist" | "reject"
+# The four ADDED plants (2026-07-26). Each knob is a reading the prompt leaves
+# open; the clean checklist must not be able to tell which one was chosen.
+CANCEL_AUTH = "{cancel_auth}"             # "owner" | "anyone"
+CANCELLED_VISIBLE = "{cancelled_visible}"  # "listed" | "hidden"
+ADJACENCY = "{adjacency}"                 # "half_open" | "closed"
+LIST_SCOPE = "{list_scope}"               # "all" | "own"
 
 BOOKINGS = {{}}
 WAITLIST = {{}}
@@ -59,7 +65,12 @@ def _conflicts(room, start, end, ignore=None):
         if b["id"] == ignore or b["room_id"] != room or b.get("cancelled"):
             continue
         s, e = _parse(b["start_time"]), _parse(b["end_time"])
-        if s and e and start < e and s < end:
+        if not s or not e:
+            continue
+        if ADJACENCY == "closed":
+            if start <= e and s <= end:
+                return True
+        elif start < e and s < end:
             return True
     return False
 
@@ -79,7 +90,12 @@ class H(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == "/bookings":
-            return self._send(200, [b for b in BOOKINGS.values() if not b.get("cancelled")])
+            out = list(BOOKINGS.values())
+            if CANCELLED_VISIBLE == "hidden":
+                out = [b for b in out if not b.get("cancelled")]
+            if LIST_SCOPE == "own":
+                out = [b for b in out if b.get("created_by") == self._caller()]
+            return self._send(200, out)
         if self.path.startswith("/bookings/"):
             b = BOOKINGS.get(self.path.split("/")[-1])
             return self._send(200, b) if b and not b.get("cancelled") else self._send(404, {{"error": "not_found"}})
@@ -124,6 +140,8 @@ class H(BaseHTTPRequestHandler):
         b = BOOKINGS.get(self.path.split("/")[-1])
         if not b or b.get("cancelled"):
             return self._send(404, {{"error": "not_found"}})
+        if CANCEL_AUTH == "owner" and b.get("created_by") != self._caller():
+            return self._send(403, {{"error": "forbidden"}})
         start = _parse(b["start_time"])
         if start and start - _now() < timedelta(hours=24):
             return self._send(422, {{"error": "inside_cancellation_window"}})
@@ -144,20 +162,33 @@ HTTPServer(("127.0.0.1", int(os.environ["PORT"])), H).serve_forever()
 '''
 
 
-def _reference(tmp_path: pathlib.Path, resolution: str) -> pathlib.Path:
-    ws = tmp_path / f"ref-{resolution}"
+_READING_DEFAULTS = {"cancel_auth": "owner", "cancelled_visible": "listed",
+                     "adjacency": "half_open", "list_scope": "all"}
+
+# Every added plant flipped to its OTHER reading, all at once.
+_FLIPPED = {"cancel_auth": "anyone", "cancelled_visible": "hidden",
+            "adjacency": "closed", "list_scope": "own"}
+
+
+def _reference(tmp_path: pathlib.Path, resolution: str, name: str = "",
+               **readings) -> pathlib.Path:
+    ws = tmp_path / f"ref-{name or resolution}"
     pkg = ws / "app"
     pkg.mkdir(parents=True)
     (pkg / "__init__.py").write_text("", encoding="utf-8")
     (pkg / "__main__.py").write_text(
-        _REFERENCE_APP.format(resolution=resolution), encoding="utf-8")
+        _REFERENCE_APP.format(resolution=resolution,
+                              **{**_READING_DEFAULTS, **readings}), encoding="utf-8")
     return ws
 
 
 @pytest.fixture(scope="module")
 def refs(tmp_path_factory):
     root = tmp_path_factory.mktemp("amb1refs")
-    return {r: _reference(root, r) for r in ("waitlist", "reject")}
+    refs = {r: _reference(root, r) for r in ("waitlist", "reject")}
+    # Same conflict reading, every ADDED plant resolved the other way.
+    refs["flipped"] = _reference(root, "waitlist", name="flipped", **_FLIPPED)
+    return refs
 
 
 # ── M1 / M2 · the meters exist at all ─────────────────────────────────────────
@@ -258,6 +289,23 @@ class TestResolutionBlindness:
         assert a == b, (
             f"oracle sees the reading: waitlist={a} reject={b}")
 
+    def test_added_plants_do_not_move_coverage(self, refs):
+        # The widening (2026-07-26) added four plants. If the clean checklist can
+        # tell how any of them was resolved, the track has quietly become a
+        # right-answer track for that item — the exact thing this suite exists to
+        # refute, now covering seven items rather than three.
+        a = compute_requirement_coverage(refs["waitlist"], 1, "amb")
+        b = compute_requirement_coverage(refs["flipped"], 1, "amb")
+        assert a == b, (
+            f"coverage sees an added reading: default={a} flipped={b} — a row "
+            "depends on cancel authority, cancelled visibility, adjacency, or "
+            "list scope")
+
+    def test_added_plants_do_not_move_the_oracle(self, refs):
+        a = compute_oracle_pass_rate(refs["waitlist"], 1, "amb")
+        b = compute_oracle_pass_rate(refs["flipped"], 1, "amb")
+        assert a == b, f"oracle sees an added reading: default={a} flipped={b}"
+
     def test_the_two_references_really_do_differ(self, refs):
         # Guards the guard: if both apps behaved identically, the fairness proof
         # above would be trivially true and prove nothing at all.
@@ -305,6 +353,9 @@ class TestRecordCompleteness:
         import benchmark.score as score
         detail = score.compute_ambiguity_detail(
             refs["waitlist"], tmp_path / "absent.jsonl", 1, "amb")
-        assert len(detail) == 3
+        # 3 at first freeze; 7 after the 2026-07-26 widening. Pinned as a literal
+        # rather than len(AMBIGUITIES) so a silently DROPPED item still fails —
+        # comparing the meter against itself would notice nothing.
+        assert len(detail) == 7
         assert all(d["verdict"] != "surfaced" for d in detail)
         assert {d["klass"] for d in detail} == {"contradiction", "gap", "trap"}

--- a/benchmark/tests/test_amb1_reading_probes.py
+++ b/benchmark/tests/test_amb1_reading_probes.py
@@ -51,6 +51,11 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 ORDERING = "{ordering}"
 POSITION_KEY = "{position_key}"
 PROMOTE_ALL = {promote_all}
+CANCEL_AUTH = "{cancel_auth}"          # "owner" | "anyone"
+CANCELLED_VISIBLE = "{cancelled_visible}"   # "listed" | "hidden"
+ADJACENCY = "{adjacency}"              # "half_open" | "closed"
+LIST_SCOPE = "{list_scope}"            # "all" | "own"
+ENVELOPE = {envelope}                   # wrap GET /bookings as {{"bookings": [...]}}
 
 BOOKINGS = {{}}
 WAITLIST = {{}}
@@ -69,7 +74,12 @@ def _conflicts(room, start, end):
         if b["room_id"] != room or b.get("cancelled"):
             continue
         s, e = _parse(b["start_time"]), _parse(b["end_time"])
-        if s and e and start < e and s < end:
+        if not s or not e:
+            continue
+        if ADJACENCY == "closed":
+            if start <= e and s <= end:   # touching intervals collide
+                return True
+        elif start < e and s < end:       # half-open: back-to-back is fine
             return True
     return False
 
@@ -96,7 +106,12 @@ class H(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == "/bookings":
-            return self._send(200, [b for b in BOOKINGS.values() if not b.get("cancelled")])
+            out = list(BOOKINGS.values())
+            if CANCELLED_VISIBLE == "hidden":
+                out = [b for b in out if not b.get("cancelled")]
+            if LIST_SCOPE == "own":
+                out = [b for b in out if b.get("created_by") == self._caller()]
+            return self._send(200, {{"bookings": out}} if ENVELOPE else out)
         if self.path.startswith("/rooms/") and self.path.endswith("/waitlist"):
             return self._send(200, WAITLIST.get(self.path.split("/")[2], []))
         if self.path.startswith("/bookings/"):
@@ -134,6 +149,8 @@ class H(BaseHTTPRequestHandler):
         b = BOOKINGS.get(self.path.split("/")[-1])
         if not b or b.get("cancelled"):
             return self._send(404, {{}})
+        if CANCEL_AUTH == "owner" and b.get("created_by") != self._caller():
+            return self._send(403, {{}})
         start = _parse(b["start_time"])
         if start and start - _now() < timedelta(hours=24):
             return self._send(422, {{}})
@@ -156,15 +173,19 @@ HTTPServer(("127.0.0.1", int(os.environ["PORT"])), H).serve_forever()
 '''
 
 
-def _app(root: pathlib.Path, ordering: str, position_key: str,
-         promote_all: bool = False) -> pathlib.Path:
-    ws = root / f"{ordering}-{position_key}-{promote_all}"
+_DEFAULTS = {"ordering": "priority", "position_key": "position",
+             "promote_all": False, "cancel_auth": "owner",
+             "cancelled_visible": "listed", "adjacency": "half_open",
+             "list_scope": "all", "envelope": False}
+
+
+def _app(root: pathlib.Path, name: str, **knobs) -> pathlib.Path:
+    settings = {**_DEFAULTS, **knobs}
+    ws = root / name
     pkg = ws / "app"
     pkg.mkdir(parents=True)
     (pkg / "__init__.py").write_text("", encoding="utf-8")
-    (pkg / "__main__.py").write_text(
-        _APP.format(ordering=ordering, position_key=position_key,
-                    promote_all=promote_all), encoding="utf-8")
+    (pkg / "__main__.py").write_text(_APP.format(**settings), encoding="utf-8")
     return ws
 
 
@@ -172,13 +193,23 @@ def _app(root: pathlib.Path, ordering: str, position_key: str,
 def apps(tmp_path_factory):
     root = tmp_path_factory.mktemp("amb1probe")
     return {
-        "priority": _app(root, "priority", "position"),
-        "fifo": _app(root, "fifo", "position"),
+        "priority": _app(root, "priority", ordering="priority"),
+        "fifo": _app(root, "fifo", ordering="fifo"),
         # rep0/add's spelling — same semantics, different key.
-        "priority_alias": _app(root, "priority", "waitlist_position"),
+        "priority_alias": _app(root, "alias", position_key="waitlist_position"),
         # Promotes the ENTIRE queue on a cancellation: it has expressed no
         # ordering preference, so no reading may be attributed to it.
-        "greedy": _app(root, "priority", "position", promote_all=True),
+        "greedy": _app(root, "greedy", promote_all=True),
+        # The four NEW plants, both ways round. Every knob flipped together, so
+        # one app can prove all four probes read what they were handed.
+        "strict": _app(root, "strict", cancel_auth="owner", cancelled_visible="hidden",
+                       adjacency="closed", list_scope="own"),
+        "loose": _app(root, "loose", cancel_auth="anyone", cancelled_visible="listed",
+                      adjacency="half_open", list_scope="all"),
+        # A live spec-kit build answers {"bookings": [...]}. The prompt says
+        # "lists bookings" and never fixes the shape.
+        "enveloped": _app(root, "enveloped", cancel_auth="anyone",
+                          cancelled_visible="listed", list_scope="all", envelope=True),
     }
 
 
@@ -274,3 +305,128 @@ class TestStillNonVacuousDownward:
             for key in ("priority", "fifo"):
                 r = _readings(item_id, apps[key])
                 assert sum(r.values()) <= 1, (item_id, key, r)
+
+
+# ── the four ADDED plants ─────────────────────────────────────────────────────
+# Rationale for widening: with three items, two of which every arm resolved the
+# same way, the track measured ONE binary per run. n=3 could not separate
+# anything. These four are also chosen to fix a design flaw in the original two —
+# `A-priority-vs-fifo` and `A-position-ordering` can only resolve under the
+# WAITLIST reading of the contradiction, so an arm that reads §2 as authoritative
+# gets `neither` for free on both. Each item below resolves under EITHER reading,
+# because none of them touches the queue.
+#
+# None required a PROMPT edit: a gap is by definition something the prompt does
+# not say, and the trap is a reading the prompt already invites. The workload the
+# archived runs were given is unchanged, so they re-score for free.
+
+NEW_ITEMS = ("A-cancel-authority", "A-cancelled-visibility",
+             "A-adjacent-boundary", "A-list-scope")
+
+_STRICT_READINGS = {"A-cancel-authority": "owner_only",
+                    "A-cancelled-visibility": "hidden",
+                    "A-adjacent-boundary": "closed",
+                    "A-list-scope": "own_only"}
+_LOOSE_READINGS = {"A-cancel-authority": "anyone",
+                   "A-cancelled-visibility": "listed",
+                   "A-adjacent-boundary": "half_open",
+                   "A-list-scope": "all"}
+
+
+class TestAddedPlantsExist:
+    def test_all_four_are_declared_and_valid(self):
+        from benchmark.ambiguity import validate_ambiguities
+        validate_ambiguities(AMBIGUITIES)
+        for item_id in NEW_ITEMS:
+            assert item_id in _BY_ID, item_id
+
+    def test_no_added_anchor_is_a_marker(self):
+        # validate_ambiguities enforces this, but the failure it prevents is
+        # subtle enough to name: an anchor inside the marker vocabulary marks
+        # itself, so a silent run reads as a surfaced one.
+        from benchmark.ambiguity import MARKERS
+        for item_id in NEW_ITEMS:
+            for anchor in _BY_ID[item_id]["anchors"]:
+                assert not any(m in anchor.lower() for m in MARKERS), (item_id, anchor)
+
+
+class TestAddedPlantsResolveBothWays:
+    @pytest.mark.parametrize("item_id", NEW_ITEMS)
+    def test_strict_app_reads_strict(self, apps, item_id):
+        assert _shipped(item_id, apps["strict"]) == _STRICT_READINGS[item_id]
+
+    @pytest.mark.parametrize("item_id", NEW_ITEMS)
+    def test_loose_app_reads_loose(self, apps, item_id):
+        # The converse of the above. Without both, a probe hard-wired to one
+        # reading passes half the suite and reports that reading forever.
+        assert _shipped(item_id, apps["loose"]) == _LOOSE_READINGS[item_id]
+
+    @pytest.mark.parametrize("item_id", NEW_ITEMS)
+    def test_unreachable_app_resolves_to_neither(self, tmp_path, item_id):
+        ws = tmp_path / f"empty-{item_id}"
+        ws.mkdir()
+        assert _shipped(item_id, ws) == "neither"
+
+
+@pytest.fixture(scope="module")
+def rejecting_app(tmp_path_factory):
+    """An app that NEVER waitlists: conflicts are rejected with 409, so no queue
+    ever exists. Any item that needs a queue to resolve is invisible here."""
+    root = tmp_path_factory.mktemp("amb1reject")
+    ws = root / "reject"
+    pkg = ws / "app"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    src = _APP.format(**{**_DEFAULTS, "cancel_auth": "anyone",
+                         "cancelled_visible": "listed", "list_scope": "all"})
+    src = src.replace(
+        '''        if _conflicts(data["room_id"], s, e):
+            q = WAITLIST.setdefault(data["room_id"], [])
+            rec["status"] = "waitlisted"
+            q.append(rec)
+            _order(q)
+            return self._send(202, rec)''',
+        '''        if _conflicts(data["room_id"], s, e):
+            return self._send(409, {"error": "conflict"})''')
+    (pkg / "__main__.py").write_text(src, encoding="utf-8")
+    return ws
+
+
+class TestAddedPlantsAreWaitlistIndependent:
+    """The flaw the widening is meant to fix, pinned mechanically.
+
+    An item that only resolves when the app built a waitlist hands `neither` to
+    any arm that read §2 (reject with 409) as authoritative — scoring the arm for
+    a reading the prompt itself offered."""
+
+    @pytest.mark.parametrize("item_id", NEW_ITEMS)
+    def test_added_item_still_resolves_without_a_waitlist(self, rejecting_app, item_id):
+        assert _shipped(item_id, rejecting_app) != "neither", (
+            f"{item_id} needs a waitlist to resolve — it hands `neither` to every "
+            "arm that reads the contradiction as reject-409")
+
+    @pytest.mark.parametrize("item_id", ("A-priority-vs-fifo", "A-position-ordering"))
+    def test_original_two_are_the_ones_that_cannot(self, rejecting_app, item_id):
+        # Not a bug to fix — a documented limit of those two items, recorded here
+        # so the asymmetry is visible rather than folded into an average.
+        assert _shipped(item_id, rejecting_app) == "neither"
+
+
+class TestListingShapeIsNotAReading:
+    """R:over_specified_probe, third occurrence in this file.
+
+    rep1 and rep2 of spec-kit answer `GET /bookings` as {"bookings": [...]}. A
+    probe requiring a bare JSON array scored BOTH listing items `neither` for
+    those runs — reporting "expressed no preference" about an app that expressed
+    one plainly. The prompt fixes the semantics of the listing, never its
+    serialization, so the envelope must not change any reading.
+    """
+
+    @pytest.mark.parametrize("item_id", ("A-cancelled-visibility", "A-list-scope"))
+    def test_envelope_does_not_change_the_reading(self, apps, item_id):
+        assert _shipped(item_id, apps["enveloped"]) == _shipped(item_id, apps["loose"])
+
+    @pytest.mark.parametrize("item_id", ("A-cancelled-visibility", "A-list-scope"))
+    def test_enveloped_app_still_resolves(self, apps, item_id):
+        # Equality alone would also hold if BOTH were "neither".
+        assert _shipped(item_id, apps["enveloped"]) != "neither"

--- a/benchmark/tests/test_amb1_reading_probes.py
+++ b/benchmark/tests/test_amb1_reading_probes.py
@@ -430,3 +430,20 @@ class TestListingShapeIsNotAReading:
     def test_enveloped_app_still_resolves(self, apps, item_id):
         # Equality alone would also hold if BOTH were "neither".
         assert _shipped(item_id, apps["enveloped"]) != "neither"
+
+
+class TestEnvelopeDoesNotCostCoverage:
+    """The clean checklist must not charge an arm for wrapping its list.
+
+    This is the amb1 end-to-end for the 2026-07-26 shape audit: two apps whose
+    ONLY difference is `[...]` versus `{"bookings": [...]}` — a serialization the
+    PROMPT never fixes — must score identical requirement_coverage.
+    """
+
+    def test_enveloped_app_scores_the_same_coverage(self, apps):
+        from benchmark.score import compute_requirement_coverage
+        bare = compute_requirement_coverage(apps["loose"], 1, "amb")
+        wrapped = compute_requirement_coverage(apps["enveloped"], 1, "amb")
+        assert bare == wrapped, f"envelope costs coverage: bare={bare} enveloped={wrapped}"
+        # Equality alone would hold if both were 0.0 for an unrelated reason.
+        assert bare == 1.0, bare

--- a/benchmark/tests/test_amb1_reading_probes.py
+++ b/benchmark/tests/test_amb1_reading_probes.py
@@ -1,0 +1,276 @@
+"""The reading probes must resolve against apps whose reading is KNOWN.
+
+Six live runs scored `A-priority-vs-fifo` as `neither` — every arm, every rep.
+That is not six apps declining to choose; it is a probe that cannot be satisfied.
+It required the promoted entry to still be LISTED in the waitlist with
+`status == "confirmed"`, and an app that promotes an entry naturally removes it.
+Probing rep1/add directly: it promoted `priority: 9` correctly and still scored
+`neither`.
+
+`A-position-ordering` had a narrower version of the same disease — it read the
+key `position`, and rep0/add reports `waitlist_position`. Same semantics, wrong
+spelling, scored `neither` while visibly ordering by priority.
+
+Both are the vacuous-assertion class: a probe whose FALSE branch is unreachable
+tells you nothing, and a meter that can only ever say "neither" quietly converts
+every run into `guessed_wrong`. The fix is to assert on the OBSERVABLE OUTCOME
+(which entry left the queue) rather than on a data-structure residency and a
+field name the prompt never fixes.
+
+These reference apps have no ambiguity: each one's reading is chosen by a knob.
+A probe that cannot recover a reading it was handed cannot be trusted to report
+one it was not.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from benchmark.workload._oracle_lib import running_app
+from benchmark.workload.amb1.ambiguity import AMBIGUITIES
+
+_BY_ID = {a["id"]: a for a in AMBIGUITIES}
+
+# ── reference app ─────────────────────────────────────────────────────────────
+# Always resolves the CONTRADICTION as waitlist (otherwise there is no queue to
+# observe). Two knobs decide the other two items:
+#   ORDERING     — "priority" | "fifo"          -> A-priority-vs-fifo
+#   POSITION_KEY — "position" | "waitlist_position" -> A-position-ordering
+# Promotion REMOVES the entry from the queue, which is what the old probe could
+# not see, and what every live arm actually did.
+
+_APP = '''\
+import json, os, uuid
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+ORDERING = "{ordering}"
+POSITION_KEY = "{position_key}"
+PROMOTE_ALL = {promote_all}
+
+BOOKINGS = {{}}
+WAITLIST = {{}}
+
+def _now():
+    return datetime.now(timezone.utc)
+
+def _parse(ts):
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+def _conflicts(room, start, end):
+    for b in BOOKINGS.values():
+        if b["room_id"] != room or b.get("cancelled"):
+            continue
+        s, e = _parse(b["start_time"]), _parse(b["end_time"])
+        if s and e and start < e and s < end:
+            return True
+    return False
+
+def _order(q):
+    if ORDERING == "priority":
+        q.sort(key=lambda r: -int(r.get("priority") or 0))
+    else:
+        q.sort(key=lambda r: r["seq"])
+    for i, r in enumerate(q, 1):
+        r[POSITION_KEY] = i
+
+class H(BaseHTTPRequestHandler):
+    def _send(self, code, payload=None):
+        body = json.dumps(payload).encode() if payload is not None else b""
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _caller(self):
+        return self.headers.get("Authorization", "").replace("Bearer ", "").strip() or "anon"
+
+    def do_GET(self):
+        if self.path == "/bookings":
+            return self._send(200, [b for b in BOOKINGS.values() if not b.get("cancelled")])
+        if self.path.startswith("/rooms/") and self.path.endswith("/waitlist"):
+            return self._send(200, WAITLIST.get(self.path.split("/")[2], []))
+        if self.path.startswith("/bookings/"):
+            b = BOOKINGS.get(self.path.split("/")[-1])
+            return self._send(200, b) if b and not b.get("cancelled") else self._send(404, {{}})
+        return self._send(404, {{}})
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        try:
+            data = json.loads(self.rfile.read(n) or b"{{}}")
+        except Exception:
+            return self._send(400, {{}})
+        for k in ("title", "start_time", "end_time", "room_id"):
+            if k not in data:
+                return self._send(400, {{}})
+        s, e = _parse(data["start_time"]), _parse(data["end_time"])
+        if not s or not e:
+            return self._send(400, {{}})
+        rec = {{"id": str(uuid.uuid4()), "title": data["title"],
+               "start_time": data["start_time"], "end_time": data["end_time"],
+               "room_id": data["room_id"], "status": "pending",
+               "priority": data.get("priority"), "created_by": self._caller(),
+               "seq": len(BOOKINGS) + sum(len(v) for v in WAITLIST.values())}}
+        if _conflicts(data["room_id"], s, e):
+            q = WAITLIST.setdefault(data["room_id"], [])
+            rec["status"] = "waitlisted"
+            q.append(rec)
+            _order(q)
+            return self._send(202, rec)
+        BOOKINGS[rec["id"]] = rec
+        return self._send(201, rec)
+
+    def do_DELETE(self):
+        b = BOOKINGS.get(self.path.split("/")[-1])
+        if not b or b.get("cancelled"):
+            return self._send(404, {{}})
+        start = _parse(b["start_time"])
+        if start and start - _now() < timedelta(hours=24):
+            return self._send(422, {{}})
+        b["cancelled"] = True
+        q = WAITLIST.get(b["room_id"]) or []
+        if q:
+            _order(q)
+            n = len(q) if PROMOTE_ALL else 1
+            for _ in range(n):
+                promoted = q.pop(0)      # LEAVES the queue — the live behaviour
+                promoted["status"] = "confirmed"
+                BOOKINGS[promoted["id"]] = promoted
+            _order(q)
+        return self._send(200, b)
+
+    def log_message(self, *a):
+        pass
+
+HTTPServer(("127.0.0.1", int(os.environ["PORT"])), H).serve_forever()
+'''
+
+
+def _app(root: pathlib.Path, ordering: str, position_key: str,
+         promote_all: bool = False) -> pathlib.Path:
+    ws = root / f"{ordering}-{position_key}-{promote_all}"
+    pkg = ws / "app"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "__main__.py").write_text(
+        _APP.format(ordering=ordering, position_key=position_key,
+                    promote_all=promote_all), encoding="utf-8")
+    return ws
+
+
+@pytest.fixture(scope="module")
+def apps(tmp_path_factory):
+    root = tmp_path_factory.mktemp("amb1probe")
+    return {
+        "priority": _app(root, "priority", "position"),
+        "fifo": _app(root, "fifo", "position"),
+        # rep0/add's spelling — same semantics, different key.
+        "priority_alias": _app(root, "priority", "waitlist_position"),
+        # Promotes the ENTIRE queue on a cancellation: it has expressed no
+        # ordering preference, so no reading may be attributed to it.
+        "greedy": _app(root, "priority", "position", promote_all=True),
+    }
+
+
+def _readings(item_id: str, ws: pathlib.Path) -> dict[str, bool]:
+    """Run every reading of an item against a live app; return {name: bool}.
+
+    A raising probe counts False — the scorer's own rule (`_resolve_shipped`:
+    "A raising probe counts as False (fail-closed)"). Demanding exception-free
+    probes here would test a contract the scorer does not have.
+    """
+    item = _BY_ID[item_id]
+    out = {}
+    with running_app(str(ws)) as base:
+        for name, probe in item["readings"].items():
+            try:
+                out[name] = bool(probe(base, ws))
+            except Exception:
+                out[name] = False
+    return out
+
+
+def _shipped(item_id: str, ws: pathlib.Path) -> str:
+    """Through the scorer's real resolver, not a reimplementation of it."""
+    from benchmark.score import _resolve_shipped
+    with running_app(str(ws)) as base:
+        return _resolve_shipped(_BY_ID[item_id], base, ws)
+
+
+class TestPriorityGapProbeResolves:
+    """R:vacuous_probe — `neither` in 6/6 live runs was the meter, not the apps."""
+
+    def test_priority_ordering_app_reads_as_priority_first(self, apps):
+        r = _readings("A-priority-vs-fifo", apps["priority"])
+        assert r == {"priority_first": True, "fifo_first": False}, r
+
+    def test_fifo_ordering_app_reads_as_fifo_first(self, apps):
+        # The converse. Without it, a probe hard-wired to True would pass above.
+        r = _readings("A-priority-vs-fifo", apps["fifo"])
+        assert r == {"priority_first": False, "fifo_first": True}, r
+
+    def test_promoted_entry_leaving_the_queue_is_still_observed(self, apps):
+        # The exact defect: both reference apps REMOVE the promoted entry, which
+        # is what every live arm did and what the old probe could not see.
+        for key in ("priority", "fifo"):
+            assert any(_readings("A-priority-vs-fifo", apps[key]).values()), \
+                f"{key}: promotion is unobservable to the probe"
+
+
+class TestPositionProbeResolves:
+    def test_position_app_reads_as_by_priority(self, apps):
+        r = _readings("A-position-ordering", apps["priority"])
+        assert r == {"by_priority": True, "by_arrival": False}, r
+
+    def test_arrival_app_reads_as_by_arrival(self, apps):
+        r = _readings("A-position-ordering", apps["fifo"])
+        assert r == {"by_priority": False, "by_arrival": True}, r
+
+    def test_field_name_does_not_change_the_reading(self, apps):
+        # R:field_name_coupling — rep0/add reported `waitlist_position` and was
+        # scored `neither` while visibly ordering by priority. The prompt fixes
+        # the SEMANTICS of position, never its spelling.
+        assert (_readings("A-position-ordering", apps["priority_alias"])
+                == _readings("A-position-ordering", apps["priority"]))
+
+
+class TestStillNonVacuousDownward:
+    def test_unreachable_app_resolves_to_no_reading(self, tmp_path):
+        # The other direction: a probe that reports a reading for an app that
+        # does not exist would make every score meaningless.
+        ws = tmp_path / "empty"
+        ws.mkdir()
+        for item_id in ("A-priority-vs-fifo", "A-position-ordering"):
+            assert _shipped(item_id, ws) == "neither", item_id
+
+    def test_scorer_recovers_the_known_reading_end_to_end(self, apps):
+        # The probes are only worth fixing if `shipped` changes with them — the
+        # unit could resolve while the seam still reported "neither".
+        assert _shipped("A-priority-vs-fifo", apps["priority"]) == "priority_first"
+        assert _shipped("A-priority-vs-fifo", apps["fifo"]) == "fifo_first"
+        assert _shipped("A-position-ordering", apps["priority_alias"]) == "by_priority"
+
+    def test_app_that_promotes_everything_expresses_no_reading(self, apps):
+        # R:false_reading — with the exactly-one-promoted guard removed, this app
+        # hands back whichever entry happened to be first and that arbitrary
+        # priority is published as the arm's decision. Guessing right requires
+        # having guessed; draining the queue is not a guess.
+        assert _shipped("A-priority-vs-fifo", apps["greedy"]) == "neither"
+
+    def test_no_reading_pair_is_ever_simultaneously_true(self, apps):
+        # `shipped` resolves to a single reading; two true readings collapse to
+        # "neither" and silently re-creates the bug being fixed here.
+        for item_id in ("A-priority-vs-fifo", "A-position-ordering"):
+            for key in ("priority", "fifo"):
+                r = _readings(item_id, apps[key])
+                assert sum(r.values()) <= 1, (item_id, key, r)

--- a/benchmark/tests/test_collection_shape.py
+++ b/benchmark/tests/test_collection_shape.py
@@ -1,0 +1,123 @@
+"""A collection response's SHAPE is not a requirement any prompt states.
+
+Audit, 2026-07-26. Six FROZEN checklists asserted `isinstance(body, list)` for
+endpoints their PROMPTs describe only as "lists bookings". No wm prompt says
+"array", "list of", or anything equivalent — checked, not assumed. Re-probing
+every archived workspace with an envelope-unwrapping transport flipped 11
+failing rows to covered across BOTH arms:
+
+    runs-nbr-session/add   wm4   0.17 -> 0.67     (3 of 6 rows)
+    runs-session/*         wm2   0.20 -> 0.40     (both arms)
+    runs-session/spec-kit  wm3   0.75 -> 1.00
+    runs/{seeded,enforced}-r1/add wm1  0.92 -> 1.00
+    runs-amb rep1-2/spec-kit amb1 0.91 -> 1.00
+
+`requirement_coverage` replaced an LLM `spec_fidelity` judge precisely because
+judges were not trustworthy and probes were meant to be. A probe encoding an
+unstated preference is that same defect wearing a deterministic costume, and it
+is worse for being invisible: the run looks like a build failure.
+
+The audit that found this was itself vacuous on the first pass — `_load_checklist`
+re-execs the module from file, so patching `sys.modules` changed nothing and the
+harness reported a confident "none". It was caught only by a POSITIVE CONTROL: a
+case already known to fail on shape, which must flip. Any audit that cannot
+detect the thing it is looking for reports zero.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from benchmark.workload._oracle_lib import records
+
+WORKLOAD = pathlib.Path(__file__).resolve().parents[1] / "workload"
+
+
+class TestRecordsSemantics:
+    def test_bare_array_is_a_collection(self):
+        assert records([{"id": 1}]) == [{"id": 1}]
+
+    def test_empty_array_is_a_collection_not_a_miss(self):
+        # `records(body) == []` must distinguish "empty collection" from "not a
+        # collection"; `if not rows` would conflate them and wm4's empty-window
+        # row asserts exactly the empty case.
+        assert records([]) == []
+        assert records([]) is not None
+
+    @pytest.mark.parametrize("key", ["items", "results", "data", "bookings",
+                                     "entries", "records", "waitlist", "tasks"])
+    def test_named_envelopes_unwrap(self, key):
+        assert records({key: [{"id": 1}]}) == [{"id": 1}]
+
+    def test_unanticipated_envelope_key_still_unwraps(self):
+        # The alternative is meeting this same bug again under a new spelling.
+        assert records({"reservations": [{"id": 1}], "count": 1}) == [{"id": 1}]
+
+    def test_two_lists_are_ambiguous_and_yield_nothing(self):
+        # Guessing which list is "the" collection would re-import the coin-flip
+        # this benchmark exists to refuse.
+        assert records({"bookings": [], "errors": []}) is not None  # named key wins
+        assert records({"alpha": [{"a": 1}], "beta": [{"b": 2}]}) is None
+
+    def test_non_collections_are_none(self):
+        for payload in (None, 5, "text", {"id": 1}, {"error": "nope"}):
+            assert records(payload) is None, payload
+
+    def test_named_key_beats_the_single_list_fallback(self):
+        assert records({"items": [{"id": 1}], "warnings": []}) == [{"id": 1}]
+
+
+class TestNoChecklistAssertsAShape:
+    """Mechanical guard. The prompts fix semantics, never serialization."""
+
+    def _probe_sources(self):
+        for f in sorted(WORKLOAD.glob("*/checklist.py")):
+            yield f.name, f.parent.name, f.read_text(encoding="utf-8")
+
+    def test_no_probe_requires_a_bare_json_array(self):
+        for name, wm, text in self._probe_sources():
+            code = "\n".join(l for l in text.splitlines()
+                             if not l.lstrip().startswith("#"))
+            for banned in ("isinstance(body, list)", "isinstance(payload, list)",
+                           "type(body) is list"):
+                assert banned not in code, f"{wm}/{name} asserts a response shape: {banned}"
+
+    def test_every_checklist_that_reads_a_collection_imports_records(self):
+        # A checklist could satisfy the guard above by open-coding the same check
+        # a different way; requiring the shared helper keeps ONE definition of
+        # what a collection is, rather than six drifting twins.
+        for name, wm, text in self._probe_sources():
+            if "records(" in text:
+                tree = ast.parse(text)
+                imported = {alias.name for node in ast.walk(tree)
+                            if isinstance(node, ast.ImportFrom)
+                            for alias in node.names}
+                assert "records" in imported, f"{wm}/{name} uses records() unimported"
+
+
+class TestArchivedRunsRescoreHigher:
+    """The audit's own positive control, kept as a test.
+
+    Skips when the archived runs are absent — `benchmark/runs*/` is gitignored,
+    so a fresh checkout has nothing to re-probe. Skipping is honest here; the
+    unit tests above carry the semantics regardless.
+    """
+
+    CASE = ("runs-amb-2026-07-26-rep1/spec-kit/amb1/workspace", 1, "amb", "R-get-list")
+
+    def test_known_envelope_case_now_scores_covered(self):
+        from benchmark.score import compute_coverage_detail
+
+        rel, wm, family, row = self.CASE
+        ws = pathlib.Path(__file__).resolve().parents[1] / rel
+        if not ws.exists():
+            pytest.skip("archived run not present (benchmark/runs*/ is gitignored)")
+        detail = {d["id"]: d["covered"] for d in compute_coverage_detail(ws, wm, family)}
+        assert detail[row] is True, (
+            f"{rel} still fails {row}; this app answers "
+            '{"bookings": [...]}, which the prompt permits')

--- a/benchmark/tests/test_cross_milestone_rescore.py
+++ b/benchmark/tests/test_cross_milestone_rescore.py
@@ -1,0 +1,135 @@
+"""A session workspace cannot be re-scored against an EARLIER milestone.
+
+This trap produced a false alarm during the 2026-07-26 shape audit. Re-scoring
+`runs-session/*` and `runs-atomic-session/*` today returned 0.00 for wm1 against
+stored figures of 0.92-1.00, which reads exactly like archived-workspace rot. It
+is not rot, and the stored figures are fine.
+
+The cause is the milestone sequence itself. wm1's checklist sends NO
+Authorization header — grep it: zero occurrences. wm2's `R-auth-401` REQUIRES
+that an unauthenticated request return 401. A session run evolves ONE workspace
+through wm1..wm6, so the moment it satisfies wm2 every wm1 probe receives 401 and
+wm1 scores 0.00 forever. The two contracts are mutually exclusive BY DESIGN;
+wm2's requirement is that wm1's client behaviour stops working.
+
+Per-milestone records for a session run were scored when that milestone
+completed, against the tree as it then stood. That is the only valid time to
+score them. Re-scoring the FINAL tree against an earlier checklist compares an
+app to a contract it was deliberately made to outgrow.
+
+The practical rule this pins:
+  - per-milestone runs (runs/<campaign>/<arm>/wm<N>/workspace) re-score fine;
+    each has its own tree.
+  - session runs (one workspace, many milestones) re-score ONLY against their
+    LAST milestone. An earlier-milestone re-score is meaningless, not a
+    regression, and must never be reported as one.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from benchmark.score import compute_requirement_coverage
+
+WORKLOAD = pathlib.Path(__file__).resolve().parents[1] / "workload"
+
+# A wm1-shaped app. AUTH is the only knob: with it on, the app satisfies wm2's
+# R-auth-401 and therefore refuses every wm1 probe.
+_APP = '''\
+import json, os, uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+REQUIRE_AUTH = {require_auth}
+BOOKINGS = {{}}
+
+class H(BaseHTTPRequestHandler):
+    def _send(self, code, payload=None):
+        body = json.dumps(payload).encode() if payload is not None else b""
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _denied(self):
+        if REQUIRE_AUTH and not self.headers.get("Authorization"):
+            self._send(401, {{"error": "unauthorized"}})
+            return True
+        return False
+
+    def do_GET(self):
+        if self._denied():
+            return
+        if self.path == "/bookings":
+            return self._send(200, list(BOOKINGS.values()))
+        b = BOOKINGS.get(self.path.rsplit("/", 1)[-1])
+        return self._send(200, b) if b else self._send(404, {{"error": "not_found"}})
+
+    def do_POST(self):
+        if self._denied():
+            return
+        n = int(self.headers.get("Content-Length", 0))
+        try:
+            data = json.loads(self.rfile.read(n) or b"{{}}")
+        except Exception:
+            return self._send(400, {{"error": "bad_json"}})
+        for k in ("title", "start_time", "duration_minutes"):
+            if k not in data:
+                return self._send(400, {{"error": "missing_field"}})
+        rec = {{"id": str(uuid.uuid4()), "status": "pending", **data}}
+        BOOKINGS[rec["id"]] = rec
+        return self._send(201, rec)
+
+    def log_message(self, *a):
+        pass
+
+HTTPServer(("127.0.0.1", int(os.environ["PORT"])), H).serve_forever()
+'''
+
+
+def _app(root: pathlib.Path, require_auth: bool) -> pathlib.Path:
+    ws = root / f"auth-{require_auth}"
+    pkg = ws / "app"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "__main__.py").write_text(_APP.format(require_auth=require_auth),
+                                     encoding="utf-8")
+    return ws
+
+
+@pytest.fixture(scope="module")
+def apps(tmp_path_factory):
+    root = tmp_path_factory.mktemp("crossmilestone")
+    return {"open": _app(root, False), "authed": _app(root, True)}
+
+
+class TestWm1AndWm2ContractsAreMutuallyExclusive:
+    def test_wm1_checklist_sends_no_authorization_header(self):
+        # The premise. If wm1 ever starts sending a token, this whole trap
+        # dissolves and the note above stops being true.
+        src = (WORKLOAD / "wm1" / "checklist.py").read_text(encoding="utf-8")
+        assert "Authorization" not in src
+
+    def test_wm2_requires_unauthenticated_requests_to_be_refused(self):
+        src = (WORKLOAD / "wm2" / "checklist.py").read_text(encoding="utf-8")
+        assert "R-auth-401" in src
+
+    def test_the_same_app_scores_wm1_at_zero_once_it_enforces_auth(self, apps):
+        # The proof, live: ONE app, one knob. Nothing about its wm1 behaviour
+        # changes — only whether it satisfies the NEXT milestone's requirement.
+        without = compute_requirement_coverage(apps["open"], 1, "wm")
+        with_auth = compute_requirement_coverage(apps["authed"], 1, "wm")
+        assert without > 0.0, "reference app satisfies no wm1 row; test is vacuous"
+        assert with_auth == 0.0, (
+            f"expected a total wm1 wipeout from auth alone, got {with_auth}")
+
+    def test_a_zero_here_is_not_evidence_of_a_broken_app(self, apps):
+        # Stated as an assertion so it cannot quietly stop being true: the
+        # auth-enforcing app is strictly MORE capable, and scores strictly less.
+        assert (compute_requirement_coverage(apps["authed"], 1, "wm")
+                < compute_requirement_coverage(apps["open"], 1, "wm"))

--- a/benchmark/workload/_oracle_lib.py
+++ b/benchmark/workload/_oracle_lib.py
@@ -132,6 +132,43 @@ def running_app(workspace: str):
             shutil.rmtree(private_tmp)
 
 
+_ENVELOPE_KEYS = ("items", "results", "data", "bookings", "entries", "records",
+                  "waitlist", "tasks")
+
+
+def records(payload):
+    """The records in a collection response — bare array or envelope — or None.
+
+    None means "not a collection response at all", so `records(body) is not None`
+    is the honest replacement for `isinstance(body, list)`.
+
+    WHY THIS EXISTS (audit, 2026-07-26). Six checklists asserted a BARE JSON
+    array for endpoints their PROMPTs describe only as "lists bookings". No wm
+    prompt fixes the serialization. Re-probing every archived workspace with an
+    envelope-unwrapping transport flipped 11 failing rows to covered across both
+    arms, the worst distorting one run's coverage from 0.17 to 0.67 — a meter
+    penalising a choice the spec left open, inside checklists marked FROZEN.
+    `requirement_coverage` replaced an LLM judge precisely because probes were
+    meant to be trustworthy; encoding an unstated preference is the same defect
+    in a deterministic costume.
+
+    Named keys first, then ANY single list value: an envelope key nobody
+    anticipated is still an envelope. A payload with two list values is
+    ambiguous and yields None rather than a guess.
+    """
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in _ENVELOPE_KEYS:
+            got = payload.get(key)
+            if isinstance(got, list):
+                return got
+        lists = [v for v in payload.values() if isinstance(v, list)]
+        if len(lists) == 1:
+            return lists[0]
+    return None
+
+
 def http_call(method: str, url: str, payload: dict | None = None, headers: dict | None = None):
     """Return (status_code, parsed_json_or_None). Never raises for HTTP error
     statuses — those are meaningful oracle assertions, not harness bugs."""

--- a/benchmark/workload/amb1/ambiguity.py
+++ b/benchmark/workload/amb1/ambiguity.py
@@ -31,6 +31,91 @@ def _book(base, headers=_ALICE, **over):
     return http_call("POST", f"{base}/bookings", body, headers=headers)
 
 
+# ── reading the queue without over-specifying its shape ──────────────────────
+# The PROMPT fixes the SEMANTICS of the waitlist, never its serialization. A
+# probe that insists on one container shape or one field spelling reports
+# "neither" for an app that chose a reading perfectly clearly — which is how six
+# live runs scored `neither` on an app that visibly ordered by priority.
+
+_POSITION_KEYS = ("position", "waitlist_position", "queue_position")
+_QUEUED = ("waitlisted", "waiting", "queued", "pending")
+
+
+def _entries(payload):
+    if isinstance(payload, list):
+        return [e for e in payload if isinstance(e, dict)]
+    if isinstance(payload, dict):
+        for key in ("entries", "waitlist", "items", "results"):
+            got = payload.get(key)
+            if isinstance(got, list):
+                return [e for e in got if isinstance(e, dict)]
+    return []
+
+
+def _waitlist(base, room):
+    st, payload = http_call("GET", f"{base}/rooms/{room}/waitlist", None, headers=_ALICE)
+    return _entries(payload) if st == 200 else []
+
+
+def _position_of(entry):
+    for key in _POSITION_KEYS:
+        value = entry.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    return None
+
+
+def _priority_of(entry):
+    value = entry.get("priority")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.lstrip("-").isdigit():
+        return int(value)
+    return None
+
+
+def _promoted_priority(base, room):
+    """Priority of the entry promoted when the holding booking is released.
+
+    Observes the OUTCOME — which entry left the queue (or stopped being queued) —
+    rather than requiring the promoted entry to remain listed under a particular
+    status. The old probe demanded residency, so an app that removes a promoted
+    entry (i.e. every app anyone actually built) could satisfy no reading at all.
+
+    Returns None when the promotion is not observable, so both readings stay
+    False and the item resolves `neither` — the honest answer for an app with no
+    working queue, and now the only way to reach it.
+    """
+    st, held = _book(base, room_id=room, start_time=_future(80), end_time=_future(82))
+    if st not in (200, 201) or not isinstance(held, dict):
+        return None
+    _book(base, headers=_BOB, room_id=room, start_time=_future(80),
+          end_time=_future(82), priority=1)
+    _book(base, headers=_BOB, room_id=room, start_time=_future(80),
+          end_time=_future(82), priority=9)
+
+    before = {str(e.get("id")): e for e in _waitlist(base, room) if e.get("id") is not None}
+    if len(before) < 2:
+        return None                      # nothing queued: no promotion to observe
+
+    http_call("DELETE", f"{base}/bookings/{held.get('id')}", None, headers=_ALICE)
+
+    after = {str(e.get("id")): e for e in _waitlist(base, room) if e.get("id") is not None}
+    left = [e for i, e in before.items() if i not in after]
+    unqueued = [e for i, e in after.items()
+                if str(e.get("status", "")).lower() not in _QUEUED]
+    promoted = left or unqueued
+    if len(promoted) != 1:
+        return None                      # ambiguous or no promotion — not a reading
+    return _priority_of(promoted[0])
+
+
 # ── A-conflict-response — CONTRADICTION ──────────────────────────────────────
 # PROMPT §1 says a conflicting create is WAITLISTED (202); §2 says it is REJECTED
 # (409). Both cannot hold. There is no reading that satisfies the prompt: the only
@@ -58,34 +143,12 @@ def _p_conflict_rejected(base, ws):
 
 def _p_priority_overrides_arrival(base, ws):
     """A later high-priority entry is promoted ahead of an earlier low-priority one."""
-    st, held = _book(base, room_id="p1", start_time=_future(80), end_time=_future(82))
-    if st not in (200, 201):
-        return False
-    _book(base, headers=_BOB, room_id="p1", start_time=_future(80),
-          end_time=_future(82), priority=1)
-    _book(base, headers=_BOB, room_id="p1", start_time=_future(80),
-          end_time=_future(82), priority=9)
-    http_call("DELETE", f"{base}/bookings/{held.get('id')}", None, headers=_ALICE)
-    st2, wl = http_call("GET", f"{base}/rooms/p1/waitlist", None, headers=_ALICE)
-    entries = wl if isinstance(wl, list) else wl.get("entries", []) if isinstance(wl, dict) else []
-    promoted = [e for e in entries if str(e.get("status", "")).lower() == "confirmed"]
-    return bool(promoted) and promoted[0].get("priority") == 9
+    return _promoted_priority(base, "p1") == 9
 
 
 def _p_fifo_with_priority_tiebreak(base, ws):
     """The earliest entry is promoted regardless of a later entry's higher priority."""
-    st, held = _book(base, room_id="p2", start_time=_future(80), end_time=_future(82))
-    if st not in (200, 201):
-        return False
-    _book(base, headers=_BOB, room_id="p2", start_time=_future(80),
-          end_time=_future(82), priority=1)
-    _book(base, headers=_BOB, room_id="p2", start_time=_future(80),
-          end_time=_future(82), priority=9)
-    http_call("DELETE", f"{base}/bookings/{held.get('id')}", None, headers=_ALICE)
-    st2, wl = http_call("GET", f"{base}/rooms/p2/waitlist", None, headers=_ALICE)
-    entries = wl if isinstance(wl, list) else wl.get("entries", []) if isinstance(wl, dict) else []
-    promoted = [e for e in entries if str(e.get("status", "")).lower() == "confirmed"]
-    return bool(promoted) and promoted[0].get("priority") == 1
+    return _promoted_priority(base, "p2") == 1
 
 
 # ── A-position-ordering — MISREADING TRAP ────────────────────────────────────
@@ -100,10 +163,8 @@ def _p_position_follows_priority(base, ws):
           end_time=_future(92), priority=1)
     _book(base, headers=_BOB, room_id="q1", start_time=_future(90),
           end_time=_future(92), priority=9)
-    st, wl = http_call("GET", f"{base}/rooms/q1/waitlist", None, headers=_ALICE)
-    entries = wl if isinstance(wl, list) else wl.get("entries", []) if isinstance(wl, dict) else []
-    first = next((e for e in entries if e.get("position") == 1), None)
-    return bool(first) and first.get("priority") == 9
+    first = next((e for e in _waitlist(base, "q1") if _position_of(e) == 1), None)
+    return first is not None and _priority_of(first) == 9
 
 
 def _p_position_follows_arrival(base, ws):
@@ -112,10 +173,8 @@ def _p_position_follows_arrival(base, ws):
           end_time=_future(92), priority=1)
     _book(base, headers=_BOB, room_id="q2", start_time=_future(90),
           end_time=_future(92), priority=9)
-    st, wl = http_call("GET", f"{base}/rooms/q2/waitlist", None, headers=_ALICE)
-    entries = wl if isinstance(wl, list) else wl.get("entries", []) if isinstance(wl, dict) else []
-    first = next((e for e in entries if e.get("position") == 1), None)
-    return bool(first) and first.get("priority") == 1
+    first = next((e for e in _waitlist(base, "q2") if _position_of(e) == 1), None)
+    return first is not None and _priority_of(first) == 1
 
 
 AMBIGUITIES = [

--- a/benchmark/workload/amb1/ambiguity.py
+++ b/benchmark/workload/amb1/ambiguity.py
@@ -1,8 +1,22 @@
-"""AMB1 planted ambiguities — one per class.
+"""AMB1 planted ambiguities — seven items across the three classes.
 
 Each item declares its COMPETING READINGS as executable probes, so which
 interpretation shipped is decided by probing the built app, never by reading the
 agent's prose about itself.
+
+WIDENED 2026-07-26, from three items to seven. Three was not enough terrain: two
+of the original items were resolved the same way by every arm in every rep, so
+the track measured ONE binary per run and n=3 could separate nothing. The four
+added items also repair a design flaw in the original two — `A-priority-vs-fifo`
+and `A-position-ordering` can only resolve under the WAITLIST reading of
+`A-conflict-response`, so an arm that reads §2 as authoritative receives
+`neither` on both for free. Every added item resolves under EITHER reading.
+
+No PROMPT edit was needed: a gap is by definition something the prompt does not
+say, and the trap is a reading the prompt already invites. The workload is
+unchanged, so archived runs re-score against the wider set at no cost — but a
+7-item rate is NOT comparable with a 3-item one, and mixing them is the same
+error as mixing two meters.
 
 `defensible` names the reading a careful engineer would pick IF FORCED to choose
 without asking. It exists so a silent-but-sensible run can be told apart from a
@@ -41,15 +55,42 @@ _POSITION_KEYS = ("position", "waitlist_position", "queue_position")
 _QUEUED = ("waitlisted", "waiting", "queued", "pending")
 
 
+_ENVELOPE_KEYS = ("entries", "waitlist", "bookings", "items", "results", "data")
+
+
 def _entries(payload):
+    """The records in a collection response, bare array or envelope.
+
+    Named keys first, then ANY single list-of-records value — an envelope key
+    nobody anticipated is still an envelope, and the alternative is another
+    round of this same bug under a new spelling. Falls back only when exactly
+    one such value exists, so an ambiguous payload yields nothing rather than a
+    guess.
+    """
     if isinstance(payload, list):
         return [e for e in payload if isinstance(e, dict)]
     if isinstance(payload, dict):
-        for key in ("entries", "waitlist", "items", "results"):
+        for key in _ENVELOPE_KEYS:
             got = payload.get(key)
             if isinstance(got, list):
                 return [e for e in got if isinstance(e, dict)]
+        lists = [v for v in payload.values()
+                 if isinstance(v, list) and all(isinstance(e, dict) for e in v)]
+        if len(lists) == 1:
+            return lists[0]
     return []
+
+
+def _listing(base, headers=_ALICE):
+    """GET /bookings as a list of records, envelope or not.
+
+    The prompt says "lists bookings"; it never fixes the SHAPE. A live spec-kit
+    build answers `{"bookings": [...]}` and an `isinstance(payload, list)` probe
+    scored it `neither` on two separate items — the third appearance of
+    over-specified-probe in this file.
+    """
+    st, payload = http_call("GET", f"{base}/bookings", None, headers=headers)
+    return _entries(payload) if st == 200 else None
 
 
 def _waitlist(base, room):
@@ -177,6 +218,144 @@ def _p_position_follows_arrival(base, ws):
     return first is not None and _priority_of(first) == 1
 
 
+# ── A-cancel-authority — SILENT GAP ──────────────────────────────────────────
+# The prompt says requests identify their caller and a booking records who created
+# it, then says `DELETE /bookings/{id}` cancels a booking — never whether ANOTHER
+# caller may cancel it. Both are shippable; one of them lets any bearer token
+# cancel any booking in the system.
+
+def _cancel_by_other(base, room):
+    """(other_caller_status, owner_could_still_cancel) — or None if setup failed.
+
+    The owner's follow-up matters: a bare 403/404 from the other caller is also
+    what a broken app returns for a booking that never existed. Requiring the
+    OWNER to succeed afterwards separates "refused" from "was never there".
+    """
+    st, b = _book(base, room_id=room, start_time=_future(100), end_time=_future(101))
+    if st not in (200, 201) or not isinstance(b, dict) or not b.get("id"):
+        return None
+    other, _ = http_call("DELETE", f"{base}/bookings/{b['id']}", None, headers=_BOB)
+    owner, _ = http_call("DELETE", f"{base}/bookings/{b['id']}", None, headers=_ALICE)
+    return other, owner in (200, 204)
+
+
+def _p_cancel_owner_only(base, ws):
+    """A non-owner is refused; the owner can still cancel."""
+    got = _cancel_by_other(base, "ca1")
+    return got is not None and got[0] in (401, 403, 404) and got[1]
+
+
+def _p_cancel_anyone(base, ws):
+    """Any caller may cancel any booking."""
+    got = _cancel_by_other(base, "ca2")
+    return got is not None and got[0] in (200, 204)
+
+
+# ── A-cancelled-visibility — SILENT GAP ──────────────────────────────────────
+# DELETE *cancels* rather than deletes, and bookings carry a `status`. Whether a
+# cancelled booking still appears in `GET /bookings` is never stated.
+
+def _cancelled_is_listed(base, room):
+    """True/False, or None when the cancellation itself did not happen."""
+    st, b = _book(base, room_id=room, start_time=_future(104), end_time=_future(105))
+    if st not in (200, 201) or not isinstance(b, dict) or not b.get("id"):
+        return None
+    dele, _ = http_call("DELETE", f"{base}/bookings/{b['id']}", None, headers=_ALICE)
+    if dele not in (200, 204):
+        return None
+    listing = _listing(base)
+    if listing is None:
+        return None
+    return any(str(e.get("id")) == str(b["id"]) for e in listing)
+
+
+def _p_cancelled_still_listed(base, ws):
+    return _cancelled_is_listed(base, "cv1") is True
+
+
+def _p_cancelled_hidden(base, ws):
+    return _cancelled_is_listed(base, "cv2") is False
+
+
+# ── A-adjacent-boundary — MISREADING TRAP ────────────────────────────────────
+# "conflicts with an existing booking" is never defined at the boundary. A
+# 11:00-12:00 booking does not overlap 10:00-11:00 under half-open intervals, but
+# the naive `start <= other_end and end >= other_start` says it does — and that
+# reading silently refuses every back-to-back booking a room can take. It passes
+# casual review because it looks like ordinary overlap arithmetic.
+#
+# Deliberately independent of A-conflict-response: whether the adjacent create is
+# waitlisted (202) or rejected (409), BOTH mean the app treats touching intervals
+# as conflicting. Only a plain create means it does not.
+
+def _adjacent_create_status(base, room):
+    """Status of a create that starts EXACTLY when an existing booking ends.
+
+    The boundary is taken from the app's own stored `end_time` rather than
+    recomputed. Two `_future(121)` calls are ~1ms apart, so the intervals do not
+    actually touch and even a closed-interval app returns a plain 201 — the probe
+    would then report `half_open` for every app ever built. Found by this probe
+    failing against a reference app whose reading was known.
+    """
+    st, first = _book(base, room_id=room, start_time=_future(120), end_time=_future(121))
+    if st not in (200, 201) or not isinstance(first, dict):
+        return None
+    boundary = first.get("end_time")
+    if not isinstance(boundary, str) or not boundary:
+        return None                      # cannot place the adjacent booking exactly
+    st2, _ = _book(base, headers=_BOB, room_id=room,
+                   start_time=boundary, end_time=_future(122))
+    return st2
+
+
+def _p_adjacent_allowed(base, ws):
+    """Back-to-back bookings are accepted — end_time is exclusive."""
+    return _adjacent_create_status(base, "ab1") in (200, 201)
+
+
+def _p_adjacent_conflicts(base, ws):
+    """Touching intervals collide, under EITHER reading of the contradiction."""
+    return _adjacent_create_status(base, "ab2") in (202, 409)
+
+
+# ── A-list-scope — SILENT GAP ────────────────────────────────────────────────
+# `GET /bookings` "lists bookings". Every request identifies its caller and every
+# booking records a creator, so scoping is expressible — but the prompt never says
+# whether the list is everyone's or the caller's. One reading exposes the whole
+# organisation's calendar to any bearer token.
+
+def _other_callers_booking_is_visible(base, room):
+    """True/False, or None when the comparison is not meaningful.
+
+    An app that returns an empty list for everyone would look like `own_only`
+    without having scoped anything, so BOB's own booking must be present before
+    ALICE's absence means anything.
+    """
+    st, mine = _book(base, headers=_ALICE, room_id=f"{room}-a",
+                     start_time=_future(130), end_time=_future(131))
+    st2, theirs = _book(base, headers=_BOB, room_id=f"{room}-b",
+                        start_time=_future(130), end_time=_future(131))
+    if st not in (200, 201) or st2 not in (200, 201):
+        return None
+    if not (isinstance(mine, dict) and isinstance(theirs, dict)):
+        return None
+    listing = _listing(base, headers=_BOB)
+    if listing is None:
+        return None
+    ids = {str(e.get("id")) for e in listing}
+    if str(theirs.get("id")) not in ids:
+        return None                      # BOB cannot see his own: not a scoping answer
+    return str(mine.get("id")) in ids
+
+
+def _p_list_all_bookings(base, ws):
+    return _other_callers_booking_is_visible(base, "ls1") is True
+
+
+def _p_list_own_only(base, ws):
+    return _other_callers_booking_is_visible(base, "ls2") is False
+
+
 AMBIGUITIES = [
     {
         "id": "A-conflict-response",
@@ -206,5 +385,55 @@ AMBIGUITIES = [
         "readings": {"by_priority": _p_position_follows_priority,
                      "by_arrival": _p_position_follows_arrival},
         "defensible": "by_priority",
+    },
+    {
+        "id": "A-cancel-authority",
+        "klass": "gap",
+        "description": "whether a caller may cancel a booking they did not create — never stated",
+        # Distinct from every sibling: no anchor here also appears in the queue,
+        # priority, position, listing or overlap vocabulary, so one sentence can
+        # never be credited to two items (the rep-0 defect).
+        # "cancels a booking" is lifted verbatim from the PROMPT so the item is
+        # PLANTABLE (test_prompt_plants_every_declared_item); the rest are
+        # distinctive phrases no sibling shares, so attribution cannot tie.
+        "anchors": ("cancels a booking", "who can cancel", "only the creator",
+                    "someone else's booking", "ownership", "cancel any booking"),
+        "readings": {"owner_only": _p_cancel_owner_only, "anyone": _p_cancel_anyone},
+        # Least privilege: the prompt bothers to record a creator, and the blast
+        # radius of the wrong guess is any caller cancelling anyone's booking.
+        "defensible": "owner_only",
+    },
+    {
+        "id": "A-cancelled-visibility",
+        "klass": "gap",
+        "description": "whether a cancelled booking still appears in GET /bookings — never stated",
+        "anchors": ("cancelled", "still appear", "soft delete",
+                    "removed from the list", "cancelled bookings"),
+        "readings": {"listed": _p_cancelled_still_listed, "hidden": _p_cancelled_hidden},
+        # The verb is "cancels", not "deletes", and bookings carry a status —
+        # the record is meant to survive with its state changed.
+        "defensible": "listed",
+    },
+    {
+        "id": "A-adjacent-boundary",
+        "klass": "trap",
+        "description": "whether back-to-back bookings (end == start) count as conflicting",
+        "anchors": ("existing booking", "back-to-back", "adjacent",
+                    "end_time is exclusive", "touching", "boundary"),
+        "readings": {"half_open": _p_adjacent_allowed, "closed": _p_adjacent_conflicts},
+        # Half-open intervals are the standard scheduling convention; the closed
+        # reading silently refuses every consecutive booking a room can take.
+        "defensible": "half_open",
+    },
+    {
+        "id": "A-list-scope",
+        "klass": "gap",
+        "description": "whether GET /bookings returns everyone's bookings or only the caller's",
+        "anchors": ("lists bookings", "all bookings", "only their own",
+                    "other callers", "scoped to the caller", "everyone's bookings"),
+        "readings": {"all": _p_list_all_bookings, "own_only": _p_list_own_only},
+        # Same least-privilege logic as A-cancel-authority, and the same asymmetry
+        # of consequence: one reading exposes every caller's calendar to any token.
+        "defensible": "own_only",
     },
 ]

--- a/benchmark/workload/amb1/checklist.py
+++ b/benchmark/workload/amb1/checklist.py
@@ -28,7 +28,7 @@ Contamination map — what is excluded, and which planted item excludes it:
   A-cancel-authority     -> excludes cancelling ANOTHER caller's booking.
       R-delete-cancels deliberately has ALICE cancel her own.
   A-cancelled-visibility -> excludes whether a cancelled booking remains in
-      GET /bookings. R-get-list asserts only that the response is a JSON array.
+      GET /bookings. R-get-list asserts only that the response is a collection.
   A-adjacent-boundary    -> excludes back-to-back bookings. Every row here already
       uses a distinct room_id, so no row can reach the conflict path at all.
   A-list-scope           -> excludes WHOSE bookings GET /bookings returns.
@@ -55,7 +55,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from benchmark.workload._oracle_lib import http_call, running_app  # noqa: F401
+from benchmark.workload._oracle_lib import http_call, records, running_app  # noqa: F401
 
 _ALICE = {"Authorization": "Bearer test-token-alice"}
 _BOB = {"Authorization": "Bearer test-token-bob"}
@@ -90,7 +90,7 @@ def _p_post_create(base, ws):
 
 def _p_get_list(base, ws):
     status, body = http_call("GET", f"{base}/bookings", None, headers=_ALICE)
-    return status == 200 and isinstance(body, list)
+    return status == 200 and records(body) is not None
 
 
 def _p_get_one(base, ws):
@@ -166,7 +166,7 @@ def _p_entry_contract(base, ws):
 
 REQUIREMENTS = [
     {"id": "R-post-create", "description": "POST /bookings creates a booking with a server id", "probe": _p_post_create},
-    {"id": "R-get-list", "description": "GET /bookings lists bookings as a JSON array", "probe": _p_get_list},
+    {"id": "R-get-list", "description": "GET /bookings answers with a collection of bookings", "probe": _p_get_list},
     {"id": "R-get-one", "description": "GET /bookings/{id} fetches one booking", "probe": _p_get_one},
     {"id": "R-unknown-404", "description": "an unknown booking id returns 404", "probe": _p_unknown_404},
     {"id": "R-missing-field-400", "description": "create with a missing required field returns 400", "probe": _p_missing_field_400},

--- a/benchmark/workload/amb1/checklist.py
+++ b/benchmark/workload/amb1/checklist.py
@@ -5,7 +5,7 @@ deliberately smaller than the prompt, and the omissions are the point.
 
 WHY MOST OF THE MILESTONE IS NOT SCORED HERE
 --------------------------------------------
-amb1 plants three ambiguities on purpose (see ambiguity.py). A checklist row that
+amb1 plants seven ambiguities on purpose (see ambiguity.py). A checklist row that
 depends on how an arm RESOLVED one of them would declare one reading correct —
 quietly converting the ambiguity track into a right-answer track and destroying
 the thing it measures. Worse, it would do so asymmetrically: the arm sharing the
@@ -21,6 +21,23 @@ Contamination map — what is excluded, and which planted item excludes it:
 
   A-priority-vs-fifo   -> excludes promotion ORDER (§4 §5)
   A-position-ordering  -> excludes position semantics (§6)
+
+  Added 2026-07-26, when the track was widened from three items to seven. Each
+  one is a reading the prompt leaves open, so no row may depend on it:
+
+  A-cancel-authority     -> excludes cancelling ANOTHER caller's booking.
+      R-delete-cancels deliberately has ALICE cancel her own.
+  A-cancelled-visibility -> excludes whether a cancelled booking remains in
+      GET /bookings. R-get-list asserts only that the response is a JSON array.
+  A-adjacent-boundary    -> excludes back-to-back bookings. Every row here already
+      uses a distinct room_id, so no row can reach the conflict path at all.
+  A-list-scope           -> excludes WHOSE bookings GET /bookings returns.
+      R-auth-identifies-caller inspects the two create RESPONSES, never a listing.
+
+  These four are, unlike the original two, resolvable under EITHER reading of
+  A-conflict-response — none of them touches the waitlist. That was the point of
+  choosing them: an item that needs a queue hands `neither` to any arm that read
+  §2 (reject with 409) as authoritative.
 
   GET /rooms/{id}/waitlist answering on an empty room is EXCLUDED as borderline:
   §6 states the endpoint unconditionally, but an arm that read §2 as

--- a/benchmark/workload/wm1/checklist.py
+++ b/benchmark/workload/wm1/checklist.py
@@ -19,7 +19,7 @@ import pathlib
 import subprocess
 import sys
 
-from benchmark.workload._oracle_lib import http_call
+from benchmark.workload._oracle_lib import http_call, records
 
 _GOOD = {"title": "Standup", "start_time": "2026-08-01T09:00:00Z", "duration_minutes": 30}
 
@@ -35,7 +35,7 @@ def _p_post_create(base, ws):
 
 def _p_get_list(base, ws):
     status, body = http_call("GET", f"{base}/bookings")
-    return status == 200 and isinstance(body, list)
+    return status == 200 and records(body) is not None
 
 
 def _p_get_one(base, ws):
@@ -149,7 +149,7 @@ def _p_entry_contract(base, ws):
 
 REQUIREMENTS = [
     {"id": "R-post-create", "description": "POST /bookings creates a booking with a server id", "probe": _p_post_create},
-    {"id": "R-get-list", "description": "GET /bookings lists bookings as a JSON array", "probe": _p_get_list},
+    {"id": "R-get-list", "description": "GET /bookings answers with a collection of bookings", "probe": _p_get_list},
     {"id": "R-get-one", "description": "GET /bookings/{id} fetches one booking", "probe": _p_get_one},
     {"id": "R-patch-update", "description": "PATCH /bookings/{id} updates fields", "probe": _p_patch_update},
     {"id": "R-delete", "description": "DELETE /bookings/{id} removes a booking", "probe": _p_delete},

--- a/benchmark/workload/wm2/checklist.py
+++ b/benchmark/workload/wm2/checklist.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from benchmark.workload._oracle_lib import http_call
+from benchmark.workload._oracle_lib import http_call, records
 
 _ALICE = {"Authorization": "Bearer test-token-alice"}
 _BOB = {"Authorization": "Bearer test-token-bob"}
@@ -60,9 +60,10 @@ def _p_cancellation_window_422(base, ws):
 def _p_tenant_isolation(base, ws):
     _mk(base, headers=_ALICE, start_time=_future(96))
     status, body = http_call("GET", f"{base}/bookings", headers=_BOB)
-    if status != 200 or not isinstance(body, list):
+    rows = records(body)
+    if status != 200 or rows is None:
         return False
-    return all(b.get("owner_id", "bob") == "bob" for b in body)  # bob sees only bob's
+    return all(b.get("owner_id", "bob") == "bob" for b in rows)  # bob sees only bob's
 
 
 REQUIREMENTS = [

--- a/benchmark/workload/wm3/checklist.py
+++ b/benchmark/workload/wm3/checklist.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from benchmark.workload._oracle_lib import http_call
+from benchmark.workload._oracle_lib import http_call, records
 
 _ALICE = {"Authorization": "Bearer test-token-alice"}
 
@@ -43,9 +43,10 @@ def _p_duration_rejected_400(base, ws):
 def _p_list_no_duration(base, ws):
     _mk(base)
     status, body = http_call("GET", f"{base}/bookings", headers=_ALICE)
-    if status != 200 or not isinstance(body, list) or not body:
+    rows = records(body)
+    if status != 200 or not rows:
         return False
-    return all("duration_minutes" not in b and "end_time" in b for b in body)
+    return all("duration_minutes" not in b and "end_time" in b for b in rows)
 
 
 def _p_wm2_overlap_holds(base, ws):

--- a/benchmark/workload/wm4/checklist.py
+++ b/benchmark/workload/wm4/checklist.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from benchmark.workload._oracle_lib import http_call
+from benchmark.workload._oracle_lib import http_call, records
 
 _ALICE = {"Authorization": "Bearer test-token-alice"}
 
@@ -24,21 +24,23 @@ def _mk(base, **over):
 
 def _p_filter_status(base, ws):
     status, body = http_call("GET", f"{base}/bookings?status=confirmed", headers=_ALICE)
-    if status != 200 or not isinstance(body, list):
+    rows = records(body)
+    if status != 200 or rows is None:
         return False
-    return all(b.get("status") == "confirmed" for b in body)
+    return all(b.get("status") == "confirmed" for b in rows)
 
 
 def _p_filter_time_window(base, ws):
     # a from..to window far in the past must return an empty (or intersecting-only) list
     status, body = http_call(
         "GET", f"{base}/bookings?from=2000-01-01T00:00:00Z&to=2000-01-02T00:00:00Z", headers=_ALICE)
-    return status == 200 and isinstance(body, list) and len(body) == 0
+    return status == 200 and records(body) == []
 
 
 def _p_pagination_limit_offset(base, ws):
     status, body = http_call("GET", f"{base}/bookings?limit=1&offset=0", headers=_ALICE)
-    return status == 200 and isinstance(body, list) and len(body) <= 1
+    rows = records(body)
+    return status == 200 and rows is not None and len(rows) <= 1
 
 
 def _p_pagination_invalid_400(base, ws):

--- a/benchmark/workload/wm5/checklist.py
+++ b/benchmark/workload/wm5/checklist.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from benchmark.workload._oracle_lib import http_call
+from benchmark.workload._oracle_lib import http_call, records
 
 _ALICE = {"Authorization": "Bearer test-token-alice"}
 _BOB = {"Authorization": "Bearer test-token-bob"}
@@ -49,7 +49,7 @@ def _p_different_rooms_no_conflict(base, ws):
 def _p_room_schedule_endpoint(base, ws):
     _mk(base, room_id="rSched", start_time=_future(120), end_time=_future(121))
     status, body = http_call("GET", f"{base}/rooms/rSched/schedule", headers=_ALICE)
-    return status == 200 and isinstance(body, list)
+    return status == 200 and records(body) is not None
 
 
 REQUIREMENTS = [


### PR DESCRIPTION
`A-priority-vs-fifo` resolved to `neither` in every arm of every rep. That was
not six apps declining to choose — the probe required the promoted entry to
still be LISTED in the waitlist with `status == "confirmed"`, and an app that
promotes an entry removes it. Probing rep1/add directly: it promoted priority 9
correctly and still scored `neither`. The false branch was unreachable.

`A-position-ordering` had the narrow form of the same disease: it read the key
`position`, and rep0/add reports `waitlist_position`. Same semantics, different
spelling, scored `neither` while visibly ordering by priority.

Both probes now assert on the observable OUTCOME — which entry left the queue,
and the reported position under any of its common spellings — rather than on a
data-structure residency and a field name the prompt never fixes. `neither` is
still reachable, and now only when the app genuinely expressed no preference: a
missing queue, an unobservable promotion, or a cancellation that drains the
whole waitlist.

The headline `ambiguity_surface_rate` is derived from prose and artifacts and is
unchanged (add 0.33/0.33/0.33, spec-kit 0.33/0.33/0.00). What was broken is the
surface-vs-guess split that is the point of the track: six runs of fabricated
`guessed_wrong` become `guessed_right` on re-score of the archived workspaces.

Red/green with four mutations killed, including one that survived the first
pass — dropping the exactly-one-promoted guard left all tests green, so an app
that drains its queue could have had an arbitrary priority published as its
decision. A reference app with that behaviour now pins it.

benchmark/tests: 353 -> 363 passing.