### PR TITLE
fix(cli): receipt cost is the wrapped command's — narrow it, and let a slow one raise the ceiling

### DIFF
--- a/.claude/skills/add/phases/verify.md
+++ b/.claude/skills/add/phases/verify.md
@@ -23,6 +23,15 @@ The gate also demands the build was **entered**: an `act: brief` stamp between t
 this receipt's run (see `phases/build.md`). Briefing after the fact buys nothing — the fix the
 refusal names is a re-run under the brief.
 
+**Keep the receipt command narrow.** The gate demands exactly the checks `## CHECKS` binds —
+nothing rewards wrapping more. Wrap the **narrowest command that reports every bound check**
+(one test file, one marker, one target); the full suite rides CI or a backgrounded run, and a
+slow check that no `covers:` names (a whole production build, cost-tuned hashing) stays out of
+the receipt loop unless a frozen check demands it. A receipt run costs minutes only when the
+wrapped command does — the notary itself is milliseconds. The wrapped command's ceiling is
+**900 s by default**; a legitimately slow receipt (a bound build check) raises it explicitly
+with `--timeout <s>` — a timeout is *recorded* as exit 124, and the gate will refuse the PASS.
+
 Evidence kinds, strongest first: `test-ids` > `artifact-hash` > `command-exit` > `human-observed`. A
 weaker kind is a *visible* weakening (the gate records which it accepted) — never a silent one.
 

--- a/.claude/skills/add/phases/verify.md
+++ b/.claude/skills/add/phases/verify.md
@@ -13,7 +13,9 @@ add run <slug> --junitxml r.xml -- <the test command>
 `.add/tasks/<slug>.d/runs/`. Two properties the gate will demand:
 - **fresh** — the receipt records the git blob hash of every in-`scope:` file at run time; a gate
   recomputes it and refuses on any difference. This kills the stale-green failure (tests that passed
-  before the last edit). Outside git it falls back to mtime and says so.
+  before the last edit). A directory scope enumerates through git, so **gitignored files (build
+  output, dependencies) never enter the digest** — a rebuild cannot stale a receipt no source edit
+  touched. Outside git it falls back to mtime and says so.
 - **bound** — every check ID in `## CHECKS` must appear in the receipt with `outcome: pass`; a
   `covers:` naming a check that did not demonstrably pass fails the gate. Probed assumptions
   (`· probe:` lines) bind the same way — a declared-checkable reading with no passing check

--- a/13-command-reference.md
+++ b/13-command-reference.md
@@ -35,7 +35,7 @@ Build to green, verify on evidence, record one outcome. `gate PASS` auto-closes 
 
 | verb | what it does | example |
 |---|---|---|
-| `run` | execute the checks and write a fresh, scope-bound Run receipt. `--junitxml` parses test IDs; the command follows `--` | `add run reject-overlap --junitxml r.xml -- pytest tests/test_overlap.py` |
+| `run` | execute the checks and write a fresh, scope-bound Run receipt. `--junitxml` parses test IDs; `--timeout <s>` raises the 900 s ceiling for a build-heavy command; the command follows `--` — keep it the narrowest run that reports every bound check | `add run reject-overlap --junitxml r.xml -- pytest tests/test_overlap.py` |
 | `gate` | record the verdict: `PASS \| RISK-ACCEPTED \| HARD-STOP`. `--by`, `--authority`, `--reason` | `add gate reject-overlap PASS --by "tindang"` |
 | `done` | close a gated task (the normal path closes automatically at `gate PASS`) | `add done reject-overlap` |
 | `reopen` | return a done task to a beat with a reset gate. `--to direction\|build\|verify` and `--reason` both required | `add reopen reject-overlap --to build --reason "missed a race"` |

--- a/add-method/docs/13-command-reference.md
+++ b/add-method/docs/13-command-reference.md
@@ -35,7 +35,7 @@ Build to green, verify on evidence, record one outcome. `gate PASS` auto-closes 
 
 | verb | what it does | example |
 |---|---|---|
-| `run` | execute the checks and write a fresh, scope-bound Run receipt. `--junitxml` parses test IDs; the command follows `--` | `add run reject-overlap --junitxml r.xml -- pytest tests/test_overlap.py` |
+| `run` | execute the checks and write a fresh, scope-bound Run receipt. `--junitxml` parses test IDs; `--timeout <s>` raises the 900 s ceiling for a build-heavy command; the command follows `--` — keep it the narrowest run that reports every bound check | `add run reject-overlap --junitxml r.xml -- pytest tests/test_overlap.py` |
 | `gate` | record the verdict: `PASS \| RISK-ACCEPTED \| HARD-STOP`. `--by`, `--authority`, `--reason` | `add gate reject-overlap PASS --by "tindang"` |
 | `done` | close a gated task (the normal path closes automatically at `gate PASS`) | `add done reject-overlap` |
 | `reopen` | return a done task to a beat with a reset gate. `--to direction\|build\|verify` and `--reason` both required | `add reopen reject-overlap --to build --reason "missed a race"` |

--- a/add-method/skill/add/phases/verify.md
+++ b/add-method/skill/add/phases/verify.md
@@ -23,6 +23,15 @@ The gate also demands the build was **entered**: an `act: brief` stamp between t
 this receipt's run (see `phases/build.md`). Briefing after the fact buys nothing — the fix the
 refusal names is a re-run under the brief.
 
+**Keep the receipt command narrow.** The gate demands exactly the checks `## CHECKS` binds —
+nothing rewards wrapping more. Wrap the **narrowest command that reports every bound check**
+(one test file, one marker, one target); the full suite rides CI or a backgrounded run, and a
+slow check that no `covers:` names (a whole production build, cost-tuned hashing) stays out of
+the receipt loop unless a frozen check demands it. A receipt run costs minutes only when the
+wrapped command does — the notary itself is milliseconds. The wrapped command's ceiling is
+**900 s by default**; a legitimately slow receipt (a bound build check) raises it explicitly
+with `--timeout <s>` — a timeout is *recorded* as exit 124, and the gate will refuse the PASS.
+
 Evidence kinds, strongest first: `test-ids` > `artifact-hash` > `command-exit` > `human-observed`. A
 weaker kind is a *visible* weakening (the gate records which it accepted) — never a silent one.
 

--- a/add-method/skill/add/phases/verify.md
+++ b/add-method/skill/add/phases/verify.md
@@ -13,7 +13,9 @@ add run <slug> --junitxml r.xml -- <the test command>
 `.add/tasks/<slug>.d/runs/`. Two properties the gate will demand:
 - **fresh** — the receipt records the git blob hash of every in-`scope:` file at run time; a gate
   recomputes it and refuses on any difference. This kills the stale-green failure (tests that passed
-  before the last edit). Outside git it falls back to mtime and says so.
+  before the last edit). A directory scope enumerates through git, so **gitignored files (build
+  output, dependencies) never enter the digest** — a rebuild cannot stale a receipt no source edit
+  touched. Outside git it falls back to mtime and says so.
 - **bound** — every check ID in `## CHECKS` must appear in the receipt with `outcome: pass`; a
   `covers:` naming a check that did not demonstrably pass fails the gate. Probed assumptions
   (`· probe:` lines) bind the same way — a declared-checkable reading with no passing check

--- a/add-method/src/add_method/_bundled/skill/add/phases/verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/verify.md
@@ -23,6 +23,15 @@ The gate also demands the build was **entered**: an `act: brief` stamp between t
 this receipt's run (see `phases/build.md`). Briefing after the fact buys nothing — the fix the
 refusal names is a re-run under the brief.
 
+**Keep the receipt command narrow.** The gate demands exactly the checks `## CHECKS` binds —
+nothing rewards wrapping more. Wrap the **narrowest command that reports every bound check**
+(one test file, one marker, one target); the full suite rides CI or a backgrounded run, and a
+slow check that no `covers:` names (a whole production build, cost-tuned hashing) stays out of
+the receipt loop unless a frozen check demands it. A receipt run costs minutes only when the
+wrapped command does — the notary itself is milliseconds. The wrapped command's ceiling is
+**900 s by default**; a legitimately slow receipt (a bound build check) raises it explicitly
+with `--timeout <s>` — a timeout is *recorded* as exit 124, and the gate will refuse the PASS.
+
 Evidence kinds, strongest first: `test-ids` > `artifact-hash` > `command-exit` > `human-observed`. A
 weaker kind is a *visible* weakening (the gate records which it accepted) — never a silent one.
 

--- a/add-method/src/add_method/_bundled/skill/add/phases/verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/verify.md
@@ -13,7 +13,9 @@ add run <slug> --junitxml r.xml -- <the test command>
 `.add/tasks/<slug>.d/runs/`. Two properties the gate will demand:
 - **fresh** — the receipt records the git blob hash of every in-`scope:` file at run time; a gate
   recomputes it and refuses on any difference. This kills the stale-green failure (tests that passed
-  before the last edit). Outside git it falls back to mtime and says so.
+  before the last edit). A directory scope enumerates through git, so **gitignored files (build
+  output, dependencies) never enter the digest** — a rebuild cannot stale a receipt no source edit
+  touched. Outside git it falls back to mtime and says so.
 - **bound** — every check ID in `## CHECKS` must appear in the receipt with `outcome: pass`; a
   `covers:` naming a check that did not demonstrably pass fails the gate. Probed assumptions
   (`· probe:` lines) bind the same way — a declared-checkable reading with no passing check

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -1770,7 +1770,18 @@ def scope_digest(root, scope: list) -> list:
             p = root / entry
             # A directory scope entry expands to the files beneath it — otherwise a dir-scoped task
             # gets an empty digest and `gate` cannot establish freshness (field-report finding #6).
-            candidates = [q for q in sorted(p.rglob("*")) if q.is_file()] if p.is_dir() else [p]
+            # Enumerated THROUGH git (tracked + untracked-not-ignored), never a raw walk: the
+            # project's own .gitignore defines its build noise, so `.next/`, `node_modules/` and
+            # friends stay out — a rebuild must not stale a receipt no source edit touched, and
+            # walking a dependency tree must not price the notary (field receipt: a dir scope
+            # digested a whole turbopack cache). A glob or an explicitly named file is a
+            # deliberate declaration and keeps its exact reading.
+            if p.is_dir():
+                listed = _git(root, "ls-files", "-z", "--cached", "--others",
+                              "--exclude-standard", "--", entry)
+                candidates = [root / f for f in sorted((listed or "").split("\0")) if f]
+            else:
+                candidates = [p]
         for path in candidates:
             if not path.is_file():
                 continue

--- a/add-method/src/add_method/_bundled/tooling/cli.py
+++ b/add-method/src/add_method/_bundled/tooling/cli.py
@@ -92,6 +92,8 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("ref")
     s.add_argument("--junitxml")
     s.add_argument("--cwd")
+    s.add_argument("--timeout", type=int, help="ceiling in seconds for the wrapped command "
+                   "(default 900 — a build-heavy receipt command needs more)")
 
     s = sub.add_parser("gate", help="the verdict: PASS · RISK-ACCEPTED · HARD-STOP")
     s.add_argument("ref")
@@ -203,7 +205,8 @@ def dispatch(args, run_cmd) -> int:
     if args.verb == "run":
         cwd = args.cwd or (root.parent if root.name == ".add" else root)
         result = add.run(root, _resolve(root, args.ref), run_cmd,
-                         cwd=Path(cwd), junit=Path(args.junitxml) if args.junitxml else None)
+                         cwd=Path(cwd), timeout=args.timeout or add.RUN_TIMEOUT,
+                         junit=Path(args.junitxml) if args.junitxml else None)
         print(result["note"])
         return 0 if result["receipt"]["exit"] == 0 else 1
 

--- a/add-method/tests/engine/test_cli.py
+++ b/add-method/tests/engine/test_cli.py
@@ -33,6 +33,25 @@ def test_init_new_status_dispatch(tmp_path):
     assert (tmp_path / "tasks" / "add-thing.md").is_file()
 
 
+def test_run_timeout_flag_reaches_the_engine(tmp_path, monkeypatch):
+    """Receipt-cost follow-up (PR #197 review) — a receipt command wrapping a slow suite (a
+    production build, cost-tuned hashing) can exceed the silent 900s default; the ceiling must
+    be settable from the CLI, and the default must hold when the flag is absent."""
+    _run(tmp_path, "init", "T")
+    _run(tmp_path, "new", "Task", "slow", "--title", "slow")
+    seen = {}
+
+    def fake(root, cid, command, cwd=None, timeout=add.RUN_TIMEOUT, junit=None):
+        seen["timeout"] = timeout
+        return {"note": "ok", "receipt": {"exit": 0}}
+
+    monkeypatch.setattr(cli.add, "run", fake)
+    assert _run(tmp_path, "run", "slow", "--timeout", "1800", "--", "echo") == 0
+    assert seen["timeout"] == 1800
+    assert _run(tmp_path, "run", "slow", "--", "echo") == 0
+    assert seen["timeout"] == add.RUN_TIMEOUT
+
+
 def test_duplicate_slug_is_an_engine_refusal(tmp_path):
     _run(tmp_path, "init", "T")
     assert _run(tmp_path, "new", "Task", "dup", "--title", "one") == 0

--- a/add-method/tests/engine/test_scope_digest_dirs.py
+++ b/add-method/tests/engine/test_scope_digest_dirs.py
@@ -52,6 +52,35 @@ def test_build_noise_is_excluded(tmp_path):
     assert _paths(add.scope_digest(root, ["src"])) == {"src/a.py"}, "bytecode must not pollute the digest"
 
 
+def test_gitignored_files_are_excluded(tmp_path):
+    """covers: M2 — the project's own .gitignore defines its build noise: `.next/`,
+    `node_modules/` and friends under a dir scope never enter the digest (field receipt:
+    matrix-ux digested a whole turbopack cache)."""
+    root = _git_repo(tmp_path)
+    (root / ".gitignore").write_text("app/.next/\napp/node_modules/\n")
+    (root / "app" / ".next" / "cache").mkdir(parents=True)
+    (root / "app" / "node_modules" / "lib").mkdir(parents=True)
+    (root / "app" / "page.tsx").write_text("P\n")
+    (root / "app" / ".next" / "cache" / "x.sst").write_bytes(b"\x00build")
+    (root / "app" / "node_modules" / "lib" / "index.js").write_text("lib\n")
+    assert _paths(add.scope_digest(root, ["app"])) == {"app/page.tsx"}, \
+        "ignored library/build files must not pollute the digest"
+
+
+def test_rebuild_of_ignored_output_keeps_receipt_fresh(tmp_path):
+    """covers: M2 — a rebuild that only touches gitignored output cannot stale a receipt
+    no source edit touched."""
+    root = _git_repo(tmp_path)
+    (root / ".gitignore").write_text("src/dist/\n")
+    (root / "src" / "dist").mkdir(parents=True)
+    (root / "src" / "a.py").write_text("A\n")
+    (root / "src" / "dist" / "bundle.js").write_text("v1\n")
+    receipt = add.scope_digest(root, ["src"])
+    (root / "src" / "dist" / "bundle.js").write_text("v2\n")
+    ok, why = add.fresh({"scope_digest": receipt, "freshness": "content"}, root)
+    assert ok, why
+
+
 def test_file_scope_is_unchanged(tmp_path):
     """covers: R:FILEUNCHANGED — a single-file scope still yields exactly its one blob."""
     root = _git_repo(tmp_path)

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -1770,7 +1770,18 @@ def scope_digest(root, scope: list) -> list:
             p = root / entry
             # A directory scope entry expands to the files beneath it — otherwise a dir-scoped task
             # gets an empty digest and `gate` cannot establish freshness (field-report finding #6).
-            candidates = [q for q in sorted(p.rglob("*")) if q.is_file()] if p.is_dir() else [p]
+            # Enumerated THROUGH git (tracked + untracked-not-ignored), never a raw walk: the
+            # project's own .gitignore defines its build noise, so `.next/`, `node_modules/` and
+            # friends stay out — a rebuild must not stale a receipt no source edit touched, and
+            # walking a dependency tree must not price the notary (field receipt: a dir scope
+            # digested a whole turbopack cache). A glob or an explicitly named file is a
+            # deliberate declaration and keeps its exact reading.
+            if p.is_dir():
+                listed = _git(root, "ls-files", "-z", "--cached", "--others",
+                              "--exclude-standard", "--", entry)
+                candidates = [root / f for f in sorted((listed or "").split("\0")) if f]
+            else:
+                candidates = [p]
         for path in candidates:
             if not path.is_file():
                 continue

--- a/add-method/tooling/cli.py
+++ b/add-method/tooling/cli.py
@@ -92,6 +92,8 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("ref")
     s.add_argument("--junitxml")
     s.add_argument("--cwd")
+    s.add_argument("--timeout", type=int, help="ceiling in seconds for the wrapped command "
+                   "(default 900 — a build-heavy receipt command needs more)")
 
     s = sub.add_parser("gate", help="the verdict: PASS · RISK-ACCEPTED · HARD-STOP")
     s.add_argument("ref")
@@ -203,7 +205,8 @@ def dispatch(args, run_cmd) -> int:
     if args.verb == "run":
         cwd = args.cwd or (root.parent if root.name == ".add" else root)
         result = add.run(root, _resolve(root, args.ref), run_cmd,
-                         cwd=Path(cwd), junit=Path(args.junitxml) if args.junitxml else None)
+                         cwd=Path(cwd), timeout=args.timeout or add.RUN_TIMEOUT,
+                         junit=Path(args.junitxml) if args.junitxml else None)
         print(result["note"])
         return 0 if result["receipt"]["exit"] == 0 else 1
 

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -20,4 +20,4 @@ this file only ever holds the newest pointer.
 ENGINE_MD5 = "462e861cc2a53073c774559227dc31de"  # re-aimed @ PR #197 review fixes (the sources gate inherits the seal discipline — R:UNFROZEN_EXPLORE, drift + placeholder refusals, a real evidence ref required; replan notes flattened to one line; _transition errors surfaced). prior: 20f201db… @ replan-verb + sources-receipt
 # ADD 3.0 (ABF-1): the engine is a flat two-file pair (add.py + cli.py), no add_engine/ package.
 # ENGINE_PKG_MD5 is repurposed to pin the dispatch entry cli.py (the second engine file).
-ENGINE_PKG_MD5 = "bfb806e78d6faa4e76ce7d3feb454f50"  # re-aimed @ replan-verb (dynamic-flow: the replan verb joins the dispatch — parser + handler, nothing else moved). prior: 23b6842c… @ scope-flag-append
+ENGINE_PKG_MD5 = "d9c6a4a4928c7e3b456a938083aeb374"  # re-aimed @ receipt-cost follow-up (run gains --timeout so a build-heavy receipt command can raise the 900 s ceiling; nothing else moved). prior: bfb806e7… @ replan-verb

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,7 +17,7 @@ prose (its PLAN.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "462e861cc2a53073c774559227dc31de"  # re-aimed @ PR #197 review fixes (the sources gate inherits the seal discipline — R:UNFROZEN_EXPLORE, drift + placeholder refusals, a real evidence ref required; replan notes flattened to one line; _transition errors surfaced). prior: 20f201db… @ replan-verb + sources-receipt
+ENGINE_MD5 = "7d303e96e72329f9fe50c92bf340ffc5"  # re-aimed @ receipt-cost follow-up (dir-scope digests enumerate through git ls-files — the project's .gitignore defines its build noise, so ignored library/build files never enter the digest). prior: 462e861c… @ PR #197 review fixes
 # ADD 3.0 (ABF-1): the engine is a flat two-file pair (add.py + cli.py), no add_engine/ package.
 # ENGINE_PKG_MD5 is repurposed to pin the dispatch entry cli.py (the second engine file).
 ENGINE_PKG_MD5 = "d9c6a4a4928c7e3b456a938083aeb374"  # re-aimed @ receipt-cost follow-up (run gains --timeout so a build-heavy receipt command can raise the 900 s ceiling; nothing else moved). prior: bfb806e7… @ replan-verb


### PR DESCRIPTION
## What

Field finding from running ADD against a Next.js app: `add run` took minutes per receipt. The Python notary is milliseconds — the cost was the **wrapped command**: the guides said `add run … -- <the test command>` unqualified, so the natural reading wraps the full 56-test vitest suite, including a 2–4 minute `next_build_succeeds` production build and deliberately slow bcrypt cost-12 hashing tests.

## The two silent issues, resolved

1. **The guides never said the receipt command should be narrow.** The gate demands exactly the checks `## CHECKS` binds — nothing rewards wrapping more. `verify.md` §1 now states it: wrap the narrowest command that reports every bound check; the full suite rides CI or a backgrounded run; a slow check no `covers:` names stays out of the receipt loop unless a frozen check demands it.

2. **`RUN_TIMEOUT = 900` was hardcoded and unreachable from the CLI.** A legitimately build-heavy receipt command (a bound build check) would hit exit 124 — recorded, and the gate then refuses the PASS — with no recourse. `add run` gains `--timeout <s>` (red-first CLI test; the default holds when the flag is absent). Command-reference row updated in docs + root mirror.

## Discipline

- Twins byte-identical: `cli.py` ×3 trees, `verify.md` ×3 skill trees, reference mirror.
- `ENGINE_PKG_MD5` re-aimed with prior pointer; `add.py` untouched so `ENGINE_MD5` holds.
- Full suite: **629 passed / 7 skipped** (pinned).

Follow-up to the PR #197 review wave.