### PR TITLE
feat(skill): all-domain evidence — the trust spine, reachable from any domain

### DIFF
--- a/.add/milestones/all-domain-evidence.md
+++ b/.add/milestones/all-domain-evidence.md
@@ -1,7 +1,7 @@
 ---
 type: Milestone
 title: All-domain evidence — the trust spine, reachable from any domain
-status: direction
+status: done
 generated: { by: add/3.1.0, at: 2026-08-12 }
 verified: []
 advised_by: method-steward
@@ -24,12 +24,25 @@ risks:
   - `.add/personas/method-steward.md` still pins SKILL.md at 150; the real pin is 176 (re-pinned at 3.1.0, human call) — a stale persona will reject a conforming plan
 
 ## EXIT
-- [ ] a non-code domain task earns `kind: test-ids` with `covers:`-bound checks, proved by a dogfood test that runs the recipe end-to-end — never by prose   (← domain-evidence-recipe)
-- [ ] every evidence rung the skill documents is one the engine can actually stamp   (← ladder-honesty)
-- [ ] `SKILL.md` ≤ 176 lines and total skill surface ≤ 1500 after every task   (← skill-pointer-truth)
-- [ ] no floor sentence reworded and no floor name introduced outside `security · data · architecture`   (← domain-evidence-recipe)
-- [ ] the three skill trees stay byte-identical   (← skill-pointer-truth)
-- [ ] the routing index reaches finance/legal/academic at a pinned floor   (← corpus-depth)
+- [x] a non-code domain task earns `kind: test-ids` with `covers:`-bound checks, proved by a dogfood test that runs the recipe end-to-end — never by prose   (← domain-evidence-recipe)
+- [x] every evidence rung the skill documents is one the engine can actually stamp   (← ladder-honesty)
+- [x] `SKILL.md` ≤ 176 lines and total skill surface ≤ 1500 after every task   (← skill-pointer-truth)
+- [x] no floor sentence reworded and no floor name introduced outside `security · data · architecture`   (← domain-evidence-recipe)
+- [x] the three skill trees stay byte-identical   (← skill-pointer-truth)
+- [x] the routing index reaches every agent-bearing division at a pinned floor, finance and academic
+      named explicitly   (← corpus-depth)
+      CORRECTED at close: this read "finance/legal/academic", written at intake on the belief that
+      those three were thin. `legal` was never a division — the corpus ships 18 and legal is not one;
+      it lives inside `support-legal-compliance-checker.md` and `specialized/data-privacy-officer.md`.
+      The wording was corrected to what is true, not relaxed to what passed: the check pins EVERY
+      agent-bearing division, which is stricter than the three it named.
 
 ## CLOSE
-evidence: <one row per task>
+evidence:
+- domain-evidence-recipe — runs/3.md · 10 referents bound · PASS at plan authority (architecture floor)
+- receipt-artifact-leak  — runs/3.md · 4 referents bound · PASS
+- skill-pointer-truth    — runs/1.md · 8 referents bound · PASS first attempt, no refusals
+- ladder-honesty         — runs/1.md · 6 referents bound · PASS
+- corpus-depth           — runs/1.md · 5 referents bound · PASS
+suite: 663 passed, 7 skipped (647 at milestone start). SKILL.md 172/176 · surface 1352/1500.
+engine bytes touched: NONE — the constraint held for all five tasks.

--- a/.add/milestones/all-domain-evidence.md
+++ b/.add/milestones/all-domain-evidence.md
@@ -1,0 +1,35 @@
+---
+type: Milestone
+title: All-domain evidence — the trust spine, reachable from any domain
+status: direction
+generated: { by: add/3.1.0, at: 2026-08-12 }
+verified: []
+advised_by: method-steward
+---
+## CARD
+goal: a finance, research or ops task earns the same bound `test-ids` receipt a code task does — with no engine change
+why: the mechanism already works and nobody knows it. Proved on a live reconciliation node (materiality Must + citation Reject, checker in project space): `kind: test-ids`, both `covers:` referents bound, `freshness: content` blob-digested on a JSON data file, and BOTH refusals fired — stale data and a blown threshold. What is missing is that nothing in the skill tells an agent it may WRITE a checker instead of FIND a runner. The gap is documentation, not capability — so the honest fix is ~61 lines of skill surface, not an evidence-adapter engine feature.
+next: add freeze all-domain-evidence
+
+## SCOPE
+In:  `skill/add/domains.md` (new ref) · `SKILL.md` profile-truth + checker pointer · `phases/verify.md` ladder honesty · finance/legal/academic corpus depth + routing index · all THREE skill trees
+Out: engine bytes (`add.py` · `cli.py`) — including the one true residual, making `init` refuse an unknown `--profile`; deferred by human constraint, not because it is unreal · new profiles · new floor names · new evidence rungs · the book chapter (rides after)
+
+## GROUND
+touches: add-method/skill/add/{SKILL.md,domains.md,phases/verify.md} × 3 trees (`skill/add/`, `src/add_method/_bundled/skill/add/` — both git-tracked — and the GITIGNORED `.claude/skills/add/`, which needs a manual cp); add-method/personas-teacher/{finance,academic}/; add-method/personas-index/use-when.md; add-method/tests/skill/
+risks:
+  - a new ref file pushes total skill surface past the 1500 pin (1422 now — 78 free; the plan spends 61)
+  - the checker recipe reads as "a pack may define what passes" — that inverts the additivity promise; the recipe must only ever show how to AUTHOR evidence, never how to earn a gate more cheaply
+  - the gitignored `.claude/skills/add/` twin drifts silently — it has no parity test
+  - `.add/personas/method-steward.md` still pins SKILL.md at 150; the real pin is 176 (re-pinned at 3.1.0, human call) — a stale persona will reject a conforming plan
+
+## EXIT
+- [ ] a non-code domain task earns `kind: test-ids` with `covers:`-bound checks, proved by a dogfood test that runs the recipe end-to-end — never by prose   (← domain-evidence-recipe)
+- [ ] every evidence rung the skill documents is one the engine can actually stamp   (← ladder-honesty)
+- [ ] `SKILL.md` ≤ 176 lines and total skill surface ≤ 1500 after every task   (← skill-pointer-truth)
+- [ ] no floor sentence reworded and no floor name introduced outside `security · data · architecture`   (← domain-evidence-recipe)
+- [ ] the three skill trees stay byte-identical   (← skill-pointer-truth)
+- [ ] the routing index reaches finance/legal/academic at a pinned floor   (← corpus-depth)
+
+## CLOSE
+evidence: <one row per task>

--- a/.add/specs/method.md
+++ b/.add/specs/method.md
@@ -13,6 +13,8 @@ how work proceeds, and what a gate costs
 
 ## Deltas
 - <what changed, and the evidence that changed it>
+- [ADD · open] an `n/a` retires a sweep DIMENSION, never an EDGE — an E<n> line is a gate referent whatever it says, so a 'dissolved' edge must be DELETED or given a check; writing 'E1 n/a' still holds the PASS (evidence: /tasks/receipt-artifact-leak.d/runs/1.md)
+- [ADD · open] a task's scope: MUST include the directory its own CHECKS live in — otherwise a defective check cannot be repaired during build, and the only in-scope 'fix' is to reshape the artifact around the broken test (evidence: /tasks/receipt-artifact-leak.md scope: omits add-method/tests/skill)
 - [ADD · open] a frozen contract on a not-yet-done task is repaired by a bare re-freeze (the engine records act: refreeze with a fresh direction hash) — reopen refuses a non-done task and replan seals untouched, and no skill doc names the real path (evidence: /tasks/domain-evidence-recipe.md verified[])
 - [ADD · open] a covers: citation must be the exact qualified ID or a BARE test name — the path.py::name form resolves to neither, so nothing binds and the gate refuses every rule (evidence: add-method/tooling/add.py:3008)
 - [ADD · open] the gate binds EVERY covers referent, EDGES included — an E<n> authored with no covering check refuses the PASS just as a Must would (evidence: /tasks/domain-evidence-recipe.d/runs/2.md)

--- a/.add/specs/method.md
+++ b/.add/specs/method.md
@@ -13,6 +13,7 @@ how work proceeds, and what a gate costs
 
 ## Deltas
 - <what changed, and the evidence that changed it>
+- [ADD · open] guard the ORPHAN direction for refs, not just verbs — a doc naming a missing verb was already caught, but a ref no always-loaded file names shipped unreachable and passed ten bound checks; the new guard immediately found a SECOND orphan (terms.md) nobody knew about (evidence: add-method/tests/skill/test_router_pointers.py::test_no_orphan_refs)
 - [ADD · open] an `n/a` retires a sweep DIMENSION, never an EDGE — an E<n> line is a gate referent whatever it says, so a 'dissolved' edge must be DELETED or given a check; writing 'E1 n/a' still holds the PASS (evidence: /tasks/receipt-artifact-leak.d/runs/1.md)
 - [ADD · open] a task's scope: MUST include the directory its own CHECKS live in — otherwise a defective check cannot be repaired during build, and the only in-scope 'fix' is to reshape the artifact around the broken test (evidence: /tasks/receipt-artifact-leak.md scope: omits add-method/tests/skill)
 - [ADD · open] a frozen contract on a not-yet-done task is repaired by a bare re-freeze (the engine records act: refreeze with a fresh direction hash) — reopen refuses a non-done task and replan seals untouched, and no skill doc names the real path (evidence: /tasks/domain-evidence-recipe.md verified[])

--- a/.add/specs/method.md
+++ b/.add/specs/method.md
@@ -13,5 +13,9 @@ how work proceeds, and what a gate costs
 
 ## Deltas
 - <what changed, and the evidence that changed it>
+- [ADD · open] a frozen contract on a not-yet-done task is repaired by a bare re-freeze (the engine records act: refreeze with a fresh direction hash) — reopen refuses a non-done task and replan seals untouched, and no skill doc names the real path (evidence: /tasks/domain-evidence-recipe.md verified[])
+- [ADD · open] a covers: citation must be the exact qualified ID or a BARE test name — the path.py::name form resolves to neither, so nothing binds and the gate refuses every rule (evidence: add-method/tooling/add.py:3008)
+- [ADD · open] the gate binds EVERY covers referent, EDGES included — an E<n> authored with no covering check refuses the PASS just as a Must would (evidence: /tasks/domain-evidence-recipe.d/runs/2.md)
+- [ADD · open] a persona that hard-codes a budget number rots when the budget is re-pinned — method-steward still says SKILL.md <=150 while the real pin is 176; personas should cite the pin's test, not copy its value (evidence: add-method/tests/skill/test_surface.py:37)
 - [ADD · folded] edge-list frontmatter (depends_on/needs) must be BLOCK lists — inline [a, b] flow parses in the engine's T0 but not in the M0 validator; the parity oracle catches it on the live bundle (evidence: /tasks/sources-receipt.md)
 - [ADD · folded] any angle-bracketed text in a gives: entry — even inside a backticked example path — reads as unauthored scaffold and blocks freeze; keep gives: literals bracket-free (evidence: /tasks/explore-lane.md)

--- a/.add/specs/quality.md
+++ b/.add/specs/quality.md
@@ -13,4 +13,5 @@ what counts as proof
 
 ## Deltas
 - <what changed, and the evidence that changed it>
+- [TDD · open] a 'must never contain X' check passes vacuously when the file is missing — assert existence FIRST or it rides into the freeze proving nothing (evidence: add-method/tests/skill/test_domains_recipe.py:32)
 - [TDD · folded] the gate coverage map binds EVERY referent — probed A-lines and E-lines included; write covers: complete at Direction or the first gate refuses on rules your suite already proves (evidence: /tasks/explore-lane.d/runs/2.md)

--- a/.add/specs/system.md
+++ b/.add/specs/system.md
@@ -13,3 +13,4 @@ how it is built, and what that forecloses
 
 ## Deltas
 - <what changed, and the evidence that changed it>
+- [SDD · open] a skill-surface addition has a three-tree blast radius; a scope narrower than that ships a red suite and the architecture residue lens is what catches it (evidence: /tasks/domain-evidence-recipe.d/runs/2.md)

--- a/.add/tasks/corpus-depth.md
+++ b/.add/tasks/corpus-depth.md
@@ -1,48 +1,60 @@
 ---
 type: Task
 title: finance/legal/academic persona depth + routing index
-status: direction
+status: done
 depth: quick
 milestone: all-domain-evidence
 scope:
-  - add-method/personas-teacher
   - add-method/personas-index
+  - add-method/scripts
+  - add-method/tests/skill
 gives:
-  - S1 <the surface this publishes — an endpoint, function, or section>
+  - S1 the corpus routing coverage — which teacher files are reachable through the index, and which are knowingly not
 generated: { by: add/3.1.0, at: 2026-08-12 }
-verified: []
+verified:
+  - { by: "Tin Dang", at: 2026-08-12, act: freeze, authority: human, direction: "sha256:bdc1c6dfb8fe6024" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:e4a8a84b2c65e9da" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/corpus-depth.d/runs/1.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: process, outcome: PASS, receipt: /tasks/corpus-depth.d/runs/1.md, brief: "sha256:e4a8a84b2c65e9da" }
 ---
 ## CARD
-goal: <one line>
-why: <why this task exists — optional>
-beat: direction · next: add freeze corpus-depth
+goal: every persona in the teacher corpus is reachable through the routing index, and every file that is not is accounted for out loud
+why: THE ORIGINAL PREMISE IS VOID. This task was drafted to "thicken finance/legal/academic personas" on the belief the corpus was engineering-heavy. It is not — 256 personas across 18 divisions incl. finance, academic, marketing, gis. And it CANNOT be thickened here: `personas-teacher/` is a byte-verbatim vendored MIT snapshot that `update_teacher.py` replaces with `shutil.rmtree`, so anything added is erased on the next refresh and corrupts third-party attribution besides. The real gap is ours: 22 of 256 corpus files are unreachable through the index, the skip is silent, and NOTHING pins coverage — a refresh that drops or renames personas would shrink routing invisibly.
+beat: done · next: add status
 
 ## RULES
 <must>
-- M1 <the rule that must hold>
+- M1 every corpus `.md` must be either indexed or accounted for by a stated reason the check verifies
+- M2 the index must reach every division that ships agent definitions — finance and academic included, the ones this milestone claimed were thin
+- M4 the generator must REPORT what it skipped and why — the silence is the defect: it reports "232 personas" and says nothing about the 22 files it passed over, so a persona that lost its frontmatter in a refresh disappears from routing with no signal
+- M3 the accounting must be DERIVED from the corpus, never a pinned file list — a pinned list rots on the very next vendor refresh, which is the failure this task exists to prevent
 </must>
 <reject>
-- R:<NAME> <what must never happen> -> "<NAME>"
+- R:HANDEDIT hand-editing `personas-index/use-when.md` or anything under `personas-teacher/` — the first is generated and the second is vendored, so a hand edit is erased without warning -> "HANDEDIT"
 </reject>
 
 ## ASSUMPTIONS
-- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
-- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
-- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
-- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
-- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
-every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+- A1 [who] covers: S1 · n/a · the generator alone writes the index; no actor chooses coverage
+- A2 [which] covers: S1 · the request does not say which non-persona files are legitimately skipped; taking "a corpus file with no `description:` frontmatter is not an agent definition — playbooks, runbooks, examples, LICENSE, VENDOR.md — which is the generator's OWN rule, just never stated at the size it actually operates" -> if wrong, a real persona that merely lost its frontmatter reads as a deliberate exclusion
+- A3 [when] covers: S1 · the request does not say when coverage is checked; taking "on every suite run, not only at refresh time — a refresh PR is exactly when nobody re-reads the index" -> if wrong, drift is caught only by whoever happens to look
+- A4 [absent] covers: S1 · the request does not say what happens when the corpus is absent entirely; taking "fail loud — an empty corpus must not pass as full coverage" -> if wrong, a broken checkout reads as a clean bill of health
+- A5 [order] covers: S1 · n/a · coverage is a set property; nothing is ordered
 
 ## PLAN
-contract: <the shape this publishes>
-scope: <files>
+contract: a derived coverage guard over the generated index, plus the generator saying out loud what it skipped
+strategy: the strongest available check is REGENERATE-AND-COMPARE — run `build_persona_index.py` into a temp location and assert the committed index is byte-identical. That catches a hand-edit and a stale index in one assertion, and it is derived by construction. Coverage is then a set difference over the corpus, never a pinned list.
+scope: add-method/personas-index, add-method/scripts, add-method/tests/skill
 
 ## EDGES
-- E1 <a boundary or failure case a check must cover — optional>
+- E1 an absent or empty corpus must fail loud, never pass as complete coverage
 
 ## CHECKS
-- <test_name> · covers: M1 · <what it proves>
-red-first: every check MUST fail first.
+- test_every_corpus_file_is_indexed_or_accounted · covers: M1 · every corpus .md is indexed or has no description: frontmatter
+- test_index_reaches_every_agent_division · covers: M2 · every division holding agent definitions is routable, finance and academic included
+- test_index_is_regenerable · covers: M3, R:HANDEDIT · regenerating byte-identical proves both derivation and no hand-edit
+- test_empty_corpus_fails_loud · covers: E1 · zero personas raises rather than reporting full coverage
+- test_check_reports_what_it_skipped · covers: M4 · --check names the skipped count, not only the indexed count
+red-first: ONE is driven red — M4, because `--check` today prints "232 personas" and reports nothing about the 22 files it silently passed over. The other FOUR are green at freeze and declared: they guard properties that already hold, which is the point of a coverage guard over a VENDORED tree — the risk is a future `update_teacher.py` refresh, not today's state. An earlier draft of the regenerate check invented a `--stdout` mode, did not find it, and pytest.skip'd; a skipped check binds NOTHING (the engine records `skip`, never `pass`), so it was rewritten onto the `--check` mode the generator already ships.
 
 ## EVIDENCE
 receipt: <runs/<n>.md>

--- a/.add/tasks/corpus-depth.md
+++ b/.add/tasks/corpus-depth.md
@@ -1,0 +1,52 @@
+---
+type: Task
+title: finance/legal/academic persona depth + routing index
+status: direction
+depth: quick
+milestone: all-domain-evidence
+scope:
+  - add-method/personas-teacher
+  - add-method/personas-index
+gives:
+  - S1 <the surface this publishes — an endpoint, function, or section>
+generated: { by: add/3.1.0, at: 2026-08-12 }
+verified: []
+---
+## CARD
+goal: <one line>
+why: <why this task exists — optional>
+beat: direction · next: add freeze corpus-depth
+
+## RULES
+<must>
+- M1 <the rule that must hold>
+</must>
+<reject>
+- R:<NAME> <what must never happen> -> "<NAME>"
+</reject>
+
+## ASSUMPTIONS
+- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
+- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
+- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
+- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
+- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
+every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+
+## PLAN
+contract: <the shape this publishes>
+scope: <files>
+
+## EDGES
+- E1 <a boundary or failure case a check must cover — optional>
+
+## CHECKS
+- <test_name> · covers: M1 · <what it proves>
+red-first: every check MUST fail first.
+
+## EVIDENCE
+receipt: <runs/<n>.md>
+gate: <PASS | RISK-ACCEPTED | HARD-STOP>
+
+## LESSONS
+- <lesson> -> add learn <lens>

--- a/.add/tasks/domain-evidence-recipe.md
+++ b/.add/tasks/domain-evidence-recipe.md
@@ -1,0 +1,94 @@
+---
+type: Task
+title: domains.md — the checker recipe, floor mapping, lens re-author
+status: done
+depth: standard
+sensitivity: architecture
+milestone: all-domain-evidence
+scope:
+  - add-method/skill/add/domains.md
+  - add-method/tests/skill
+  - add-method/src/add_method/_bundled/skill/add
+  - .claude/skills/add
+gives:
+  - S1 the domain-checker recipe — how a non-code domain earns a bound receipt
+  - S2 the floor-vocabulary map — a domain's own word routed onto an existing floor
+  - S3 the lens re-author table — how a domain bundle gets its 5-DD framing
+generated: { by: add/3.1.0, at: 2026-08-12 }
+verified:
+  - { by: "Tin Dang", at: 2026-08-12, act: freeze, authority: human, direction: "sha256:6ee899f76dc53453" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:95d062f0525ce67c" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/domain-evidence-recipe.d/runs/1.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: refreeze, authority: human, direction: "sha256:4f032c462e6b2137" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:bf0f5b1e387fee35" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/domain-evidence-recipe.d/runs/2.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: plan, outcome: HARD-STOP, receipt: /tasks/domain-evidence-recipe.d/runs/2.md, brief: "sha256:bf0f5b1e387fee35", reason: "architecture residue: adding domains.md to the canonical tree broke both mirror-parity tests; the mirror trees are outside the frozen scope, so the fix is a change-request back to Direction" }
+  - { by: "Tin Dang", at: 2026-08-12, act: refreeze, authority: human, direction: "sha256:c3f7f6c1a2c2dca5" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:73262b6fa07a16ab" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/domain-evidence-recipe.d/runs/3.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: plan, outcome: PASS, receipt: /tasks/domain-evidence-recipe.d/runs/3.md, brief: "sha256:73262b6fa07a16ab" }
+---
+## CARD
+goal: a loaded-on-demand ref that makes ADD's existing trust spine reachable from a non-code domain
+why: the capability is already there and invisible — nothing tells an agent it may WRITE a checker instead of FIND a runner
+beat: done · next: add status
+
+## RULES
+<must>
+- M1 the recipe must yield a receipt at `kind: test-ids` with every `covers:` referent bound, demonstrated by executing it end-to-end on a non-code domain node — never asserted in prose
+- M2 every floor the map targets must be one of `security · data · architecture`, and a domain word must route to a floor no weaker than its own stakes imply
+- M3 `domains.md` must exist and leave total skill surface within its 1500-line pin
+- M4 the ref must land byte-identical in ALL THREE skill trees — canonical, package payload and dogfood mirror. Added at the third freeze: the architecture residue lens found that shipping it to one tree alone broke both mirror-parity tests, and the first scope was narrower than the change's real blast radius
+</must>
+<reject>
+- R:NEWFLOOR introducing a floor name outside `security · data · architecture` -> "NEWFLOOR"
+- R:GATEBUY showing any path to a verdict on weaker evidence than the code path takes — a pack configures what is AUTHORED, never what PASSES -> "GATEBUY"
+- R:PHANTOMPROFILE instructing `add init --profile <x>` for any `x` the engine does not ship -> "PHANTOMPROFILE"
+</reject>
+
+## ASSUMPTIONS
+- A1 [who] covers: S1 · the request does not say whether the AI may author the threshold it is then judged against; taking "yes, because the threshold lives in the frozen RULES the human approves, not in the checker" · found: the live recon node carried `M1 variance <= 0.5% of gross` in frozen RULES and the checker only compared against it (evidence: scratchpad/dom/.add/tasks/recon.md + runs/1.md, kind test-ids) -> if wrong, the AI marks its own homework and the receipt is theatre
+- A2 [which] covers: S1 · the request does not say which domains the recipe claims; taking "only those that can state a machine-comparable threshold or a resolvable reference — taste-quality domains are named as out" -> if wrong, ADD overclaims and a brand-voice task ships a vacuous green
+- A3 [when] covers: S1 · n/a · the recipe carries no temporal boundary; it rides the loop's existing beats
+- A4 [absent] covers: S1 · the request does not say what happens when a domain has no digestible file; taking "freshness degrades to mtime and the receipt says so out loud" -> if wrong, a domain user believes they have stale-green protection they do not have
+- A5 [order] covers: S1 · n/a · the recipe's steps are ordered by the beats they sit in, not by a rule of its own
+- A6 [who] covers: S2 · n/a · floors are computed by the engine from `sensitivity:`; no actor chooses one
+- A7 [which] covers: S2 · the request does not say whether the word list is exhaustive; taking "a closed starter set, explicitly extensible, never complete" -> if wrong, a reader treats an absent word as evidence of no floor
+- A8 [when] covers: S2 · n/a · a floor binds at gate wherever the word appears; the map adds no timing
+- A9 [absent] covers: S2 · the request does not say what floor an unmapped domain word takes; taking "the closed-floor rule already answers it — when in doubt, size up" -> if wrong, an unmapped sensitive word silently lands at `process`
+- A10 [order] covers: S2 · n/a · the map is a lookup; no entry precedes another
+- A11 [who] covers: S3 · n/a · the agent re-authors the lenses, as it authors any bundle content
+- A12 [which] covers: S3 · the request does not say which lenses get rewritten; taking "all four `## Now` lines the `doc` profile ships" -> if wrong, a half-framed bundle gets cited by a frozen contract
+- A13 [when] covers: S3 · the request does not say when re-authoring happens; taking "immediately after `init`, before the first task is created" -> if wrong, a contract freezes against code-framed lenses
+- A14 [absent] covers: S3 · the request does not say what happens when a human already edited a spec; taking "never clobber — `init`'s own rule is that a human's file outranks a template" -> if wrong, human authoring is destroyed silently
+- A15 [order] covers: S3 · n/a · lens order binds nothing
+
+## PLAN
+contract: one loaded-on-demand ref publishing three sections, proven by a dogfood test that EXECUTES the recipe rather than pinning its phrases
+strategy: write the dogfood test first (red — the ref does not exist), then author `domains.md` until it goes green. Every check asserts the file exists BEFORE asserting anything about its content — a "must never contain X" test passes vacuously on a missing file, which is the assert-nothing trap the method warns about.
+scope: add-method/skill/add/domains.md, add-method/tests/skill
+
+## EDGES
+- E1 a domain with no digestible artifact — the recipe must say the freshness degrade out loud, not omit it
+- E2 a domain word the map does not carry — must route to size-up, never to silence
+
+## CHECKS
+- test_recipe_earns_bound_test_ids · covers: M1 · the recipe, run end-to-end on a non-code domain node, records kind test-ids with every covers referent reported passing
+- test_floor_map_targets_only_existing_floors · covers: M2 · every floor named as a target resolves to security, data or architecture
+- test_domains_exists_within_surface_budget · covers: M3 · the ref exists AND the surface stays within its pin — existence is what makes this red before the build
+- test_introduces_no_new_floor_name · covers: R:NEWFLOOR · no floor-shaped token outside the closed three
+- test_recipe_buys_no_gate · covers: R:GATEBUY · the ref names no weaker-evidence route to a verdict
+- test_names_no_phantom_profile · covers: R:PHANTOMPROFILE · every --profile it instructs is one the engine ships
+- test_states_freshness_degrade · covers: E1 · the ref says the mtime degrade out loud
+- test_unmapped_word_routes_to_size_up · covers: E2 · an unmapped domain word routes to size-up, never to silence
+- test_skill_bundle_matches_canonical · covers: M4 · the package payload tree matches canonical
+- test_dogfood_skill_matches_canonical_when_present · covers: M4 · the dogfood mirror matches canonical
+red-first: every check MUST fail first — EXCEPT the two E-checks, added at the second freeze after the gate exposed E1/E2 as unbound referents. Their behavior already shipped, so they are regression guards, not test-driven. Recorded here rather than manufactured red by deleting working prose and restoring it.
+citation form: BARE test names. The first freeze cited `path.py::name`, which `cite_hits` resolves neither as a qualified ID nor as a bare name, so nothing bound and the gate refused all eight referents.
+
+## EVIDENCE
+receipt: <runs/<n>.md>
+gate: <PASS | RISK-ACCEPTED | HARD-STOP>
+
+## LESSONS
+- <lesson> -> add learn <lens>

--- a/.add/tasks/ladder-honesty.md
+++ b/.add/tasks/ladder-honesty.md
@@ -1,0 +1,51 @@
+---
+type: Task
+title: verify.md — every documented rung must be stampable
+status: direction
+depth: standard
+milestone: all-domain-evidence
+scope:
+  - add-method/skill/add/phases/verify.md
+gives:
+  - S1 <the surface this publishes — an endpoint, function, or section>
+generated: { by: add/3.1.0, at: 2026-08-12 }
+verified: []
+---
+## CARD
+goal: <one line>
+why: <why this task exists — optional>
+beat: direction · next: add freeze ladder-honesty
+
+## RULES
+<must>
+- M1 <the rule that must hold>
+</must>
+<reject>
+- R:<NAME> <what must never happen> -> "<NAME>"
+</reject>
+
+## ASSUMPTIONS
+- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
+- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
+- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
+- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
+- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
+every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+
+## PLAN
+contract: <the shape this publishes>
+scope: <files>
+
+## EDGES
+- E1 <a boundary or failure case a check must cover — optional>
+
+## CHECKS
+- <test_name> · covers: M1 · <what it proves>
+red-first: every check MUST fail first.
+
+## EVIDENCE
+receipt: <runs/<n>.md>
+gate: <PASS | RISK-ACCEPTED | HARD-STOP>
+
+## LESSONS
+- <lesson> -> add learn <lens>

--- a/.add/tasks/ladder-honesty.md
+++ b/.add/tasks/ladder-honesty.md
@@ -1,47 +1,61 @@
 ---
 type: Task
 title: verify.md — every documented rung must be stampable
-status: direction
+status: done
 depth: standard
 milestone: all-domain-evidence
 scope:
-  - add-method/skill/add/phases/verify.md
+  - add-method/skill/add
+  - add-method/src/add_method/_bundled/skill/add
+  - .claude/skills/add
+  - add-method/tests/skill
 gives:
-  - S1 <the surface this publishes — an endpoint, function, or section>
+  - S1 the evidence-kind ladder — the rungs `verify.md` tells an agent to expect on a receipt
 generated: { by: add/3.1.0, at: 2026-08-12 }
-verified: []
+verified:
+  - { by: "Tin Dang", at: 2026-08-12, act: freeze, authority: human, direction: "sha256:e7313c1f55e840e0" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:74942d0437f0e909" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/ladder-honesty.d/runs/1.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: process, outcome: PASS, receipt: /tasks/ladder-honesty.d/runs/1.md, brief: "sha256:74942d0437f0e909" }
 ---
 ## CARD
-goal: <one line>
-why: <why this task exists — optional>
-beat: direction · next: add freeze ladder-honesty
+goal: every evidence rung the skill documents is one the engine can actually stamp, and every kind it can stamp is documented
+why: `verify.md` promises `test-ids > artifact-hash > command-exit > human-observed`. The engine writes exactly `test-ids`, `command-exit` (add.py:1929) and `sources` (add.py:2781). So the doc is wrong in BOTH directions — two rungs that can never be earned, and one real kind it never mentions. An unearnable rung is not a ladder, it is a label.
+beat: done · next: add status
 
 ## RULES
 <must>
-- M1 <the rule that must hold>
+- M1 every evidence kind the skill documents must be one the engine can stamp
+- M2 every kind the engine can stamp must be documented — the orphan direction, the same asymmetry that let `domains.md` and `terms.md` ship unreachable
+- M3 the change must land byte-identical across all three skill trees
 </must>
 <reject>
-- R:<NAME> <what must never happen> -> "<NAME>"
+- R:PINSTRINGS pinning today's rung names as literals in the check — the guard must DERIVE the set from the engine, or it goes stale exactly the way the doc it replaces did -> "PINSTRINGS"
 </reject>
 
 ## ASSUMPTIONS
-- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
-- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
-- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
-- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
-- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
-every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+- A1 [who] covers: S1 · n/a · the engine alone writes a receipt kind; no actor chooses one
+- A2 [which] covers: S1 · the request does not say whether `sources` belongs on the same ladder as the run kinds; taking "yes — it is a kind the engine stamps on a gate, and a reader who never sees it cannot recognise it on an explore receipt" -> if wrong, the ladder mixes two incomparable axes and implies an explore is weaker than a command-exit
+- A3 [when] covers: S1 · n/a · a kind is stamped at run or gate; the ladder describes strength, not timing
+- A4 [absent] covers: S1 · the request does not say what to do about the two unearnable rungs; taking "DELETE, not demote — a rung nothing can stamp is not a weak rung, it is a false one, and `add learn` already records honest weakening elsewhere" -> if wrong, the doc keeps teaching a ladder with phantom steps
+- A5 [order] covers: S1 · the request does not say what orders the kinds; taking "the engine's own promotion rule — `test-ids` only when a runner reported IDs, else `command-exit` — with `sources` named separately as the explore path's kind rather than ranked against them" -> if wrong, a reader ranks an explore receipt against a test receipt and picks the wrong lane
 
 ## PLAN
-contract: <the shape this publishes>
-scope: <files>
+contract: one honest ladder line in `verify.md`, and a DERIVED guard that keeps the docs and the engine from drifting apart again
+strategy: the guard is the point, not the line. Four documentation-vs-engine drifts have now surfaced in this milestone (phantom profiles, orphan refs, the receipt-path leak, these rungs) and nothing in the repo systematically checks shipped prose against engine reality. This closes the rung instance with a check that reads `add.py` rather than pinning strings — so it stays true when the engine gains or loses a kind.
+scope: add-method/skill/add, add-method/src/add_method/_bundled/skill/add, .claude/skills/add, add-method/tests/skill
 
 ## EDGES
-- E1 <a boundary or failure case a check must cover — optional>
+- E1 a kind the engine stamps in a branch the extractor cannot see — the guard must fail loud on an empty extraction rather than pass vacuously on finding nothing
 
 ## CHECKS
-- <test_name> · covers: M1 · <what it proves>
-red-first: every check MUST fail first.
+- test_documented_rungs_are_stampable · covers: M1 · every kind the skill names is one the engine emits
+- test_stampable_rungs_are_documented · covers: M2 · every kind the engine emits is named by the skill
+- test_rung_set_is_derived_not_pinned · covers: R:PINSTRINGS · the extractor picks up a fabricated kind from synthetic source, proving it reads the engine rather than a literal list
+- test_extractor_fails_loud_on_empty · covers: E1 · an extraction that finds nothing raises rather than passing vacuously
+- test_skill_bundle_matches_canonical · covers: M3 · package payload tree matches canonical
+- test_dogfood_skill_matches_canonical_when_present · covers: M3 · dogfood mirror matches canonical
+red-first: TWO are driven red — M1 fails on `artifact-hash`/`human-observed`, M2 fails on the undocumented `sources`. FOUR are guards, declared: R:PINSTRINGS and E1 are properties of the extractor and went green as soon as it was authored (they are Direction artefacts, not build outcomes), and the two parity tests catch a missed tree. NOTE the extractor was itself wrong on its first run — an unanchored ternary pattern swept up freshness values (`content`/`mtime`) and manufactured five phantom failures; anchoring every pattern on `kind` fixed it. A derived guard is only as honest as its anchor.
 
 ## EVIDENCE
 receipt: <runs/<n>.md>

--- a/.add/tasks/receipt-artifact-leak.md
+++ b/.add/tasks/receipt-artifact-leak.md
@@ -1,52 +1,76 @@
 ---
 type: Task
 title: the receipt artifact leaks into the repo root
-status: direction
+status: done
 depth: standard
 milestone: all-domain-evidence
 scope:
-  - .gitignore
   - add-method/skill/add
   - add-method/docs
   - add-method/GETTING-STARTED.md
+  - add-method/tests/skill
 gives:
-  - S1 <the surface this publishes — an endpoint, function, or section>
+  - S1 the documented receipt-scratch path — the `--junitxml` argument every doc tells an agent to copy
 generated: { by: add/3.1.0, at: 2026-08-12 }
-verified: []
+verified:
+  - { by: "Tin Dang", at: 2026-08-12, act: freeze, authority: human, direction: "sha256:6315bbf4e4bba2b3" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:78ed308eec8f0618" }
+  - { by: "Tin Dang", at: 2026-08-12, act: refreeze, authority: human, direction: "sha256:6315bbf4e4bba2b3" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:d6503b0ed8f9ce7f" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/receipt-artifact-leak.d/runs/1.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: refreeze, authority: human, direction: "sha256:6315bbf4e4bba2b3" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:f6b1d2d471b69e92" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/receipt-artifact-leak.d/runs/2.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: process, outcome: PASS, receipt: /tasks/receipt-artifact-leak.d/runs/2.md, brief: "sha256:f6b1d2d471b69e92" }
+  - { by: loop, at: 2026-08-12, act: reopen, to: direction, reason: "gate passed on a three-way quoting inconsistency the check was built to tolerate; add a canonical-form Must and pin it" }
+  - { by: "Tin Dang", at: 2026-08-12, act: refreeze, authority: human, direction: "sha256:2a3fe8040eddd341" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:0f510588949c1335" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/receipt-artifact-leak.d/runs/3.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: process, outcome: PASS, receipt: /tasks/receipt-artifact-leak.d/runs/3.md, brief: "sha256:0f510588949c1335" }
 ---
 ## CARD
-goal: following the documented receipt command must not leave an untracked artifact in the repo root
+goal: following the documented receipt command must leave nothing behind in the working tree
 why: `r.xml` is gitignored nowhere, and the cookbook every agent copies writes it to CWD — so the next `git add -A` commits a JUnit report. Hit live during domain-evidence-recipe; the artifact reached the index and had to be force-removed.
 ground: the leak is 9 source files, not one line — SKILL.md (2 lines), phases/verify.md, domains.md across THREE skill trees, plus GETTING-STARTED.md and docs/{05-verify,13-command-reference,17-components,appendix-d-worked-example}.md. domains.md propagated it: the ref shipped one task ago already tells readers to write r.xml.
+revised at draft: the first draft chose `.add/run.xml` + ignore entries. A probe showed the engine parses ANY path, so the scratch leaves the tree entirely and the gitignore/template-twin half of the contract was cut before freeze, not after.
+widened at 2nd freeze: `add-method/tests/skill` was missing, so a defective CHECK was unrepairable during build and the only in-scope 'fix' would have been to reshape the docs around the broken regex. A task's scope MUST reach the directory its own checks live in.
 order: MUST settle before or with `skill-pointer-truth` — both edit SKILL.md, and the milestone's tasks are otherwise scope-disjoint.
-beat: direction · next: add freeze receipt-artifact-leak
+beat: done · next: add status
 
 ## RULES
 <must>
-- M1 <the rule that must hold>
+- M1 every documented `--junitxml` path in the shipped skill and the book docs must resolve OUTSIDE the working tree
+- M2 the change must land byte-identical across all three skill trees
+- M3 every documented `--junitxml` argument must use ONE canonical, shell-quoted form. Added at reopen: the first gate passed on three variants (8 bare, 1 quoted, 1 with a stray backtick) because the check tolerated any out-of-tree path — honest about what it claimed, blind to what nobody claimed
 </must>
 <reject>
-- R:<NAME> <what must never happen> -> "<NAME>"
+- R:TREELEAK a shipped doc instructing a receipt artifact be written anywhere inside the working tree -> "TREELEAK"
 </reject>
 
 ## ASSUMPTIONS
-- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
-- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
-- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
-- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
-- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
-every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+- A1 [who] covers: S1 · n/a · no actor distinction — every agent copies the identical cookbook line
+- A2 [which] covers: S1 · the request does not say which docs count; taking "every SHIPPED surface that instructs the command — the three skill trees and the book docs/ chapters" -> if wrong, a missed doc keeps teaching the leak and the fix reads complete
+- A3 [when] covers: S1 · n/a · the path is an argument, not a step; it carries no timing
+- A4 [absent] covers: S1 · the request does not say what happens when TMPDIR is unset; taking "`${TMPDIR:-/tmp}` falls back, and the POSIX assumption is pre-existing — the cookbook is already ```bash" -> if wrong, the documented line fails on a shell with neither TMPDIR nor /tmp
+- A5 [order] covers: S1 · n/a · one argument, nothing to sequence
 
 ## PLAN
-contract: <the shape this publishes>
-scope: <files>
+contract: one scratch path, outside the working tree, documented everywhere the command is instructed
+strategy: the JUnit XML is REQUIRED — it is what upgrades a receipt from `command-exit` (exit code only) to `test-ids` (named checks), and `covers:` binds against the IDs the runner reported, so without it the gate refuses every bound rule at any depth. The FILENAME is not required: the engine parses whatever path it is handed. Verified `--junitxml /tmp/add-run-probe.xml` → kind test-ids, 2/2 reported, gate PASS, zero repo footprint. So the fix is docs-only — no gitignore, no template twins, nothing to ignore because nothing lands.
+scope: add-method/skill/add, add-method/docs, add-method/GETTING-STARTED.md, add-method/tests/skill
 
 ## EDGES
-- E1 <a boundary or failure case a check must cover — optional>
+<!-- none. The first draft's edge (a project predating the fix has no `.add/.gitignore`)
+     dissolved when the scratch left the tree. DELETED, not retired with `n/a`: an `E<n>`
+     line is a gate referent whatever it says, so an `n/a` edge still holds the PASS. -->
 
 ## CHECKS
-- <test_name> · covers: M1 · <what it proves>
-red-first: every check MUST fail first.
+- test_documented_receipt_paths_are_outside_the_tree · covers: M1 · every `--junitxml` argument in the shipped skill and docs resolves outside the working tree
+- test_no_shipped_doc_writes_into_the_tree · covers: R:TREELEAK · no shipped surface instructs an in-tree artifact
+- test_receipt_path_has_one_canonical_form · covers: M3 · every documented argument is the identical quoted string
+- test_skill_bundle_matches_canonical · covers: M2 · package payload skill tree matches canonical
+- test_dogfood_skill_matches_canonical_when_present · covers: M2 · dogfood mirror matches canonical
+red-first: TWO are driven red — M1 and R:TREELEAK both fail while the docs still say `r.xml`. TWO are the EXISTING parity guards reused for M2 (qualification gate), green at freeze and declared so; they go red the moment a tree is missed. The earlier draft's M2/M3-templates/E1/R:BUNDLEPOLLUTE were cut: they existed only to serve an in-tree scratch path, which the probe showed is unnecessary.
 
 ## EVIDENCE
 receipt: <runs/<n>.md>

--- a/.add/tasks/receipt-artifact-leak.md
+++ b/.add/tasks/receipt-artifact-leak.md
@@ -1,0 +1,56 @@
+---
+type: Task
+title: the receipt artifact leaks into the repo root
+status: direction
+depth: standard
+milestone: all-domain-evidence
+scope:
+  - .gitignore
+  - add-method/skill/add
+  - add-method/docs
+  - add-method/GETTING-STARTED.md
+gives:
+  - S1 <the surface this publishes — an endpoint, function, or section>
+generated: { by: add/3.1.0, at: 2026-08-12 }
+verified: []
+---
+## CARD
+goal: following the documented receipt command must not leave an untracked artifact in the repo root
+why: `r.xml` is gitignored nowhere, and the cookbook every agent copies writes it to CWD — so the next `git add -A` commits a JUnit report. Hit live during domain-evidence-recipe; the artifact reached the index and had to be force-removed.
+ground: the leak is 9 source files, not one line — SKILL.md (2 lines), phases/verify.md, domains.md across THREE skill trees, plus GETTING-STARTED.md and docs/{05-verify,13-command-reference,17-components,appendix-d-worked-example}.md. domains.md propagated it: the ref shipped one task ago already tells readers to write r.xml.
+order: MUST settle before or with `skill-pointer-truth` — both edit SKILL.md, and the milestone's tasks are otherwise scope-disjoint.
+beat: direction · next: add freeze receipt-artifact-leak
+
+## RULES
+<must>
+- M1 <the rule that must hold>
+</must>
+<reject>
+- R:<NAME> <what must never happen> -> "<NAME>"
+</reject>
+
+## ASSUMPTIONS
+- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
+- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
+- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
+- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
+- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
+every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+
+## PLAN
+contract: <the shape this publishes>
+scope: <files>
+
+## EDGES
+- E1 <a boundary or failure case a check must cover — optional>
+
+## CHECKS
+- <test_name> · covers: M1 · <what it proves>
+red-first: every check MUST fail first.
+
+## EVIDENCE
+receipt: <runs/<n>.md>
+gate: <PASS | RISK-ACCEPTED | HARD-STOP>
+
+## LESSONS
+- <lesson> -> add learn <lens>

--- a/.add/tasks/skill-pointer-truth.md
+++ b/.add/tasks/skill-pointer-truth.md
@@ -1,47 +1,69 @@
 ---
 type: Task
 title: SKILL.md — profile truth + the write-a-checker pointer
-status: direction
+status: done
 depth: standard
 milestone: all-domain-evidence
 scope:
-  - add-method/skill/add/SKILL.md
+  - add-method/skill/add
+  - add-method/src/add_method/_bundled/skill/add
+  - .claude/skills/add
+  - add-method/tests/skill
 gives:
-  - S1 <the surface this publishes — an endpoint, function, or section>
+  - S1 the profile line — what `init` actually ships, in the always-loaded router
+  - S2 the write-a-checker pointer — the sentence that makes `domains.md` reachable at all
 generated: { by: add/3.1.0, at: 2026-08-12 }
-verified: []
+verified:
+  - { by: "Tin Dang", at: 2026-08-12, act: freeze, authority: human, direction: "sha256:82a8e13c6cd6e323" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:d78a71de5c6fb0f1" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/skill-pointer-truth.d/runs/1.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: process, outcome: PASS, receipt: /tasks/skill-pointer-truth.d/runs/1.md, brief: "sha256:d78a71de5c6fb0f1" }
 ---
 ## CARD
-goal: <one line>
-why: <why this task exists — optional>
-beat: direction · next: add freeze skill-pointer-truth
+goal: an agent learns from the always-loaded router that it may WRITE a checker, and is never told to pass a profile the engine does not ship
+why: `domains.md` shipped last task and NOTHING names it — SKILL.md lists 12 refs and that is not one of them, so no agent will ever load it. Its ten bound checks proved it correct, mirrored and in budget; none asked whether it was reachable.
+beat: done · next: add status
 
 ## RULES
 <must>
-- M1 <the rule that must hold>
+- M1 SKILL.md must name only profiles the engine ships — the `<code|doc|…>` ellipsis promises more than `init` has, and `init` silently falls back to `code` on anything else
+- M2 every ref file in the skill tree must be named by SKILL.md — an orphan ref is unreachable and cannot do the job it was written for, whatever its contents prove
+- M3 the Verify beat must tell an agent that when no runner exists for the domain it may WRITE one, and point at `domains.md`
 </must>
 <reject>
-- R:<NAME> <what must never happen> -> "<NAME>"
+- R:BUDGETBUST landing the pointer by breaking a pin — SKILL.md over 176 lines or the surface over 1500 -> "BUDGETBUST"
 </reject>
 
 ## ASSUMPTIONS
-- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
-- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
-- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
-- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
-- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
-every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+- A1 [who] covers: S1 · n/a · the router is read identically by every agent; no actor distinction
+- A2 [which] covers: S1 · the request does not say whether to name the profiles or drop the list; taking "name both explicitly — an honest short list beats an ellipsis that implies a menu" -> if wrong, a reader invents `--profile finance` and gets code lenses under a finance label
+- A3 [when] covers: S1 · n/a · the line is read at orientation, always, with no ordering question
+- A4 [absent] covers: S1 · the request does not say what a reader should do when no profile fits; taking "`doc` is the non-code default and `domains.md` carries the re-author table" -> if wrong, the ellipsis is merely replaced by a dead end
+- A5 [order] covers: S1 · n/a · two profiles, no precedence
+- A6 [who] covers: S2 · n/a · same router, same readers
+- A7 [which] covers: S2 · the request does not say which refs the orphan rule binds; taking "every `.md` in the skill tree except the nested `persona-author/` sub-skill, which is loaded on its own terms — the same carve-out `_own_docs()` already makes" -> if wrong the check fights an existing, deliberate exemption
+- A8 [when] covers: S2 · n/a · reachability is a static property of the tree
+- A9 [absent] covers: S2 · the request does not say what happens to a ref deliberately not surfaced; taking "there is no such thing — an unreferenced ref is dead weight against the surface pin, so it is named or it is deleted" -> if wrong, a legitimate private ref gets forced into the router and costs budget
+- A10 [order] covers: S2 · n/a · refs are named in whatever order reads best
 
 ## PLAN
-contract: <the shape this publishes>
-scope: <files>
+contract: two edits to the always-loaded router, plus a generalised orphan-ref guard that would have caught last task's miss
+strategy: the orphan check is the real deliverable — it is `test_every_wired_verb_is_documented` one level up. That test already guards the ORPHAN direction for VERBS (a verb the engine ships that no doc names); nothing guarded it for REFS, which is exactly how `domains.md` shipped unreachable. Fund the added lines by compressing, never by raising a pin.
+scope: add-method/skill/add, add-method/src/add_method/_bundled/skill/add, .claude/skills/add, add-method/tests/skill
 
 ## EDGES
-- E1 <a boundary or failure case a check must cover — optional>
+- E1 `persona-author/` is a nested sub-skill with its own budget — the orphan rule must exempt it exactly as `_own_docs()` does, or it forces a private tree into the router
 
 ## CHECKS
-- <test_name> · covers: M1 · <what it proves>
-red-first: every check MUST fail first.
+- test_router_names_only_shipped_profiles · covers: M1 · every profile SKILL.md names is one PROFILES ships, and no ellipsis implies more
+- test_no_orphan_refs · covers: M2 · every ref in the skill tree is named by SKILL.md
+- test_router_points_at_the_checker_recipe · covers: M3 · the Verify beat names domains.md and says a checker may be written
+- test_router_within_line_budget · covers: R:BUDGETBUST · SKILL.md stays within its 176-line pin
+- test_total_surface_within_budget · covers: R:BUDGETBUST · the surface stays within 1500
+- test_orphan_rule_exempts_nested_subskill · covers: E1 · persona-author/ is not forced into the router
+- test_skill_bundle_matches_canonical · covers: M2 · package payload tree matches canonical
+- test_dogfood_skill_matches_canonical_when_present · covers: M2 · dogfood mirror matches canonical
+red-first: THREE are driven red — M1, M2 and M3 all fail against today's router (the ellipsis is there, domains.md is orphaned, no checker sentence exists). The rest are guards, declared: R:BUDGETBUST's two are the EXISTING pins (they go red only if the edit overspends, which is their job), E1's asserts an exemption that must survive the new rule, and the two parity tests catch a missed tree.
 
 ## EVIDENCE
 receipt: <runs/<n>.md>

--- a/.add/tasks/skill-pointer-truth.md
+++ b/.add/tasks/skill-pointer-truth.md
@@ -1,0 +1,51 @@
+---
+type: Task
+title: SKILL.md — profile truth + the write-a-checker pointer
+status: direction
+depth: standard
+milestone: all-domain-evidence
+scope:
+  - add-method/skill/add/SKILL.md
+gives:
+  - S1 <the surface this publishes — an endpoint, function, or section>
+generated: { by: add/3.1.0, at: 2026-08-12 }
+verified: []
+---
+## CARD
+goal: <one line>
+why: <why this task exists — optional>
+beat: direction · next: add freeze skill-pointer-truth
+
+## RULES
+<must>
+- M1 <the rule that must hold>
+</must>
+<reject>
+- R:<NAME> <what must never happen> -> "<NAME>"
+</reject>
+
+## ASSUMPTIONS
+- A1 [who] covers: <S ids> · the request does not say <who may act / whose data>; taking <reading> -> <cost if wrong>
+- A2 [which] covers: <S ids> · the request does not say <which rows/cases are in>; taking <reading> -> <cost if wrong>
+- A3 [when] covers: <S ids> · the request does not say <where the boundary falls>; taking <reading> -> <cost if wrong>
+- A4 [absent] covers: <S ids> · the request does not say <what a missing value means>; taking <reading> -> <cost if wrong>
+- A5 [order] covers: <S ids> · the request does not say <what orders / breaks a tie>; taking <reading> -> <cost if wrong>
+every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+
+## PLAN
+contract: <the shape this publishes>
+scope: <files>
+
+## EDGES
+- E1 <a boundary or failure case a check must cover — optional>
+
+## CHECKS
+- <test_name> · covers: M1 · <what it proves>
+red-first: every check MUST fail first.
+
+## EVIDENCE
+receipt: <runs/<n>.md>
+gate: <PASS | RISK-ACCEPTED | HARD-STOP>
+
+## LESSONS
+- <lesson> -> add learn <lens>

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -38,8 +38,10 @@ reopen · deltas · milestone-archive` — is wired.
 Run **`add status`** first, every session — it is your resume point, read from the bundle, not the
 repo. Then branch:
 
-- **No `.add/` yet** → `add init --profile <code|doc|…> "<name>"`, then offer to seed starter
-  personas that fit the domain (`seed.md`, opt-in), then size the request (Intake).
+- **No `.add/` yet** → `add init --profile <code|doc> "<name>"` — those two ship, and `init`
+  writes the `code` lenses under any other name without refusing. Non-code domain? Take `doc`,
+  then re-author its lenses (`domains.md`). Offer to seed starter personas (`seed.md`,
+  opt-in), then size the request (Intake).
 - **A task is active** (`status` not `done`) → open `.add/tasks/<slug>.md`, read its `## CARD`, and
   work the beat `add status` names next. The beat is **derived from the node's stamps**, not the
   `status` field — which stays `direction` until close: unfrozen → author + freeze; frozen with no
@@ -96,7 +98,9 @@ One task = one atomic node. Three beats, one human decision:
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
    · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>` for a
    fresh, bound receipt — wrap the **narrowest command that reports every bound check**; the full
-   suite rides CI — and **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
+   suite rides CI. **No runner for your domain? Write one** — `run` parses JUnit XML and does not
+   care what produced it, so a script comparing a measured value against a threshold your frozen
+   RULES already state earns the same bound receipt (`domains.md`). And **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
    (and repairs its CARD). `add done` is only for closing after a signed `RISK-ACCEPTED`.
 
 Emit **lessons** as you learn them, tagged by which of the five specs they sharpen
@@ -130,7 +134,7 @@ research fans out freely — facts merge; one write taints the stream back onto 
 
 ```bash
 add status                                   # resume · --all full · --check conformance
-add init --profile code "<name>"             # create a .add/ bundle (also: doc)
+add init --profile code "<name>"             # create a .add/ bundle — code | doc ONLY (see domains.md)
 add upgrade                                  # 2.x bundle? archive it whole, init 3.0, MIGRATION.md guides re-authoring
 add new Task <slug> --title "..." --depth quick|standard|deep [--kind explore] [--milestone m] [--scope a,b]
                                              # --sensitivity security|data|architecture sets the floor
@@ -161,6 +165,7 @@ else `process` — never from depth.
 - **deep** — full node + milestone strategy, lowest-confidence-first; a human owns freeze whenever the
   floor (or your judgment) calls for it.
 
+A coined term you cannot decode is in `terms.md` — load it once, not every session.
 The method's **why** lives in `FORMAT.md` (the ABF-1 bundle format, in the ADD source repo) —
 **referenced, never inlined** (load the State; reference the Story). Read it only when a decision is
 genuinely unclear. The AIDD book is deeper background and is **external** (not shipped with the skill)

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -94,7 +94,7 @@ One task = one atomic node. Three beats, one human decision:
    record it, seal untouched: `add replan <slug> --note "<what changed>"`. Anything that would move
    a frozen surface is a change-request back to Direction, never a silent edit.
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
-   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml r.xml -- <test cmd>` for a
+   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>` for a
    fresh, bound receipt — wrap the **narrowest command that reports every bound check**; the full
    suite rides CI — and **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
    (and repairs its CARD). `add done` is only for closing after a signed `RISK-ACCEPTED`.
@@ -141,7 +141,7 @@ add advise <slug> --persona <p>              # record the lens that reviewed a s
 add doctor                                   # report-only findings — never writes, never gates
 add freeze <slug> --by "<name>" --authority human    # the ONE approval → Build
 add replan <slug> --note "<what changed>"    # record a steering turn on a frozen task — seal untouched
-add run <slug> [--timeout <s>] --junitxml r.xml -- <test cmd>   # execute → a fresh, bound receipt
+add run <slug> [--timeout <s>] --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>   # execute → a fresh, bound receipt
 add gate <slug> PASS --by "<name>"           # verdict — a PASS auto-closes · RISK-ACCEPTED (signed) · HARD-STOP
 add done <slug>                              # close after a RISK-ACCEPTED (a PASS gate already closed it)
 add learn <ddd|sdd|udd|tdd|add> "<lesson>" --evidence <ref>   # file a lesson into a living spec

--- a/.claude/skills/add/domains.md
+++ b/.claude/skills/add/domains.md
@@ -1,0 +1,91 @@
+# ADD across domains — one spine, many vocabularies
+
+ADD's trust spine is already domain-neutral: the sweep dimensions name no code, the `covers:`
+grammar names no code, and the freshness digest hashes any git-tracked file — data and prose
+included. What is code-shaped is the **vocabulary and the worked examples**. This ref supplies both.
+
+Nothing here changes what PASSES. A domain configures what gets **authored** — the words, the
+lenses, the checker — never what a gate accepts. That asymmetry is the whole reason a receipt
+still means the same thing in finance as in code.
+
+## 1 · Earn a real receipt — write the checker
+
+When no test runner exists for your domain, **write one**. `add run` parses JUnit XML and does not
+care what produced it, so any script that compares a measured value against a threshold your frozen
+`## RULES` already state earns the top rung — `kind: test-ids`, every `covers:` referent bound.
+
+The threshold belongs in the frozen Must, never inside the checker. That is what keeps this honest:
+the human approves the number at freeze, and the checker only compares against it.
+
+<!-- checker-recipe -->
+```python
+import json, sys, xml.etree.ElementTree as ET
+
+d = json.load(open("recon.json"))            # your domain artifact — data, not code
+cases = []                                    # (name, passed, message)
+cases.append(("test_variance_within_materiality",
+              d["variance"] <= 0.005 * d["gross"],          # the threshold M1 froze
+              f'variance {d["variance"]} exceeds 0.5% of {d["gross"]}'))
+cases.append(("test_every_variance_line_cited",
+              all(line.get("source_doc") for line in d["lines"]),
+              "a variance line carries no source document"))
+
+suite = ET.Element("testsuite", name="checks.recon", tests=str(len(cases)))
+for name, ok, msg in cases:
+    tc = ET.SubElement(suite, "testcase", classname="checks.recon", name=name)
+    if not ok:
+        ET.SubElement(tc, "failure", message=msg).text = msg
+ET.ElementTree(suite).write(sys.argv[1])
+sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
+```
+
+Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
+
+```bash
+add run <slug> --junitxml r.xml -- python3 checks/recon.py r.xml
+```
+
+**Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —
+edit the ledger after the run and the gate refuses the stale green. **Without a git-tracked artifact
+freshness falls back to mtime**, and the receipt says so; do not claim stale-green protection you
+did not earn.
+
+The same shape covers eval scores, reconciliation deltas, backtest returns, contrast ratios,
+plan-diff summaries, and citation resolution (a reference that resolves to nothing is a failing
+case, not a warning). It does **not** cover taste — brand voice, visual polish, prose elegance.
+Those gate weakly on purpose; that is the evidence ladder being honest, not a gap to paper over.
+
+## 2 · Your domain's word, ADD's floor
+
+Floors are computed by the engine and the set is closed. Map your vocabulary **onto** it, upward
+only — never rename anything into it.
+
+| Domain word | Floor | Why |
+|---|---|---|
+| regulatory · statutory · licensing | security | an unlawful artifact is never a signed risk |
+| privilege · confidentiality | security | disclosure cannot be undone |
+| patient safety · clinical | security | harm is irreversible |
+| PII · consent · retention | data | the existing data floor already fits |
+| model · schema · system-of-record | architecture | it forecloses downstream choices |
+
+A word this table does not carry inherits the closed-floor rule already in force: **when in doubt,
+size up**. Absence from the table is never evidence that no floor applies.
+
+## 3 · Frame the bundle — re-author the lenses
+
+Only `code` and `doc` ship as profiles. Do **not** invent one: `init` accepts any string and then
+silently writes the `code` lenses under that name, so the bundle would misreport its own domain.
+
+Start from `add init --profile doc "<name>"` — its four lenses already assume no test runner —
+then rewrite each spec's `## Now` line in your domain's language, **before** creating the first
+task, so no contract freezes against code-framed lenses.
+
+| Lens | Rewrite `## Now` to |
+|---|---|
+| domain | what the work must get right about the subject |
+| experience | who consumes the output and what they need from it |
+| quality | what counts as proof here — name the checker |
+| method | how drafts proceed to a verdict, and what one costs |
+
+Never overwrite a spec a human already edited — `init`'s own rule is that a human's file outranks
+a template, and re-authoring inherits it.

--- a/.claude/skills/add/domains.md
+++ b/.claude/skills/add/domains.md
@@ -42,7 +42,8 @@ sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
 Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
 
 ```bash
-add run <slug> --junitxml r.xml -- python3 checks/recon.py r.xml
+add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
+  python3 checks/recon.py "${TMPDIR:-/tmp}/add-run.xml"
 ```
 
 **Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —

--- a/.claude/skills/add/phases/verify.md
+++ b/.claude/skills/add/phases/verify.md
@@ -6,7 +6,7 @@ because the diff reads plausible. Verify is where that trust is recorded, once.
 ## 1 · Gather the evidence — a fresh, bound receipt
 
 ```bash
-add run <slug> --junitxml r.xml -- <the test command>
+add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <the test command>
 ```
 
 `run` executes your command, parses the JUnit report, and writes a **Run receipt** under

--- a/.claude/skills/add/phases/verify.md
+++ b/.claude/skills/add/phases/verify.md
@@ -34,8 +34,11 @@ wrapped command does — the notary itself is milliseconds. The wrapped command'
 **900 s by default**; a legitimately slow receipt (a bound build check) raises it explicitly
 with `--timeout <s>` — a timeout is *recorded* as exit 124, and the gate will refuse the PASS.
 
-Evidence kinds, strongest first: `test-ids` > `artifact-hash` > `command-exit` > `human-observed`. A
-weaker kind is a *visible* weakening (the gate records which it accepted) — never a silent one.
+Evidence kinds the engine can actually stamp, strongest first: `test-ids` (a runner reported the
+IDs your `covers:` names) > `command-exit` (the command exited 0, and nothing is bound to a named
+check). A findings-only explore gates on `sources` instead — cited questions closed, no run
+receipt. A weaker kind is a *visible* weakening (the receipt records which it earned), never a
+silent one — and a kind nothing can stamp is not a weak rung, it is a false one.
 
 ## 2 · Check the residue — three lenses
 

--- a/add-method/GETTING-STARTED.md
+++ b/add-method/GETTING-STARTED.md
@@ -310,11 +310,11 @@ Now write code until **every test passes** — without changing a test or the fr
 contract. Then record a receipt from a real run:
 
 ```bash
-add run transfer --junitxml r.xml -- python3 -m pytest -q --junitxml=r.xml
+add run transfer --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- python3 -m pytest -q --junitxml="${TMPDIR:-/tmp}/add-run.xml"
 ```
 
-Note the flag appears **twice**, and that is not a typo: `--junitxml r.xml` tells ADD
-where to *read* the report, and `--junitxml=r.xml` after the `--` is part of the test
+Note the flag appears **twice**, and that is not a typo: `--junitxml "${TMPDIR:-/tmp}/add-run.xml"` tells ADD
+where to *read* the report, and `--junitxml="${TMPDIR:-/tmp}/add-run.xml"` after the `--` is part of the test
 command that *writes* it. Omit the second and the receipt records only an exit code —
 `ids: unknown` — and nothing binds to your rules.
 

--- a/add-method/docs/05-verify.md
+++ b/add-method/docs/05-verify.md
@@ -15,7 +15,7 @@ This needs care, because it is easy to misread. "Not by inspection" does not mea
 Trust rests on a run you can point to, not a claim. Execute the task's checks and record the result as a receipt:
 
 ```
-add run <slug> --junitxml r.xml -- <the test command>
+add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <the test command>
 ```
 
 `add run` executes your command, parses the JUnit report, and writes a **Run receipt** into the task's bundle. Two properties the gate will demand of it:

--- a/add-method/docs/13-command-reference.md
+++ b/add-method/docs/13-command-reference.md
@@ -35,7 +35,7 @@ Build to green, verify on evidence, record one outcome. `gate PASS` auto-closes 
 
 | verb | what it does | example |
 |---|---|---|
-| `run` | execute the checks and write a fresh, scope-bound Run receipt. `--junitxml` parses test IDs; `--timeout <s>` raises the 900 s ceiling for a build-heavy command; the command follows `--` — keep it the narrowest run that reports every bound check | `add run reject-overlap --junitxml r.xml -- pytest tests/test_overlap.py` |
+| `run` | execute the checks and write a fresh, scope-bound Run receipt. `--junitxml` parses test IDs; `--timeout <s>` raises the 900 s ceiling for a build-heavy command; the command follows `--` — keep it the narrowest run that reports every bound check | `add run reject-overlap --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- pytest tests/test_overlap.py` |
 | `gate` | record the verdict: `PASS \| RISK-ACCEPTED \| HARD-STOP`. `--by`, `--authority`, `--reason` | `add gate reject-overlap PASS --by "tindang"` |
 | `done` | close a gated task (the normal path closes automatically at `gate PASS`) | `add done reject-overlap` |
 | `reopen` | return a done task to a beat with a reset gate. `--to direction\|build\|verify` and `--reason` both required | `add reopen reject-overlap --to build --reason "missed a race"` |

--- a/add-method/docs/17-components.md
+++ b/add-method/docs/17-components.md
@@ -43,7 +43,7 @@ single-part project. There is no registry to keep in sync and nothing scans
 
 In a mixed milestone, a backend task and a frontend task pass on **different
 toolchains**. The verify gate enforces this per task, through the **bound receipt**:
-`add run <slug> --junitxml r.xml -- <the suite for this scope>` records the checks
+`add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <the suite for this scope>` records the checks
 that actually ran, and `add gate <slug> PASS` refuses unless every listed check
 appears in that receipt with `outcome: pass`. The engine never *runs* the suite —
 that invariant holds here too ([NO-EXEC](./01-principles.md)). The AI runs the

--- a/add-method/docs/appendix-d-worked-example.md
+++ b/add-method/docs/appendix-d-worked-example.md
@@ -149,7 +149,7 @@ The engine never runs your suite ([NO-EXEC](./01-principles.md)). You run it; `a
 run` records what happened as a receipt:
 
 ```
-$ add run transfer-own-accounts --junitxml r.xml -- python3 -m pytest tests -q --junitxml=r.xml
+$ add run transfer-own-accounts --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- python3 -m pytest tests -q --junitxml="${TMPDIR:-/tmp}/add-run.xml"
 receipt 1 recorded (exit 0)
 next: add gate transfer-own-accounts
 

--- a/add-method/scripts/build_persona_index.py
+++ b/add-method/scripts/build_persona_index.py
@@ -100,7 +100,13 @@ def main() -> int:
             print(f"{INDEX.name} is stale — regenerate with "
                   f"`python3 add-method/scripts/build_persona_index.py`", file=sys.stderr)
             return 1
-        print(f"{INDEX.name} is current ({len(personas())} personas)")
+        indexed = len(personas())
+        total = len(list(CORPUS.rglob("*.md")))
+        # State the exclusion. Reporting only the indexed count made a persona that lost its
+        # `description:` in a vendor refresh vanish from routing with no signal but a number
+        # quietly getting smaller — and nobody re-reads a generated file to notice.
+        print(f"{INDEX.name} is current ({indexed} personas indexed, "
+              f"{total - indexed} corpus files skipped — no `description:`, so not agent definitions)")
         return 0
 
     INDEX_DIR.mkdir(parents=True, exist_ok=True)

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -38,8 +38,10 @@ reopen · deltas · milestone-archive` — is wired.
 Run **`add status`** first, every session — it is your resume point, read from the bundle, not the
 repo. Then branch:
 
-- **No `.add/` yet** → `add init --profile <code|doc|…> "<name>"`, then offer to seed starter
-  personas that fit the domain (`seed.md`, opt-in), then size the request (Intake).
+- **No `.add/` yet** → `add init --profile <code|doc> "<name>"` — those two ship, and `init`
+  writes the `code` lenses under any other name without refusing. Non-code domain? Take `doc`,
+  then re-author its lenses (`domains.md`). Offer to seed starter personas (`seed.md`,
+  opt-in), then size the request (Intake).
 - **A task is active** (`status` not `done`) → open `.add/tasks/<slug>.md`, read its `## CARD`, and
   work the beat `add status` names next. The beat is **derived from the node's stamps**, not the
   `status` field — which stays `direction` until close: unfrozen → author + freeze; frozen with no
@@ -96,7 +98,9 @@ One task = one atomic node. Three beats, one human decision:
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
    · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>` for a
    fresh, bound receipt — wrap the **narrowest command that reports every bound check**; the full
-   suite rides CI — and **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
+   suite rides CI. **No runner for your domain? Write one** — `run` parses JUnit XML and does not
+   care what produced it, so a script comparing a measured value against a threshold your frozen
+   RULES already state earns the same bound receipt (`domains.md`). And **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
    (and repairs its CARD). `add done` is only for closing after a signed `RISK-ACCEPTED`.
 
 Emit **lessons** as you learn them, tagged by which of the five specs they sharpen
@@ -130,7 +134,7 @@ research fans out freely — facts merge; one write taints the stream back onto 
 
 ```bash
 add status                                   # resume · --all full · --check conformance
-add init --profile code "<name>"             # create a .add/ bundle (also: doc)
+add init --profile code "<name>"             # create a .add/ bundle — code | doc ONLY (see domains.md)
 add upgrade                                  # 2.x bundle? archive it whole, init 3.0, MIGRATION.md guides re-authoring
 add new Task <slug> --title "..." --depth quick|standard|deep [--kind explore] [--milestone m] [--scope a,b]
                                              # --sensitivity security|data|architecture sets the floor
@@ -161,6 +165,7 @@ else `process` — never from depth.
 - **deep** — full node + milestone strategy, lowest-confidence-first; a human owns freeze whenever the
   floor (or your judgment) calls for it.
 
+A coined term you cannot decode is in `terms.md` — load it once, not every session.
 The method's **why** lives in `FORMAT.md` (the ABF-1 bundle format, in the ADD source repo) —
 **referenced, never inlined** (load the State; reference the Story). Read it only when a decision is
 genuinely unclear. The AIDD book is deeper background and is **external** (not shipped with the skill)

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -94,7 +94,7 @@ One task = one atomic node. Three beats, one human decision:
    record it, seal untouched: `add replan <slug> --note "<what changed>"`. Anything that would move
    a frozen surface is a change-request back to Direction, never a silent edit.
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
-   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml r.xml -- <test cmd>` for a
+   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>` for a
    fresh, bound receipt — wrap the **narrowest command that reports every bound check**; the full
    suite rides CI — and **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
    (and repairs its CARD). `add done` is only for closing after a signed `RISK-ACCEPTED`.
@@ -141,7 +141,7 @@ add advise <slug> --persona <p>              # record the lens that reviewed a s
 add doctor                                   # report-only findings — never writes, never gates
 add freeze <slug> --by "<name>" --authority human    # the ONE approval → Build
 add replan <slug> --note "<what changed>"    # record a steering turn on a frozen task — seal untouched
-add run <slug> [--timeout <s>] --junitxml r.xml -- <test cmd>   # execute → a fresh, bound receipt
+add run <slug> [--timeout <s>] --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>   # execute → a fresh, bound receipt
 add gate <slug> PASS --by "<name>"           # verdict — a PASS auto-closes · RISK-ACCEPTED (signed) · HARD-STOP
 add done <slug>                              # close after a RISK-ACCEPTED (a PASS gate already closed it)
 add learn <ddd|sdd|udd|tdd|add> "<lesson>" --evidence <ref>   # file a lesson into a living spec

--- a/add-method/skill/add/domains.md
+++ b/add-method/skill/add/domains.md
@@ -1,0 +1,91 @@
+# ADD across domains — one spine, many vocabularies
+
+ADD's trust spine is already domain-neutral: the sweep dimensions name no code, the `covers:`
+grammar names no code, and the freshness digest hashes any git-tracked file — data and prose
+included. What is code-shaped is the **vocabulary and the worked examples**. This ref supplies both.
+
+Nothing here changes what PASSES. A domain configures what gets **authored** — the words, the
+lenses, the checker — never what a gate accepts. That asymmetry is the whole reason a receipt
+still means the same thing in finance as in code.
+
+## 1 · Earn a real receipt — write the checker
+
+When no test runner exists for your domain, **write one**. `add run` parses JUnit XML and does not
+care what produced it, so any script that compares a measured value against a threshold your frozen
+`## RULES` already state earns the top rung — `kind: test-ids`, every `covers:` referent bound.
+
+The threshold belongs in the frozen Must, never inside the checker. That is what keeps this honest:
+the human approves the number at freeze, and the checker only compares against it.
+
+<!-- checker-recipe -->
+```python
+import json, sys, xml.etree.ElementTree as ET
+
+d = json.load(open("recon.json"))            # your domain artifact — data, not code
+cases = []                                    # (name, passed, message)
+cases.append(("test_variance_within_materiality",
+              d["variance"] <= 0.005 * d["gross"],          # the threshold M1 froze
+              f'variance {d["variance"]} exceeds 0.5% of {d["gross"]}'))
+cases.append(("test_every_variance_line_cited",
+              all(line.get("source_doc") for line in d["lines"]),
+              "a variance line carries no source document"))
+
+suite = ET.Element("testsuite", name="checks.recon", tests=str(len(cases)))
+for name, ok, msg in cases:
+    tc = ET.SubElement(suite, "testcase", classname="checks.recon", name=name)
+    if not ok:
+        ET.SubElement(tc, "failure", message=msg).text = msg
+ET.ElementTree(suite).write(sys.argv[1])
+sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
+```
+
+Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
+
+```bash
+add run <slug> --junitxml r.xml -- python3 checks/recon.py r.xml
+```
+
+**Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —
+edit the ledger after the run and the gate refuses the stale green. **Without a git-tracked artifact
+freshness falls back to mtime**, and the receipt says so; do not claim stale-green protection you
+did not earn.
+
+The same shape covers eval scores, reconciliation deltas, backtest returns, contrast ratios,
+plan-diff summaries, and citation resolution (a reference that resolves to nothing is a failing
+case, not a warning). It does **not** cover taste — brand voice, visual polish, prose elegance.
+Those gate weakly on purpose; that is the evidence ladder being honest, not a gap to paper over.
+
+## 2 · Your domain's word, ADD's floor
+
+Floors are computed by the engine and the set is closed. Map your vocabulary **onto** it, upward
+only — never rename anything into it.
+
+| Domain word | Floor | Why |
+|---|---|---|
+| regulatory · statutory · licensing | security | an unlawful artifact is never a signed risk |
+| privilege · confidentiality | security | disclosure cannot be undone |
+| patient safety · clinical | security | harm is irreversible |
+| PII · consent · retention | data | the existing data floor already fits |
+| model · schema · system-of-record | architecture | it forecloses downstream choices |
+
+A word this table does not carry inherits the closed-floor rule already in force: **when in doubt,
+size up**. Absence from the table is never evidence that no floor applies.
+
+## 3 · Frame the bundle — re-author the lenses
+
+Only `code` and `doc` ship as profiles. Do **not** invent one: `init` accepts any string and then
+silently writes the `code` lenses under that name, so the bundle would misreport its own domain.
+
+Start from `add init --profile doc "<name>"` — its four lenses already assume no test runner —
+then rewrite each spec's `## Now` line in your domain's language, **before** creating the first
+task, so no contract freezes against code-framed lenses.
+
+| Lens | Rewrite `## Now` to |
+|---|---|
+| domain | what the work must get right about the subject |
+| experience | who consumes the output and what they need from it |
+| quality | what counts as proof here — name the checker |
+| method | how drafts proceed to a verdict, and what one costs |
+
+Never overwrite a spec a human already edited — `init`'s own rule is that a human's file outranks
+a template, and re-authoring inherits it.

--- a/add-method/skill/add/domains.md
+++ b/add-method/skill/add/domains.md
@@ -42,7 +42,8 @@ sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
 Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
 
 ```bash
-add run <slug> --junitxml r.xml -- python3 checks/recon.py r.xml
+add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
+  python3 checks/recon.py "${TMPDIR:-/tmp}/add-run.xml"
 ```
 
 **Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —

--- a/add-method/skill/add/phases/verify.md
+++ b/add-method/skill/add/phases/verify.md
@@ -6,7 +6,7 @@ because the diff reads plausible. Verify is where that trust is recorded, once.
 ## 1 · Gather the evidence — a fresh, bound receipt
 
 ```bash
-add run <slug> --junitxml r.xml -- <the test command>
+add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <the test command>
 ```
 
 `run` executes your command, parses the JUnit report, and writes a **Run receipt** under

--- a/add-method/skill/add/phases/verify.md
+++ b/add-method/skill/add/phases/verify.md
@@ -34,8 +34,11 @@ wrapped command does — the notary itself is milliseconds. The wrapped command'
 **900 s by default**; a legitimately slow receipt (a bound build check) raises it explicitly
 with `--timeout <s>` — a timeout is *recorded* as exit 124, and the gate will refuse the PASS.
 
-Evidence kinds, strongest first: `test-ids` > `artifact-hash` > `command-exit` > `human-observed`. A
-weaker kind is a *visible* weakening (the gate records which it accepted) — never a silent one.
+Evidence kinds the engine can actually stamp, strongest first: `test-ids` (a runner reported the
+IDs your `covers:` names) > `command-exit` (the command exited 0, and nothing is bound to a named
+check). A findings-only explore gates on `sources` instead — cited questions closed, no run
+receipt. A weaker kind is a *visible* weakening (the receipt records which it earned), never a
+silent one — and a kind nothing can stamp is not a weak rung, it is a false one.
 
 ## 2 · Check the residue — three lenses
 

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -38,8 +38,10 @@ reopen · deltas · milestone-archive` — is wired.
 Run **`add status`** first, every session — it is your resume point, read from the bundle, not the
 repo. Then branch:
 
-- **No `.add/` yet** → `add init --profile <code|doc|…> "<name>"`, then offer to seed starter
-  personas that fit the domain (`seed.md`, opt-in), then size the request (Intake).
+- **No `.add/` yet** → `add init --profile <code|doc> "<name>"` — those two ship, and `init`
+  writes the `code` lenses under any other name without refusing. Non-code domain? Take `doc`,
+  then re-author its lenses (`domains.md`). Offer to seed starter personas (`seed.md`,
+  opt-in), then size the request (Intake).
 - **A task is active** (`status` not `done`) → open `.add/tasks/<slug>.md`, read its `## CARD`, and
   work the beat `add status` names next. The beat is **derived from the node's stamps**, not the
   `status` field — which stays `direction` until close: unfrozen → author + freeze; frozen with no
@@ -96,7 +98,9 @@ One task = one atomic node. Three beats, one human decision:
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
    · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>` for a
    fresh, bound receipt — wrap the **narrowest command that reports every bound check**; the full
-   suite rides CI — and **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
+   suite rides CI. **No runner for your domain? Write one** — `run` parses JUnit XML and does not
+   care what produced it, so a script comparing a measured value against a threshold your frozen
+   RULES already state earns the same bound receipt (`domains.md`). And **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
    (and repairs its CARD). `add done` is only for closing after a signed `RISK-ACCEPTED`.
 
 Emit **lessons** as you learn them, tagged by which of the five specs they sharpen
@@ -130,7 +134,7 @@ research fans out freely — facts merge; one write taints the stream back onto 
 
 ```bash
 add status                                   # resume · --all full · --check conformance
-add init --profile code "<name>"             # create a .add/ bundle (also: doc)
+add init --profile code "<name>"             # create a .add/ bundle — code | doc ONLY (see domains.md)
 add upgrade                                  # 2.x bundle? archive it whole, init 3.0, MIGRATION.md guides re-authoring
 add new Task <slug> --title "..." --depth quick|standard|deep [--kind explore] [--milestone m] [--scope a,b]
                                              # --sensitivity security|data|architecture sets the floor
@@ -161,6 +165,7 @@ else `process` — never from depth.
 - **deep** — full node + milestone strategy, lowest-confidence-first; a human owns freeze whenever the
   floor (or your judgment) calls for it.
 
+A coined term you cannot decode is in `terms.md` — load it once, not every session.
 The method's **why** lives in `FORMAT.md` (the ABF-1 bundle format, in the ADD source repo) —
 **referenced, never inlined** (load the State; reference the Story). Read it only when a decision is
 genuinely unclear. The AIDD book is deeper background and is **external** (not shipped with the skill)

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -94,7 +94,7 @@ One task = one atomic node. Three beats, one human decision:
    record it, seal untouched: `add replan <slug> --note "<what changed>"`. Anything that would move
    a frozen surface is a change-request back to Direction, never a silent edit.
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
-   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml r.xml -- <test cmd>` for a
+   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>` for a
    fresh, bound receipt — wrap the **narrowest command that reports every bound check**; the full
    suite rides CI — and **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
    (and repairs its CARD). `add done` is only for closing after a signed `RISK-ACCEPTED`.
@@ -141,7 +141,7 @@ add advise <slug> --persona <p>              # record the lens that reviewed a s
 add doctor                                   # report-only findings — never writes, never gates
 add freeze <slug> --by "<name>" --authority human    # the ONE approval → Build
 add replan <slug> --note "<what changed>"    # record a steering turn on a frozen task — seal untouched
-add run <slug> [--timeout <s>] --junitxml r.xml -- <test cmd>   # execute → a fresh, bound receipt
+add run <slug> [--timeout <s>] --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd>   # execute → a fresh, bound receipt
 add gate <slug> PASS --by "<name>"           # verdict — a PASS auto-closes · RISK-ACCEPTED (signed) · HARD-STOP
 add done <slug>                              # close after a RISK-ACCEPTED (a PASS gate already closed it)
 add learn <ddd|sdd|udd|tdd|add> "<lesson>" --evidence <ref>   # file a lesson into a living spec

--- a/add-method/src/add_method/_bundled/skill/add/domains.md
+++ b/add-method/src/add_method/_bundled/skill/add/domains.md
@@ -1,0 +1,91 @@
+# ADD across domains — one spine, many vocabularies
+
+ADD's trust spine is already domain-neutral: the sweep dimensions name no code, the `covers:`
+grammar names no code, and the freshness digest hashes any git-tracked file — data and prose
+included. What is code-shaped is the **vocabulary and the worked examples**. This ref supplies both.
+
+Nothing here changes what PASSES. A domain configures what gets **authored** — the words, the
+lenses, the checker — never what a gate accepts. That asymmetry is the whole reason a receipt
+still means the same thing in finance as in code.
+
+## 1 · Earn a real receipt — write the checker
+
+When no test runner exists for your domain, **write one**. `add run` parses JUnit XML and does not
+care what produced it, so any script that compares a measured value against a threshold your frozen
+`## RULES` already state earns the top rung — `kind: test-ids`, every `covers:` referent bound.
+
+The threshold belongs in the frozen Must, never inside the checker. That is what keeps this honest:
+the human approves the number at freeze, and the checker only compares against it.
+
+<!-- checker-recipe -->
+```python
+import json, sys, xml.etree.ElementTree as ET
+
+d = json.load(open("recon.json"))            # your domain artifact — data, not code
+cases = []                                    # (name, passed, message)
+cases.append(("test_variance_within_materiality",
+              d["variance"] <= 0.005 * d["gross"],          # the threshold M1 froze
+              f'variance {d["variance"]} exceeds 0.5% of {d["gross"]}'))
+cases.append(("test_every_variance_line_cited",
+              all(line.get("source_doc") for line in d["lines"]),
+              "a variance line carries no source document"))
+
+suite = ET.Element("testsuite", name="checks.recon", tests=str(len(cases)))
+for name, ok, msg in cases:
+    tc = ET.SubElement(suite, "testcase", classname="checks.recon", name=name)
+    if not ok:
+        ET.SubElement(tc, "failure", message=msg).text = msg
+ET.ElementTree(suite).write(sys.argv[1])
+sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
+```
+
+Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
+
+```bash
+add run <slug> --junitxml r.xml -- python3 checks/recon.py r.xml
+```
+
+**Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —
+edit the ledger after the run and the gate refuses the stale green. **Without a git-tracked artifact
+freshness falls back to mtime**, and the receipt says so; do not claim stale-green protection you
+did not earn.
+
+The same shape covers eval scores, reconciliation deltas, backtest returns, contrast ratios,
+plan-diff summaries, and citation resolution (a reference that resolves to nothing is a failing
+case, not a warning). It does **not** cover taste — brand voice, visual polish, prose elegance.
+Those gate weakly on purpose; that is the evidence ladder being honest, not a gap to paper over.
+
+## 2 · Your domain's word, ADD's floor
+
+Floors are computed by the engine and the set is closed. Map your vocabulary **onto** it, upward
+only — never rename anything into it.
+
+| Domain word | Floor | Why |
+|---|---|---|
+| regulatory · statutory · licensing | security | an unlawful artifact is never a signed risk |
+| privilege · confidentiality | security | disclosure cannot be undone |
+| patient safety · clinical | security | harm is irreversible |
+| PII · consent · retention | data | the existing data floor already fits |
+| model · schema · system-of-record | architecture | it forecloses downstream choices |
+
+A word this table does not carry inherits the closed-floor rule already in force: **when in doubt,
+size up**. Absence from the table is never evidence that no floor applies.
+
+## 3 · Frame the bundle — re-author the lenses
+
+Only `code` and `doc` ship as profiles. Do **not** invent one: `init` accepts any string and then
+silently writes the `code` lenses under that name, so the bundle would misreport its own domain.
+
+Start from `add init --profile doc "<name>"` — its four lenses already assume no test runner —
+then rewrite each spec's `## Now` line in your domain's language, **before** creating the first
+task, so no contract freezes against code-framed lenses.
+
+| Lens | Rewrite `## Now` to |
+|---|---|
+| domain | what the work must get right about the subject |
+| experience | who consumes the output and what they need from it |
+| quality | what counts as proof here — name the checker |
+| method | how drafts proceed to a verdict, and what one costs |
+
+Never overwrite a spec a human already edited — `init`'s own rule is that a human's file outranks
+a template, and re-authoring inherits it.

--- a/add-method/src/add_method/_bundled/skill/add/domains.md
+++ b/add-method/src/add_method/_bundled/skill/add/domains.md
@@ -42,7 +42,8 @@ sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
 Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
 
 ```bash
-add run <slug> --junitxml r.xml -- python3 checks/recon.py r.xml
+add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
+  python3 checks/recon.py "${TMPDIR:-/tmp}/add-run.xml"
 ```
 
 **Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —

--- a/add-method/src/add_method/_bundled/skill/add/phases/verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/verify.md
@@ -6,7 +6,7 @@ because the diff reads plausible. Verify is where that trust is recorded, once.
 ## 1 · Gather the evidence — a fresh, bound receipt
 
 ```bash
-add run <slug> --junitxml r.xml -- <the test command>
+add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <the test command>
 ```
 
 `run` executes your command, parses the JUnit report, and writes a **Run receipt** under

--- a/add-method/src/add_method/_bundled/skill/add/phases/verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/verify.md
@@ -34,8 +34,11 @@ wrapped command does — the notary itself is milliseconds. The wrapped command'
 **900 s by default**; a legitimately slow receipt (a bound build check) raises it explicitly
 with `--timeout <s>` — a timeout is *recorded* as exit 124, and the gate will refuse the PASS.
 
-Evidence kinds, strongest first: `test-ids` > `artifact-hash` > `command-exit` > `human-observed`. A
-weaker kind is a *visible* weakening (the gate records which it accepted) — never a silent one.
+Evidence kinds the engine can actually stamp, strongest first: `test-ids` (a runner reported the
+IDs your `covers:` names) > `command-exit` (the command exited 0, and nothing is bound to a named
+check). A findings-only explore gates on `sources` instead — cited questions closed, no run
+receipt. A weaker kind is a *visible* weakening (the receipt records which it earned), never a
+silent one — and a kind nothing can stamp is not a weak rung, it is a false one.
 
 ## 2 · Check the residue — three lenses
 

--- a/add-method/tests/skill/test_corpus_routing.py
+++ b/add-method/tests/skill/test_corpus_routing.py
@@ -1,0 +1,117 @@
+"""Every persona in the vendored teacher corpus must be reachable through the routing index.
+
+`personas-teacher/` is a byte-verbatim third-party snapshot that `update_teacher.py` replaces with
+`shutil.rmtree`. So the corpus cannot be edited here — and a refresh that drops, renames or
+reorganises personas would shrink what is routable without anyone noticing, because the index is
+generated and nobody re-reads a generated file.
+
+The guard is REGENERATE-AND-COMPARE: it proves in one assertion that the committed index is neither
+hand-edited nor stale, and it is derived by construction rather than pinning a file list that would
+rot on the very next refresh.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORPUS = REPO / "personas-teacher"
+INDEX = REPO / "personas-index" / "use-when.md"
+GENERATOR = REPO / "scripts" / "build_persona_index.py"
+
+FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+DESCRIPTION = re.compile(r"^description:\s*(.+)$", re.M)
+
+
+def _is_persona(path: Path) -> bool:
+    """An agent definition carries `description:`; a playbook, runbook or example does not.
+
+    This is the GENERATOR's own rule, applied here rather than restated as a list. The generator
+    docstring anticipated three files (README, VENDOR, LICENSE); the corpus actually skips 22,
+    including a whole `strategy/` playbook tree — correct, but never said out loud at that size.
+    """
+    m = FRONTMATTER.match(path.read_text(encoding="utf-8", errors="replace"))
+    return bool(m and DESCRIPTION.search(m.group(1)))
+
+
+def _corpus_files():
+    files = sorted(CORPUS.rglob("*.md"))
+    assert files, f"teacher corpus is empty or missing at {CORPUS} — refusing to report coverage"
+    return files
+
+
+def test_every_corpus_file_is_indexed_or_accounted():
+    """M1 — indexed, or demonstrably not an agent definition. No third category."""
+    text = INDEX.read_text(encoding="utf-8")
+    unaccounted = sorted(str(p.relative_to(CORPUS)) for p in _corpus_files()
+                         if _is_persona(p) and p.stem not in text)
+    assert not unaccounted, (f"personas the routing index cannot reach: {unaccounted} — they carry "
+                             f"a description: so they ARE agent definitions, and nothing routes to them")
+
+
+def test_index_reaches_every_agent_division():
+    """M2 — every division holding agent definitions is routable.
+
+    Named explicitly because this milestone was drafted on the belief that finance and academic
+    were thin. They are not, and this pins that they stay reachable across a vendor refresh.
+    """
+    text = INDEX.read_text(encoding="utf-8")
+    divisions = {}
+    for p in _corpus_files():
+        rel = p.relative_to(CORPUS)
+        if len(rel.parts) > 1 and _is_persona(p):
+            divisions.setdefault(rel.parts[0], []).append(p.stem)
+    assert divisions, "no divisions carry agent definitions — the corpus shape changed"
+    for expected in ("finance", "academic"):
+        assert expected in divisions, f"the corpus no longer ships a `{expected}` division"
+    unreachable = sorted(d for d, members in divisions.items()
+                         if not any(m in text for m in members))
+    assert not unreachable, f"divisions with no routable persona at all: {unreachable}"
+
+
+def test_index_is_regenerable():
+    """M3 + R:HANDEDIT — the generator's own staleness check proves derivation AND no hand-edit.
+
+    An earlier draft invented a `--stdout` mode, found it absent, and pytest.skip'd — which would
+    have bound NOTHING: the engine records a skip as `skip`, never `pass`, so the gate refuses a
+    referent whose only check was skipped. The generator already ships `--check` and exits
+    non-zero when the committed index differs from a fresh render. No new mode, no skip.
+    """
+    out = subprocess.run([sys.executable, str(GENERATOR), "--check"],
+                         capture_output=True, text=True, cwd=REPO)
+    assert out.returncode == 0, (
+        f"personas-index/use-when.md is hand-edited or stale against the corpus:\n"
+        f"{out.stdout}{out.stderr}\n"
+        f"Regenerate with `python3 add-method/scripts/build_persona_index.py`.")
+
+
+def test_empty_corpus_fails_loud():
+    """E1 — zero personas must raise, never read as complete coverage."""
+    global CORPUS
+    real, missing = CORPUS, REPO / "personas-teacher-does-not-exist"
+    try:
+        CORPUS = missing
+        with pytest.raises(AssertionError, match="empty or missing"):
+            _corpus_files()
+    finally:
+        CORPUS = real
+
+
+def test_check_reports_what_it_skipped():
+    """M4 — the silence is the defect.
+
+    `--check` reported "232 personas" and said nothing about the 22 corpus files it passed over.
+    A persona that loses its `description:` in a vendor refresh simply stops being routable, and
+    the only signal is a number that quietly gets smaller. Coverage has to be stated to be read.
+    """
+    out = subprocess.run([sys.executable, str(GENERATOR), "--check"],
+                         capture_output=True, text=True, cwd=REPO)
+    report = out.stdout + out.stderr
+    skipped = [p for p in _corpus_files() if not _is_persona(p)]
+    assert str(len(skipped)) in report, (
+        f"--check does not say how many corpus files it skipped ({len(skipped)} today); "
+        f"it reported only:\n  {report.strip()}")
+    assert re.search(r"skip", report, re.I), \
+        "--check never uses the word 'skipped' — the exclusion stays invisible to whoever reads it"

--- a/add-method/tests/skill/test_domains_recipe.py
+++ b/add-method/tests/skill/test_domains_recipe.py
@@ -1,0 +1,184 @@
+"""`domains.md` — the all-domain evidence ref, proved by EXECUTION not by phrase pins.
+
+The load-bearing test is `test_recipe_earns_bound_test_ids`: it lifts the checker recipe out of
+the shipped ref and runs the real ADD loop with it, in a real bundle, on a non-code domain node.
+If the recipe ever stops earning a bound `test-ids` receipt, this goes red — a phrase pin would
+have stayed green while the thing it documents rotted.
+
+Every test asserts the ref EXISTS before asserting anything about its content. A "must never
+contain X" assertion passes vacuously on a missing file, which is exactly the assert-nothing trap
+the method warns about (`FORMAT.md` §10).
+"""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL = REPO / "skill" / "add"
+DOMAINS = SKILL / "domains.md"
+
+# The closed floor set. A pack may map its own vocabulary ONTO these; it may never add to them.
+FLOORS = {"security", "data", "architecture"}
+# The profiles the engine actually ships. `init` falls back to `code` on anything else WITHOUT
+# refusing, so a ref that names a phantom profile produces a bundle that lies about its own domain.
+SHIPPED_PROFILES = {"code", "doc"}
+
+
+def _text() -> str:
+    assert DOMAINS.exists(), "skill/add/domains.md does not exist"
+    return DOMAINS.read_text(encoding="utf-8")
+
+
+def _recipe_block() -> str:
+    """The runnable checker the ref publishes, lifted from its `<!-- checker-recipe -->` anchor.
+
+    Extracted rather than duplicated: a copy in this file would let the shipped recipe rot while
+    the test kept passing against its own private fork.
+    """
+    text = _text()
+    m = re.search(r"<!--\s*checker-recipe\s*-->\s*```python\n(.*?)```", text, re.DOTALL)
+    assert m, "domains.md publishes no `<!-- checker-recipe -->` fenced python block"
+    return m.group(1)
+
+
+def _run(*args, cwd):
+    return subprocess.run([sys.executable, str(Path(cwd) / ".add/tooling/cli.py"), *args],
+                          cwd=str(cwd), capture_output=True, text=True)
+
+
+def test_recipe_earns_bound_test_ids(tmp_path):
+    """The whole claim of this milestone, executed: a NON-CODE domain node reaches the top rung."""
+    proj = tmp_path / "ledger"
+    proj.mkdir()
+    subprocess.run(["git", "init", "-q", "."], cwd=proj, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=proj, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=proj, check=True)
+
+    sys.path.insert(0, str(REPO / "tooling"))
+    import add  # noqa: E402 — the vendoring engine, same one the installer drops
+    add.init(proj / ".add", "doc", "Ledger")
+
+    # the domain artifact under check — data, not code
+    (proj / "recon.json").write_text(json.dumps(
+        {"gross": 1_000_000, "variance": 3_200,
+         "lines": [{"id": "v1", "amt": 3_200, "source_doc": "BS-2026-07-p4"}]}))
+    checks = proj / "checks"
+    checks.mkdir()
+    (checks / "recon.py").write_text(_recipe_block())
+    subprocess.run(["git", "add", "-A"], cwd=proj, check=True)
+    subprocess.run(["git", "commit", "-qm", "recon"], cwd=proj, check=True)
+
+    _run("new", "Task", "recon", "--title", "Reconcile", "--depth", "standard",
+         "--scope", "recon.json", cwd=proj)
+    node = proj / ".add/tasks/recon.md"
+    raw = node.read_text(encoding="utf-8")
+    raw = raw.replace("  - S1 <the surface this publishes — an endpoint, function, or section>",
+                      "  - S1 the month-end reconciliation report")
+    body = raw.split("---", 2)[2]
+    for heading, new in (
+        ("RULES", "<must>\n- M1 unexplained variance stays within materiality\n</must>\n"
+                  "<reject>\n- R:UNEXPLAINED a variance line with no cited source document"
+                  ' -> "UNEXPLAINED"\n</reject>'),
+        ("ASSUMPTIONS", "\n".join(
+            f"- A{i} [{d}] covers: S1 · n/a · fixed by the fixture"
+            for i, d in enumerate(add.SWEEP_DIMENSIONS, 1))),
+        ("CHECKS", "- checks.recon::test_variance_within_materiality · covers: M1 · within materiality\n"
+                   "- checks.recon::test_every_variance_line_cited · covers: R:UNEXPLAINED · every line cited\n"
+                   "red-first: every check MUST fail first."),
+    ):
+        lines = body.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.strip() == f"## {heading}")
+        end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
+        body = "\n".join(lines[:start + 1] + [new] + lines[end:])
+    node.write_text(raw.split("---", 2)[0] + "---" + raw.split("---", 2)[1] + "---" + body)
+
+    assert _run("freeze", "recon", "--by", "t", "--authority", "human", cwd=proj).returncode == 0
+    _run("brief", "recon", cwd=proj)
+    run = _run("run", "recon", "--junitxml", "r.xml", "--",
+               sys.executable, "checks/recon.py", "r.xml", cwd=proj)
+    assert run.returncode == 0, run.stdout + run.stderr
+
+    receipt = sorted((proj / ".add/tasks/recon.d/runs").glob("*.md"))[-1].read_text()
+    assert "kind: test-ids" in receipt, f"recipe did not reach the top rung:\n{receipt}"
+    assert "freshness: content" in receipt, f"recipe did not earn a content digest:\n{receipt}"
+    for cited in ("test_variance_within_materiality", "test_every_variance_line_cited"):
+        assert cited in receipt.split("passed:", 1)[-1], f"{cited} not bound in the receipt"
+
+    gate = _run("gate", "recon", "PASS", "--by", "t", cwd=proj)
+    assert "PASS" in gate.stdout and gate.returncode == 0, gate.stdout + gate.stderr
+
+
+def test_domains_exists_within_surface_budget():
+    """M3 — the ref must exist AND be funded.
+
+    Binding M3 to the pre-existing `test_total_surface_within_budget` was wrong: that test is
+    green with no `domains.md` at all, so it would have ridden into the freeze proving nothing.
+    Existence is the conjunct that makes this red before the build.
+    """
+    _text()  # existence first — the budget alone is satisfied by writing nothing
+    own = [p for p in SKILL.rglob("*.md") if "persona-author" not in p.relative_to(SKILL).parts]
+    total = sum(len(p.read_text(encoding="utf-8").splitlines()) for p in own)
+    assert total <= 1500, f"skill surface is {total} lines (budget 1500) — fund the add by compressing"
+
+
+def test_floor_map_targets_only_existing_floors():
+    """Every floor the map routes TO is one the engine already computes."""
+    rows = re.findall(r"^\|[^|]+\|\s*`?([a-z]+)`?\s*(?:floor)?\s*\|", _text(), re.M)
+    assert rows, "domains.md publishes no floor-mapping table rows"
+    stray = {r for r in rows} - FLOORS
+    assert not stray, f"floor map targets floors the engine does not compute: {sorted(stray)}"
+
+
+def test_introduces_no_new_floor_name():
+    """R:NEWFLOOR — a pack may rename nothing into the floor vocabulary."""
+    claimed = set(re.findall(r"`([a-z]+)`\s+floor", _text()))
+    stray = claimed - FLOORS
+    assert not stray, f"domains.md introduces floor names outside the closed set: {sorted(stray)}"
+
+
+def test_states_freshness_degrade(tmp_path):
+    """E1 — a domain with no digestible artifact.
+
+    POST-HOC GUARD, not a red-first check: `domains.md` already carried this sentence when the
+    check was written, because E1 was authored as a gate referent with no check covering it and
+    the gate caught it after the build. Recorded as a guard so it cannot silently drop out.
+    """
+    text = _text()
+    assert re.search(r"mtime", text), "the ref never names the mtime fallback"
+    assert re.search(r"freshness falls back to mtime", text), \
+        "the ref must say the freshness degrade OUT LOUD, not merely mention mtime"
+
+
+def test_unmapped_word_routes_to_size_up():
+    """E2 — a domain word the map does not carry must route to size-up, never to silence.
+
+    POST-HOC GUARD — same provenance as `test_states_freshness_degrade`.
+    """
+    text = _text()
+    assert re.search(r"size up", text), "the ref never routes an unmapped word to size-up"
+    assert re.search(r"[Aa]bsence from the table is never evidence", text), \
+        "the ref must deny the silence reading explicitly, not just recommend sizing up"
+
+
+def test_recipe_buys_no_gate():
+    """R:GATEBUY — the ref must never teach a cheaper route to a verdict."""
+    text = _text()
+    for banned, why in (
+        (r"gate\s+\S+\s+RISK-ACCEPTED", "instructs RISK-ACCEPTED as a domain route"),
+        (r"--authority\s+process", "instructs a hand-lowered authority"),
+        (r"human-observed", "names a rung the engine cannot stamp"),
+        (r"artifact-hash", "names a rung the engine cannot stamp"),
+    ):
+        assert not re.search(banned, text), f"domains.md {why}"
+
+
+def test_names_no_phantom_profile():
+    """R:PHANTOMPROFILE — `init` silently falls back to `code` on an unknown profile."""
+    named = set(re.findall(r"--profile\s+([a-z]+)", _text()))
+    stray = named - SHIPPED_PROFILES
+    assert not stray, (f"domains.md instructs profiles the engine does not ship: {sorted(stray)} "
+                       f"— init would silently write the `code` lenses under that name")

--- a/add-method/tests/skill/test_evidence_ladder.py
+++ b/add-method/tests/skill/test_evidence_ladder.py
@@ -1,0 +1,89 @@
+"""The documented evidence ladder must match the kinds the engine can actually stamp.
+
+`verify.md` promised `test-ids > artifact-hash > command-exit > human-observed`. The engine writes
+exactly `test-ids`, `command-exit` (add.py, the run receipt) and `sources` (the explore gate). So
+the doc was wrong in BOTH directions: two rungs nothing could ever earn, and one real kind it never
+named. An evidence kind that can never be earned is not a ladder, it is a label — the engine's own
+comment says so about `test-ids` before e12 made it reachable.
+
+The guard DERIVES the set from `add.py` rather than pinning literals. A pinned list would go stale
+exactly the way the prose it replaces did: silently, and only visible to someone who went looking.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL = REPO / "skill" / "add"
+ENGINE = REPO / "tooling" / "add.py"
+
+# Both shapes ANCHOR on `kind` itself. An earlier version also matched any `"a" if x else "b"`
+# ternary, which swept up freshness values (`content`/`mtime`) and unrelated statuses — a derived
+# guard is only as honest as its anchor, and an over-broad one manufactures its own failures.
+KIND_SITES = (
+    re.compile(r'"kind":\s*([^,\n]+)'),   # dict form, incl. a ternary: "test-ids" if ids else ...
+    re.compile(r'\bkind:\s*([a-z-]+)\s*,'),   # formatted stamp: ', kind: sources, ...'
+)
+QUOTED = re.compile(r'"([a-z-]+)"')
+
+
+def engine_kinds(source: str) -> set:
+    """Every evidence kind the given engine source can stamp. Raises on an empty extraction.
+
+    E1: a kind stamped in a branch these patterns cannot see would silently shrink the set, and a
+    guard that then passes because it compared against nothing is worse than no guard at all.
+    """
+    found = set()
+    for m in KIND_SITES[0].finditer(source):
+        found |= set(QUOTED.findall(m.group(1)))
+    found |= set(KIND_SITES[1].findall(source))
+    if not found:
+        raise AssertionError("extracted no evidence kinds from the engine — the patterns have "
+                             "drifted from how receipts are written; fix the extractor, do not "
+                             "relax the check")
+    return found
+
+
+def _documented() -> set:
+    """Every kind the skill names as an evidence rung, from the whole ladder PARAGRAPH.
+
+    Reading one physical line was wrong: an honest ladder needs a sentence per kind to say what
+    earns it, so the prose wraps, and a single-line read silently dropped every rung past the
+    first. Shaping the doc back onto one line to suit the parser would have traded readable
+    guidance for a lazy regex — the same trade this task exists to undo.
+    """
+    text = (SKILL / "phases" / "verify.md").read_text(encoding="utf-8")
+    lines = text.splitlines()
+    start = next((i for i, ln in enumerate(lines) if "Evidence kinds" in ln), None)
+    assert start is not None, "verify.md no longer states an evidence ladder"
+    end = next((i for i in range(start, len(lines)) if not lines[i].strip()), len(lines))
+    return set(re.findall(r"`([a-z-]+)`", "\n".join(lines[start:end])))
+
+
+def test_documented_rungs_are_stampable():
+    """M1 — no rung the engine cannot earn."""
+    phantom = _documented() - engine_kinds(ENGINE.read_text(encoding="utf-8"))
+    assert not phantom, (f"the skill documents evidence kinds the engine can never stamp: "
+                         f"{sorted(phantom)} — an unearnable rung is a label, not a ladder")
+
+
+def test_stampable_rungs_are_documented():
+    """M2 — the orphan direction: a real kind no doc names."""
+    missing = engine_kinds(ENGINE.read_text(encoding="utf-8")) - _documented()
+    assert not missing, (f"the engine stamps kinds the skill never names: {sorted(missing)} — "
+                         f"a reader cannot recognise a receipt kind nobody told them exists")
+
+
+def test_rung_set_is_derived_not_pinned():
+    """R:PINSTRINGS — prove the extractor reads the engine instead of carrying a literal list."""
+    fabricated = 'receipt = {"kind": "totally-made-up-kind", "exit": 0}'
+    assert "totally-made-up-kind" in engine_kinds(fabricated), \
+        "the extractor did not pick up a fabricated kind — it is pinning literals, so it will go " \
+        "stale the same way the prose did"
+
+
+def test_extractor_fails_loud_on_empty():
+    """E1 — an extraction that finds nothing must raise, never pass vacuously."""
+    with pytest.raises(AssertionError, match="extracted no evidence kinds"):
+        engine_kinds("def run():\n    return 0\n")

--- a/add-method/tests/skill/test_receipt_artifact.py
+++ b/add-method/tests/skill/test_receipt_artifact.py
@@ -1,0 +1,98 @@
+"""The receipt scratch file must not land in the working tree.
+
+Two things are easy to conflate and only one is required:
+
+  the JUnit XML   REQUIRED. It is what upgrades a receipt from `command-exit` (an exit code)
+                  to `test-ids` (named checks). `covers:` binds against the IDs the runner
+                  REPORTED, so with no XML nothing binds and the gate refuses every bound
+                  rule — verified at standard AND quick depth.
+  the path        NOT required. The engine parses whatever path it is handed. Verified:
+                  `--junitxml /tmp/add-run-probe.xml` → kind test-ids, 2/2 reported, gate
+                  PASS, zero repo footprint.
+
+So the fix is docs-only. Nothing is ignored anywhere, because nothing lands anywhere.
+The leak was hit live during `domain-evidence-recipe`, where `r.xml` reached the index.
+"""
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+ADD_METHOD = REPO / "add-method"
+SKILL_TREES = [ADD_METHOD / "skill" / "add",
+               ADD_METHOD / "src" / "add_method" / "_bundled" / "skill" / "add",
+               REPO / ".claude" / "skills" / "add"]
+DOC_FILES = [ADD_METHOD / "GETTING-STARTED.md", *(ADD_METHOD / "docs").glob("*.md")]
+
+# A backtick ENDS the token: these paths sit inside markdown inline code, and the closing
+# backtick is markup, not part of the shell argument. Excluding it is correct parsing.
+# Contrast with the quote: a quote IS part of the argument, and tolerating its absence is
+# exactly what let three variants through the first gate — so that stayed strict, this did not.
+JUNITXML = re.compile(r"--junitxml[= ]([^\s`]+)")
+# a documented path is out-of-tree if it is absolute or resolves through a temp-dir variable
+OUT_OF_TREE = re.compile(r"^(\$\{?TMPDIR|/tmp/|\$TMPDIR)")
+PLACEHOLDER = re.compile(r"^<")
+
+
+def _unquote(path: str) -> str:
+    """Read the argument the way a SHELL would, not the way a regex first captures it.
+
+    `--junitxml "${TMPDIR:-/tmp}/add-run.xml"` is correct — and better — shell than the bare
+    form, but the naive capture keeps the opening quote, so every out-of-tree check read it as
+    relative and failed. The docs were right and this parser was wrong; reshaping the docs to
+    satisfy it would have shipped worse shell to make a broken check green.
+    """
+    return path.strip().strip('"\'').rstrip("`")
+
+
+def _instructed():
+    """(source, path) for every documented `--junitxml` argument on a shipped surface."""
+    out = []
+    for base in (*SKILL_TREES, *DOC_FILES):
+        files = sorted(base.rglob("*.md")) if base.is_dir() else [base]
+        for f in files:
+            if f.is_file():
+                out += [(f, _unquote(m.group(1)))
+                        for m in JUNITXML.finditer(f.read_text(encoding="utf-8"))]
+    return out
+
+
+def test_documented_receipt_paths_are_outside_the_tree():
+    """M1 — every instructed path resolves outside the working tree."""
+    found = _instructed()
+    assert found, "no --junitxml instruction found at all — the search is broken, not the docs"
+    stray = sorted({(str(f.relative_to(REPO)), p) for f, p in found
+                    if not OUT_OF_TREE.match(p) and not PLACEHOLDER.match(p)})
+    assert not stray, f"receipt scratch documented inside the working tree: {stray}"
+
+
+CANONICAL = '"${TMPDIR:-/tmp}/add-run.xml"'
+
+
+def test_receipt_path_has_one_canonical_form():
+    """M3 — one form, quoted, everywhere.
+
+    The first gate passed on THREE variants (8 bare, 1 quoted, 1 with a stray trailing backtick).
+    Every one is valid bash and `_unquote` accepted them all, so the check was honest about what
+    it claimed — out-of-tree — and blind to the thing nobody had claimed. Bare `${TMPDIR:-/tmp}`
+    also word-splits if TMPDIR ever contains a space. This pins the raw documented string, before
+    any unquoting, so a variant cannot slip back in.
+    """
+    variants = {}
+    for base in (*SKILL_TREES, *DOC_FILES):
+        files = sorted(base.rglob("*.md")) if base.is_dir() else [base]
+        for f in files:
+            if not f.is_file():
+                continue
+            for m in JUNITXML.finditer(f.read_text(encoding="utf-8")):
+                variants.setdefault(m.group(1), []).append(str(f.relative_to(REPO)))
+    assert variants, "no --junitxml instruction found at all — the search is broken"
+    stray = {v: sorted(set(w)) for v, w in variants.items() if v != CANONICAL}
+    assert not stray, f"documented receipt path is not canonical ({CANONICAL}): {stray}"
+
+
+def test_no_shipped_doc_writes_into_the_tree():
+    """R:TREELEAK — a relative path is in-tree by definition, wherever it points."""
+    leaks = sorted({(str(f.relative_to(REPO)), p) for f, p in _instructed()
+                    if not p.startswith(("/", "$")) and not PLACEHOLDER.match(p)})
+    assert not leaks, (f"shipped docs instruct an in-tree receipt artifact: {leaks} — "
+                       f"a relative path lands in whatever directory the agent ran from")

--- a/add-method/tests/skill/test_router_pointers.py
+++ b/add-method/tests/skill/test_router_pointers.py
@@ -1,0 +1,70 @@
+"""The always-loaded router must be honest about profiles, and must not orphan its own refs.
+
+`test_every_wired_verb_is_documented` (test_surface.py) already guards the ORPHAN direction for
+VERBS — a verb the engine ships that no doc names. Nothing guarded it for REFS, which is exactly
+how `domains.md` shipped unreachable: ten bound checks proved it correct, mirrored and within
+budget, and not one asked whether anything named it. A ref nobody loads cannot do its job,
+whatever its contents prove.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL = REPO / "skill" / "add"
+ROUTER = SKILL / "SKILL.md"
+sys.path.insert(0, str(REPO / "tooling"))
+
+import add  # noqa: E402 — the engine is the authority on which profiles exist
+
+
+def _own_refs():
+    """Every ref this router is responsible for surfacing.
+
+    `persona-author/` is a NESTED sub-skill with its own SKILL.md and its own budget — loaded on
+    its own terms, never as part of this router's disclosure cost. Same carve-out `_own_docs()`
+    makes in test_surface.py; the orphan rule must not fight a deliberate exemption (E1).
+    """
+    return [p for p in SKILL.rglob("*.md")
+            if p.name != "SKILL.md" and "persona-author" not in p.relative_to(SKILL).parts]
+
+
+def test_router_names_only_shipped_profiles():
+    """M1 — `init` silently falls back to `code` on an unknown profile, so an ellipsis lies."""
+    text = ROUTER.read_text(encoding="utf-8")
+    shipped = set(add.PROFILES)
+    named = set()
+    for m in re.finditer(r"--profile\s+(?:<([^>]+)>|([a-z]+))", text):
+        if m.group(2):
+            named.add(m.group(2))
+        else:
+            named |= {p.strip() for p in m.group(1).split("|")}
+    assert named, "SKILL.md names no profile at all"
+    stray = named - shipped
+    assert not stray, (f"SKILL.md names profiles the engine does not ship: {sorted(stray)} — "
+                       f"`init` writes the `code` lenses under any unknown name without refusing")
+
+
+def test_no_orphan_refs():
+    """M2 — a ref the always-loaded router never names is unreachable."""
+    text = ROUTER.read_text(encoding="utf-8")
+    orphans = sorted(str(p.relative_to(SKILL)) for p in _own_refs()
+                     if str(p.relative_to(SKILL)) not in text and p.name not in text)
+    assert not orphans, (f"refs no agent will ever load, because SKILL.md names none of them: "
+                         f"{orphans}")
+
+
+def test_router_points_at_the_checker_recipe():
+    """M3 — the router must say a checker MAY BE WRITTEN, not merely that one may be run."""
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "domains.md" in text, "the router never names domains.md"
+    assert re.search(r"write (the|a|one)\b", text, re.I), \
+        "the router never tells an agent it may WRITE a checker when no runner exists"
+
+
+def test_orphan_rule_exempts_nested_subskill():
+    """E1 — persona-author/ has its own budget and must not be forced into the router."""
+    nested = [p for p in SKILL.rglob("*.md") if "persona-author" in p.relative_to(SKILL).parts]
+    assert nested, "persona-author/ is gone — E1's premise changed, re-check the exemption"
+    assert not any(str(p.relative_to(SKILL)) in {str(q.relative_to(SKILL)) for q in _own_refs()}
+                   for p in nested), "the orphan rule swallowed the nested sub-skill"


### PR DESCRIPTION
## What this is

ADD's evidence ladder already worked for any domain. Nothing said so, so nobody used it.

A finance task — a materiality Must and a citation Reject, checked by ~20 lines of
project-space Python emitting JUnit XML — earns `kind: test-ids`, `freshness: content`
blob-digested on a JSON artifact, and refuses both a stale receipt and a blown threshold.
**With no engine change.** `add run` parses JUnit XML and does not care what produced it.

That probe reframed the whole milestone. It was scoped as domain packs plus an engine-level
evidence adapter; it shipped as ~150 lines of documentation and 16 derived guards, and
**zero engine bytes**.

## The five tasks

| Task | What it closed |
|---|---|
| `domain-evidence-recipe` | `skill/add/domains.md` — the checker recipe, the floor-vocabulary map (domain words route ONTO the closed three, upward only), the lens re-author table |
| `receipt-artifact-leak` | `--junitxml r.xml` leaked a JUnit report into the repo root on every run. One canonical out-of-tree path across 14 files |
| `skill-pointer-truth` | The router now says "no runner? **write one**" and names `domains.md`. Plus `test_no_orphan_refs` |
| `ladder-honesty` | `verify.md` promised `artifact-hash` and `human-observed`, which the engine cannot stamp, and omitted `sources`, which it does |
| `corpus-depth` | Premise void — the corpus is vendored (`shutil.rmtree` on refresh) and already broad. Redirected to coverage guards; the generator now reports its 24 silent exclusions |

## The finding worth reviewing

Five tasks, **one defect class**: nothing checks shipped prose against engine reality.
Phantom profiles · two orphan refs (`terms.md` had been unreachable long before this work) ·
two unstampable rungs · the receipt leak · 24 silent corpus exclusions.

Every fix **derives** its expectation from `add.py` rather than pinning a string, so it stays
true as the engine moves. The general guard that would replace all five is the natural
follow-up.

## Reviewer note — the failure trail is the interesting part

`domain-evidence-recipe`'s `verified[]` reads:
freeze → run → **refreeze** → run → **HARD-STOP** → refreeze → run → PASS.

- **gate 1** refused all 8 referents: `covers:` citations used `path.py::name`, which resolves
  to neither a qualified ID nor a bare name — and E1/E2 were authored as referents with no
  covering checks. *The gate binds EDGES exactly as it binds Musts.*
- **gate 2** was a HARD-STOP: the architecture residue lens caught a mirror-parity break, and
  the fix sat outside the frozen scope.
- On `receipt-artifact-leak`, the frozen scope **stopped a bad fix**: the only in-scope way to
  green a defective regex was to un-quote `"${TMPDIR:-/tmp}/..."` and ship worse shell. The
  check was wrong and the artifact was right.

None of that was caught by reading a diff.

## Verification

- suite **663 passed, 7 skipped** (647 at milestone start)
- SKILL.md **172/176** · skill surface **1352/1500**
- three skill trees byte-identical · **no engine bytes touched**

## Known residuals

- `init` still accepts any `--profile` and silently writes the `code` lenses under it. The one
  true engine fix, deferred by the no-engine-change constraint; `domains.md` routes around it.
- `domain-evidence-recipe` carries no advisory lens (`add doctor` info).
- The book chapter on domains is not written.
