### PR TITLE
fix(test): a partial test run says what it did not cover

### DIFF
--- a/.add/specs/quality.md
+++ b/.add/specs/quality.md
@@ -13,6 +13,7 @@ what counts as proof
 
 ## Deltas
 - <what changed, and the evidence that changed it>
+- [TDD · open] A green suite is only evidence about the tests that RAN. The command that runs a subset must not produce output shaped like the command that runs everything — an uncollected suite reports as a smaller number, and a smaller number reads as success. (evidence: /tasks/partial-run-visible.md)
 - [TDD · open] an assumption is worth writing only if you will go DISPROVE it: A1 assumed the installers pass --profile through. Ten minutes of reading bin/cli.js showed its 'profile' is agent detection and the flag is ignored — with its value silently becoming the target directory. The assumption cost a shipped falsehood because it was recorded and then trusted rather than tested (evidence: .add/tasks/profile-refusal.md)
 - [TDD · open] a derived guard must distinguish a DEAD name from a LAZILY-CREATED one: probing with `init` alone made the corrected prose .add/tasks/<slug>.md fail beside the state.json it replaced. Drive the probe through a bundle that has been USED (init + first task), which still refuses names no sequence of verbs produces (evidence: add-method/tests/skill/test_front_door_truth.py)
 - [TDD · open] a 'must never contain X' check passes vacuously when the file is missing — assert existence FIRST or it rides into the freeze proving nothing (evidence: add-method/tests/skill/test_domains_recipe.py:32)

--- a/.add/tasks/partial-run-visible.md
+++ b/.add/tasks/partial-run-visible.md
@@ -1,0 +1,69 @@
+---
+type: Task
+title: A partial test run must say so
+status: done
+depth: standard
+sensitivity: architecture
+scope:
+  - add-method/conftest.py
+  - add-method/pytest.ini
+  - add-method/tests/skill/test_run_completeness.py
+gives:
+  - S1 the notice a partial run prints when it collected fewer test roots than the repo has
+  - S2 the guard that every test root a bare run should reach is actually reachable
+generated: { by: add/3.2.0, at: 2026-08-12 }
+verified:
+  - { by: "Tin Dang", at: 2026-08-12, act: freeze, authority: human, direction: "sha256:b49bdd9134edc2ae" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:e966ac52f2b62953" }
+  - { by: "Tin Dang", at: 2026-08-12, act: refreeze, authority: human, direction: "sha256:b49bdd9134edc2ae" }
+  - { by: "cli", at: 2026-08-12, act: brief, authority: process, brief: "sha256:8c7db565edbd8da7" }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: FAIL, receipt: /tasks/partial-run-visible.d/runs/1.md }
+  - { by: "process:run", at: 2026-08-12, act: run, authority: process, outcome: PASS, receipt: /tasks/partial-run-visible.d/runs/2.md }
+  - { by: "Tin Dang", at: 2026-08-12, act: gate, authority: plan, outcome: PASS, receipt: /tasks/partial-run-visible.d/runs/2.md, brief: "sha256:8c7db565edbd8da7" }
+---
+## CARD
+goal: a test run that covered less than the whole suite says so in its own output, and a test root that a bare run cannot reach fails a check by name
+why: across an entire session I reported "suite green" from `pytest add-method/tests/` while `add-method/tooling/` — 8 checks, including the `ENGINE_MD5` pins, which CI also runs — was RED. Every green I reported was true of the suite I ran and silent about the one I did not. A red branch reached the point of merge on that basis. The repo was not at fault: `pytest.ini` already makes a bare `pytest` from `add-method/` collect all 715, and its comment already explains why `tooling/` must stay collectable. Nothing can stop someone typing a narrower command — but a run that covered part of the suite can refuse to look like a run that covered all of it.
+beat: done · next: add status
+
+## RULES
+<must>
+- M1 a run that collects from fewer than every known test root prints a notice naming the roots it did NOT reach, and the command that would
+- M2 the notice never fails the run — a narrow run while iterating is legitimate and making it an error would train people to pass a suppression flag
+- M3 a test root that a bare run cannot reach fails a check BY NAME, so a new suite cannot be added and go silently uncollected
+- M4 a full run prints nothing new — a notice that appears every time is one nobody reads
+</must>
+<reject>
+- R:GAGGED the notice must not be suppressible by an environment variable or flag added for convenience; the one thing it exists to survive is someone finding it inconvenient -> "gagged"
+- R:PINNED the set of known roots must be discovered from the tree, not written down — a hand-maintained list would have omitted `tooling/` exactly as I did -> "pinned"
+</reject>
+
+## ASSUMPTIONS
+- A1 [who] covers: S1, S2 · it does not say who the notice is for; taking it as whoever ran the command, human or agent, printed to the run's own terminal output rather than a log file, because the failure being fixed is someone READING a green summary and believing it covered everything -> if wrong, the notice lands somewhere nobody looks and the run still reads as complete
+- A2 [which] covers: S1, S2 · it does not say what counts as a test root; taking it as any directory holding a `test_*.py` file that a bare run from the package root would collect, which excludes the `eval/fixture/` sample project that `norecursedirs` already excludes for a documented reason -> if wrong, the notice fires on every run about a fixture that is not part of the suite, and M4 is defeated on day one
+- A3 [when] covers: S1, S2 · it does not say when the notice prints; taking it as at session finish, after the summary line, so it is the last thing on screen next to the count it qualifies -> if wrong, it scrolls past above hundreds of lines of test output and is never seen
+- A4 [absent] covers: S1, S2 · it does not say what to do when collection is empty or the run was aborted; taking it as: print nothing, because a run that collected nothing has an obvious problem of its own and a second message about coverage would bury it -> if wrong, a crashed run gains a confusing extra notice
+- A5 [order] covers: S1, S2 · it does not say whether root discovery must be deterministic; taking it as sorted, so two runs of the same partial command print the same list and a diff of two outputs is meaningful -> if wrong, the notice churns between runs and reads as noise
+- A6 [experience] covers: S1, S2 · it does not say what the reader needs from the notice; taking it as someone who believes they just ran the whole suite, so the notice must state what was MISSED rather than what ran, and hand them the exact command that would cover it — a bare "partial run" tells them nothing they can act on, and a count tells them less than a name -> if wrong, they read it as noise, learn to skip it, and the next stale pin ships exactly as this one did
+
+## PLAN
+contract: a `conftest.py` at the package root discovers every test root under it, compares that set against the roots the current session actually collected from, and at session finish prints the difference — the missed roots by name plus the command that covers them. Nothing is printed when the run was complete or collected nothing. A guard asserts the discovery is derived rather than listed, that every discovered root is reachable from a bare run, and that a full run stays silent.
+scope: add-method/conftest.py, add-method/pytest.ini, add-method/tests/skill/test_run_completeness.py
+widened after freeze: the reachability check found a REAL uncollected suite on its first execution — `norecursedirs = eval …` matches any directory NAMED eval, so `tests/eval` (2 tests) has never been collected by a bare run or by CI, while the exclusion was only ever meant for the top-level `eval/` fixture project. Fixing what the check found needs `pytest.ini`, which the original scope did not reach. Re-frozen rather than edited under seal.
+
+## EDGES
+- E1 the guard runs INSIDE the suite it is measuring, so it can see its own session's collected roots and would trivially pass whenever the full suite runs it. It must therefore establish reachability by asking the collector what a bare run WOULD collect, not by observing what the current run did.
+
+## CHECKS
+- test_every_test_root_is_reachable_from_a_bare_run · covers: M3, E1, R:PINNED · every directory holding a `test_*.py` under the package root is collected by a bare run, discovered from the tree rather than from a list
+- test_partial_run_names_what_it_missed · covers: M1, A6 · a run restricted to one root prints the missed roots by name and the command that covers them
+- test_full_run_prints_no_notice · covers: M4 · a complete run adds nothing to its output
+- test_notice_has_no_off_switch · covers: R:GAGGED, M2 · the notice is not gated on any environment variable or option, and its emission never changes the exit code
+red-first: 3 of 4 are red at freeze — `conftest.py` does not exist at the package root, so there is nothing to discover roots, nothing to print, and nothing to inspect for an off switch. The reachability check is red for a subtler reason worth stating: without the discovery helper it cannot enumerate roots at all, which is the same gap that let `tooling/` stay invisible. The fourth is green VACUOUSLY — nothing prints today, so a full run trivially prints no notice — and that is the honest reason, not a claim it is proving anything yet. It stays armed through the build as the one check that fails if the notice fires on a complete run, which is how M4 dies.
+
+## EVIDENCE
+receipt: <runs/<n>.md>
+gate: <PASS | RISK-ACCEPTED | HARD-STOP>
+
+## LESSONS
+- <lesson> -> add learn <lens>

--- a/add-method/conftest.py
+++ b/add-method/conftest.py
@@ -1,0 +1,82 @@
+"""Package-root conftest — a partial run says so.
+
+`pytest.ini` already makes a bare `pytest` from this directory collect the whole suite, and its
+comment already explains why `tooling/` must stay collectable. None of that helps when someone
+runs `pytest add-method/tests/` and reads the green summary as a verdict on everything. That
+happened here for a full session: `tests/` was green every time while `tooling/` — 8 checks,
+including the ENGINE_MD5 pins CI also runs — was red, and a red branch reached the point of merge
+on the strength of it.
+
+Nothing here tries to stop a narrow run. Running one directory while iterating is the right thing
+to do most of the time, and an error would only teach people to reach for a suppression flag —
+which is precisely what this must not have. It just removes the ambiguity: when the run covered
+part of the suite, the last line on screen says which part it didn't.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parent
+
+# Discovered, never listed. A hand-maintained list of test directories would have omitted
+# `tooling/` for the same reason a person does: it does not look like a test directory, it looks
+# like the engine's home. Whatever `norecursedirs` excludes (the `eval/` sample project, `.add/`
+# bundles left by a dogfood run) is excluded here too, by asking the same config.
+_SKIP = {".git", ".add", "node_modules", "build", "dist", "__pycache__", "eval"}
+
+# `eval/fixture/` is a nested sample project the eval driver (`tests/eval/`) copies and runs; its
+# tests import `src.calc` relative to their own root and must not be collected here. Anchored to
+# THIS directory on purpose: `norecursedirs = eval` matched the basename and swallowed
+# `tests/eval` too, and `--ignore=eval` resolves against rootdir, so it stopped applying the
+# moment pytest was invoked from the repo root. An absolute path holds from either.
+collect_ignore = [str(PKG / "eval")]
+
+
+def test_roots(pkg: Path = PKG) -> list:
+    """Every directory under `pkg` holding a `test_*.py`, sorted for a stable notice."""
+    found = set()
+    for path in pkg.rglob("test_*.py"):
+        rel = path.relative_to(pkg)
+        if rel.parts[0] in _SKIP or any(p.startswith(".") for p in rel.parts[:-1]):
+            continue
+        found.add(path.parent)
+    return sorted(found)
+
+
+def rel(path: Path, pkg: Path = PKG) -> str:
+    return path.relative_to(pkg).as_posix()
+
+
+def _top(path: Path, pkg: Path = PKG) -> str:
+    """The top-level root a directory belongs to — `tests/skill` reports under `tests`.
+
+    The notice is about which SUITE went unrun, not which leaf directory. Naming
+    `tests/book`, `tests/engine`, `tests/eval` and `tests/skill` separately when someone ran
+    `pytest tooling/` would bury the one word they need.
+    """
+    return path.relative_to(pkg).parts[0]
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Name the suites this run did not reach — after the summary line it qualifies.
+
+    Deliberately not `pytest_sessionfinish`: this hook writes through the terminal reporter, so
+    the notice lands with the rest of the report instead of after it.
+    """
+    collected = getattr(terminalreporter, "_session", None)
+    items = getattr(collected, "items", None) if collected else None
+    if not items:
+        return                      # A4 — a run that collected nothing has a louder problem
+
+    ran = {_top(Path(str(item.fspath)).parent) for item in items}
+    known = {_top(root) for root in test_roots()}
+    missed = sorted(known - ran)
+    if not missed:
+        return                      # M4 — silence on a complete run, or nobody reads it
+
+    terminalreporter.write_sep("=", "PARTIAL RUN", yellow=True)
+    terminalreporter.write_line(
+        f"not collected: {' · '.join(missed)} — this run says nothing about "
+        f"{'them' if len(missed) > 1 else 'it'}.")
+    terminalreporter.write_line(
+        f"full suite:    python3 -m pytest -q      (from {PKG.name}/, what CI runs)")

--- a/add-method/pytest.ini
+++ b/add-method/pytest.ini
@@ -6,4 +6,14 @@
 # eval/fixture/ is a nested sample project that the eval driver (tests/eval/) copies and runs; its
 # tests import `src.calc` relative to their own root and must not be collected here. Same for any
 # `.add/` bundle a dogfood run leaves behind.
-norecursedirs = eval .add .git node_modules *.egg build dist
+#
+# That exclusion lives in `conftest.py` as `collect_ignore`, NOT here, and the reason is worth
+# keeping. `norecursedirs` matches a BASENAME: the entry `eval` excluded the top-level fixture
+# project AND `tests/eval` — the driver this very comment names — so the driver's 2 tests were
+# never collected by a bare run or by CI. Nothing said so; the suite just reported a smaller
+# number. `--ignore=eval` fixes the over-match but is resolved against ROOTDIR, so it silently
+# stops applying when pytest is invoked from the repo root instead of here. `collect_ignore` is
+# anchored to the conftest's own directory and holds from either. Found by
+# test_every_test_root_is_reachable_from_a_bare_run on its first execution, then by its own
+# receipt run — which is the whole argument for both.
+norecursedirs = .add .git node_modules *.egg build dist

--- a/add-method/tests/skill/test_run_completeness.py
+++ b/add-method/tests/skill/test_run_completeness.py
@@ -1,0 +1,124 @@
+"""A test run that covered part of the suite must not look like one that covered all of it.
+
+Across a whole session I reported "suite green" from `pytest add-method/tests/` while
+`add-method/tooling/` — 8 checks, including the `ENGINE_MD5` pins that CI also runs — was RED.
+Every green was true of the suite I ran and silent about the one I did not, and a red branch
+reached the point of merge on that basis.
+
+The repo was not at fault. `pytest.ini` already makes a bare `pytest` from the package root
+collect all of it, and its comment already explains why `tooling/` must stay collectable. Nothing
+here can stop someone typing a narrower command, and nothing should: running one directory while
+iterating is the correct thing to do most of the time. What can be fixed is the *ambiguity* — a
+partial run now names what it missed, right underneath the summary line that would otherwise be
+read as a verdict on the whole suite.
+
+Two design choices worth defending:
+
+1. **The notice never fails the run** (M2). An error would teach people to reach for a suppression
+   flag, and a suppression flag is the one thing this must not have (R:GAGGED) — the failure mode
+   is somebody finding it inconvenient.
+2. **Roots are discovered, never listed** (R:PINNED). A hand-maintained list of test directories
+   would have omitted `tooling/` for exactly the reason I did: it does not look like a test
+   directory, it looks like the engine's home.
+
+E1 is the subtle one. This guard runs inside the suite it measures, so asking "did this session
+collect everything?" would pass trivially whenever the full suite is what ran it. Reachability is
+therefore established by asking a fresh collector what a BARE run would collect — a separate
+process, with no knowledge of how the current one was invoked.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parents[2]
+CONFTEST = PKG / "conftest.py"
+
+
+def _root_conftest():
+    """Load the package-root conftest BY PATH, under a name that cannot collide.
+
+    A plain `import conftest` works when this file is run alone and silently resolves to
+    `tests/engine/conftest.py` on a full run — pytest has already put that one in `sys.modules`
+    under the bare name `conftest`. The symptom was an AttributeError 700 tests in, on a check
+    that passed in isolation. Which is, with some irony, the same class of mistake this whole
+    task is about: a narrow run agreeing with you and a full run not.
+    """
+    spec = importlib.util.spec_from_file_location("add_root_conftest", CONFTEST)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bare_collect() -> str:
+    """What a bare `pytest` from the package root collects — a fresh process, not this session."""
+    return subprocess.run([sys.executable, "-m", "pytest", "--collect-only", "-q"],
+                          cwd=PKG, capture_output=True, text=True).stdout
+
+
+def test_every_test_root_is_reachable_from_a_bare_run():
+    """covers: M3, E1, R:PINNED — discovered from the tree, verified against a fresh collector."""
+    conftest = _root_conftest()
+
+    roots = conftest.test_roots(PKG)
+    assert roots, "root discovery found no test directories at all — it is not looking where it should"
+    assert any(r.name == "tooling" for r in roots), (
+        "discovery missed `tooling/` — the directory whose invisibility this task exists to fix. "
+        "It holds test_tree_parity.py and does not look like a test directory, which is the point")
+
+    collected = _bare_collect()
+    unreachable = [conftest.rel(r, PKG) for r in roots
+                   if f"{conftest.rel(r, PKG)}/" not in collected]
+    assert not unreachable, (
+        f"these test roots exist but a bare `pytest` from {PKG.name}/ does not collect them: "
+        f"{unreachable} — a suite nothing runs is a suite nothing proves. Either it belongs in the "
+        f"run, or it belongs in `norecursedirs` with the reason written down, as `eval/` is.")
+
+
+def test_partial_run_names_what_it_missed():
+    """covers: M1, A6 — the reader believes they just ran everything; tell them what they didn't."""
+    out = subprocess.run([sys.executable, "-m", "pytest", "tests/skill", "-q",
+                          "--collect-only"],
+                         cwd=PKG, capture_output=True, text=True).stdout
+
+    assert "PARTIAL RUN" in out, (
+        f"a run restricted to tests/skill printed no notice — this is the exact shape of the run "
+        f"that reported green all session while tooling/ was red. Output tail:\n{out[-600:]}")
+    assert "tooling" in out.split("PARTIAL RUN", 1)[1], (
+        "the notice fired but did not name `tooling/` — a count tells the reader less than a name, "
+        "and the whole point is that they can act on it")
+    assert re.search(r"pytest\b", out.split("PARTIAL RUN", 1)[1]), (
+        "the notice names what was missed but not the command that would cover it — 'you missed "
+        "something' without 'run this' is a message that gets learned and then skipped")
+
+
+def test_full_run_prints_no_notice():
+    """covers: M4 — a notice that appears every time is one nobody reads."""
+    out = subprocess.run([sys.executable, "-m", "pytest", "-q", "--collect-only"],
+                         cwd=PKG, capture_output=True, text=True).stdout
+    assert "PARTIAL RUN" not in out, (
+        "the complete run still printed the partial-run notice — it would be noise within a day, "
+        f"and noise is how a real warning gets ignored. Output tail:\n{out[-600:]}")
+
+
+def test_notice_has_no_off_switch():
+    """covers: R:GAGGED, M2 — the one thing it must survive is being found inconvenient."""
+    src = CONFTEST.read_text(encoding="utf-8")
+
+    gated = [m for m in re.findall(r"os\.environ[^\n]*|getenv\([^\n]*|addoption\([^\n]*", src)
+             if "PARTIAL" in src[max(0, src.find(m) - 400):src.find(m) + 400].upper()]
+    assert not gated, (
+        f"the notice is gated on something that can be switched off: {gated} — a warning with an "
+        f"off switch is a warning that will be off")
+
+    # M2: emission must not change the outcome. A partial collect-only run still exits clean.
+    proc = subprocess.run([sys.executable, "-m", "pytest", "tests/skill", "-q", "--collect-only"],
+                          cwd=PKG, capture_output=True, text=True,
+                          env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"})
+    assert proc.returncode == 0, (
+        f"a partial run exited {proc.returncode} — the notice is meant to inform, never to fail. "
+        f"Making it an error is what teaches people to silence it.")


### PR DESCRIPTION
## A partial test run says what it did not cover

Across a full session I reported *"suite green"* from `pytest add-method/tests/` while `add-method/tooling/` — 8 checks including the `ENGINE_MD5` pins CI also runs — was **red**. Every green was true of the suite I ran and silent about the one I didn't, and a red branch reached the point of merge on the strength of it.

**The repo was not at fault.** `pytest.ini` already made a bare `pytest` from `add-method/` collect everything, and its comment already explained why `tooling/` had to stay collectable. Nothing here stops a narrow run, and nothing should — running one directory while iterating is usually the right thing to do. What's fixed is the *ambiguity*:

```
================================= PARTIAL RUN ==================================
not collected: tooling — this run says nothing about it.
full suite:    python3 -m pytest -q      (from add-method/, what CI runs)
```

### Design

- **Roots are discovered, never listed.** A hand-maintained list would have omitted `tooling/` for the same reason a person does: it doesn't look like a test directory, it looks like the engine's home.
- **No off switch.** The one thing this must survive is somebody finding it inconvenient.
- **Never fails the run.** An error would only teach people to silence it. It informs; it does not gate.
- **Silent on a complete run.** A notice that appears every time is one nobody reads.

### Three real defects, each caught by the new checks rather than by reading

1. **`tests/eval` had never run** — not in a bare run, not in CI. `norecursedirs` matches a **basename**, so the entry meant for the top-level `eval/` fixture project also swallowed the eval driver that `pytest.ini`'s own comment names. Two tests, absent from every count this repo has ever reported.
2. **The first fix broke position-independence.** `--ignore=eval` resolves against **rootdir**, so it stopped applying the moment pytest ran from the repo root — caught by this task's own receipt run. Now `collect_ignore` anchored to the conftest's directory, which holds from either invocation point.
3. **`import conftest` silently resolved to `tests/engine/conftest.py`** on a full run. It passed in isolation and failed 700 tests in — the same class of mistake this task exists to fix: a narrow run agreeing with you and a full run not.

### Verification

- Collection **715 → 721**
- **714 passed, 7 skipped**, verified from **both** `add-method/` and the repo root
- `partial-run-visible` gate PASS @ `plan`, receipt `runs/2.md`, `freshness: fresh`
- Re-frozen once to widen scope to `pytest.ini`, after the reachability check found the uncollected suite on its first execution
