### PR TITLE
fix: a stamp the notary reports written is a stamp that reads back — and 3.3.0

### DIFF
--- a/.add/index.md
+++ b/.add/index.md
@@ -2,8 +2,8 @@
 abf_version: "1.3"
 name: AIDD-Book
 profile: code
-engine: add/3.2.0
-tooling_engine: add/3.2.0
+engine: add/3.3.0
+tooling_engine: add/3.3.0
 created: 2026-08-08
 sensitive_paths: []
 generated: { by: add/3.0.0, at: 2026-08-08 }

--- a/.add/specs/method.md
+++ b/.add/specs/method.md
@@ -13,6 +13,7 @@ how work proceeds, and what a gate costs
 
 ## Deltas
 - <what changed, and the evidence that changed it>
+- [ADD · open] A normaliser is only as good as the set of writers that call it. _oneline was correct and applied to one field of seven for a year; when a helper exists to make a value safe, enumerate its call sites FROM THE SOURCE in a check, because a hand list is how the seventh writer gets missed. (evidence: /tasks/stamp-field-integrity.md)
 - [ADD · open] A new verb is never one edit: it ripples into the CLI verb-set registry, the book command reference, both READMEs' verb counts, and five SKILL.md budget pins — one of which is literally R:BUDGET_BUMP, so fund the addition by compressing the prose beside it. (evidence: /tasks/freeze-interview.md)
 - [ADD · open] Eight freeze refusals checked the DOCUMENT and none checked the CONVERSATION. When a gate exists to protect a human decision, check that the decision was actually PUT to them — the assumption sweep made the AI write down what it decided, and nothing made it ask. (evidence: /tasks/freeze-interview.md)
 - [ADD · open] A guard written for one verdict is a guard for one verdict. When a refusal protects the RECORD rather than the EVIDENCE, condition it on the node, never on the verdict — sixteen sites each written verdict == PASS let RISK-ACCEPTED walk a never-frozen scaffold to done in three calls. (evidence: /tasks/risk-accepted-integrity.md)

--- a/.add/tasks/stamp-field-integrity.md
+++ b/.add/tasks/stamp-field-integrity.md
@@ -1,7 +1,7 @@
 ---
 type: Task
 title: A stamp the notary reports written is a stamp that reads back
-status: direction
+status: done
 depth: standard
 sensitivity: data
 scope:
@@ -11,12 +11,19 @@ gives:
   - S1 the stamp writers — every verb that appends a flow-map record to `verified:`
   - S2 the `_oneline` normaliser — what it must neutralise for a flow-map scalar
 generated: { by: add/3.2.0, at: 2026-09-01 }
-verified: []
+verified:
+  - { by: "Tin Dang", at: 2026-09-01, act: freeze, authority: human, direction: "sha256:e6b2551ca8df9afe" }
+  - { by: "cli", at: 2026-09-01, act: brief, authority: process, brief: "sha256:9c08d55836a6b8f8" }
+  - { by: "process:run", at: 2026-09-01, act: run, authority: process, outcome: PASS, receipt: /tasks/stamp-field-integrity.d/runs/1.md }
+  - { by: "Tin Dang", at: 2026-09-01, act: refreeze, authority: human, direction: "sha256:2293042cc7b4e254" }
+  - { by: "cli", at: 2026-09-01, act: brief, authority: process, brief: "sha256:f677674f76672298" }
+  - { by: "process:run", at: 2026-09-01, act: run, authority: process, outcome: PASS, receipt: /tasks/stamp-field-integrity.d/runs/2.md }
+  - { by: "Tin Dang", at: 2026-09-01, act: gate, authority: plan, outcome: PASS, receipt: /tasks/stamp-field-integrity.d/runs/2.md, brief: "sha256:f677674f76672298" }
 ---
 ## CARD
 goal: no operator-supplied value can make a stamp read back as something other than what the verb reported writing.
 why: `_oneline` is applied to `--reason` and to nothing else. Seven writers interpolate `by:` raw. Measured 2026-09-01: `add freeze t --by 'O"Brien' --authority human` prints `freeze recorded at authority `human`` and writes a record that parses back carrying ONLY `by` — `act`, `authority` and `direction` are swallowed by the unterminated scalar. `_is_frozen` is then False and `sealed_direction` is None: the seal silently does not exist while the human is told it does. It fails CLOSED (the gate refuses with R:UNSEALED, so nothing is let through), and that is the whole severity — but a notary whose only job is to record faithfully must never report a record it did not write. The trigger is an ODD number of `"`; a balanced pair (`Tin "TinDang97" Dang`) round-trips, which is exactly why this survived every real use.
-beat: scaffold · next: author stamp-field-integrity's RULES, ASSUMPTIONS and CHECKS, then add freeze stamp-field-integrity
+beat: done · next: add status
 
 ## RULES
 <must>
@@ -64,7 +71,7 @@ scope: add-method/tooling/add.py, add-method/tests/engine
 - test_an_empty_by_keeps_the_writers_default · covers: A4, E2 · `unrecorded` and `process:check` still land.
 - test_a_value_of_only_quotes_is_not_erased · covers: E3, R:LOSSY · normalising substitutes, never deletes.
 - test_the_library_is_safe_without_the_cli · covers: A5 · `add.freeze` called directly is enough.
-- test_a_flow_map_round_trips_every_punctuation · covers: A2 · quotes, braces, colons, commas and newlines.
+- test_a_flow_map_round_trips_every_punctuation · covers: A2, M4 · what the verb reports matches what the ledger holds, over every punctuation.
 - test_no_existing_stamp_is_rewritten · covers: A3, E4 · the fix touches the writer, not history.
 red-first: every check MUST fail first.
 

--- a/.add/tasks/stamp-field-integrity.md
+++ b/.add/tasks/stamp-field-integrity.md
@@ -1,0 +1,76 @@
+---
+type: Task
+title: A stamp the notary reports written is a stamp that reads back
+status: direction
+depth: standard
+sensitivity: data
+scope:
+  - add-method/tooling/add.py
+  - add-method/tests/engine
+gives:
+  - S1 the stamp writers — every verb that appends a flow-map record to `verified:`
+  - S2 the `_oneline` normaliser — what it must neutralise for a flow-map scalar
+generated: { by: add/3.2.0, at: 2026-09-01 }
+verified: []
+---
+## CARD
+goal: no operator-supplied value can make a stamp read back as something other than what the verb reported writing.
+why: `_oneline` is applied to `--reason` and to nothing else. Seven writers interpolate `by:` raw. Measured 2026-09-01: `add freeze t --by 'O"Brien' --authority human` prints `freeze recorded at authority `human`` and writes a record that parses back carrying ONLY `by` — `act`, `authority` and `direction` are swallowed by the unterminated scalar. `_is_frozen` is then False and `sealed_direction` is None: the seal silently does not exist while the human is told it does. It fails CLOSED (the gate refuses with R:UNSEALED, so nothing is let through), and that is the whole severity — but a notary whose only job is to record faithfully must never report a record it did not write. The trigger is an ODD number of `"`; a balanced pair (`Tin "TinDang97" Dang`) round-trips, which is exactly why this survived every real use.
+beat: scaffold · next: author stamp-field-integrity's RULES, ASSUMPTIONS and CHECKS, then add freeze stamp-field-integrity
+
+## RULES
+<must>
+- M1 `_oneline` neutralises the double quote as well as the brace, so a value it returns cannot terminate or re-key a flow-map scalar.
+- M2 Every writer that interpolates an operator-supplied value into a `verified:` flow map passes it through `_oneline` — `freeze`, `brief`, `replan`, `check`, `interview`, and both `gate` paths.
+- M3 A stamp written with any operator string reads back with every key the writer intended, and the actor is recognisable in the recorded value.
+- M4 A verb that cannot write a faithful record reports a refusal, never a success.
+</must>
+<reject>
+- R:LIE a verb must never report a stamp recorded when the record does not read back -> "R:LIE"
+- R:LOSSY normalising must not silently delete an actor's name down to nothing -> "R:LOSSY"
+</reject>
+
+## ASSUMPTIONS
+- A1 [who] covers: S1 · the request does not say whose values need normalising; taking every operator-supplied one — `by`, `reason`, `persona`, `note` — since the engine cannot tell a careful actor from a careless one -> if wrong a writer is missed and the defect survives in the one place nobody probed · probe: a check enumerates the writers from the SOURCE rather than from a hand list.
+- A2 [which] covers: S2 · the request does not say which characters break a flow map; taking the double quote (terminates a scalar) and the brace (ends the map), which is what `_oneline` already half-does -> if wrong another character corrupts a record · probe: a round-trip check over quotes, braces, colons, commas and newlines.
+- A3 [when] covers: S1 · the request does not say what happens to stamps ALREADY written badly; taking them as-is — this fixes the writer, never rewrites history, because an append-only ledger whose past entries can be edited is not a ledger -> if wrong an existing damaged bundle stays damaged · probe: the fix touches no reader and no existing file.
+- A4 [absent] covers: S2 · the request does not say what an EMPTY `by` means; taking the writers' existing defaults (`unrecorded`, `process:check`) unchanged -> if wrong a blank name becomes a silent anonymous stamp · probe: an empty `by` still lands its default, not an empty scalar.
+- A5 [order] covers: S2 · the request does not say whether normalising happens at the CLI or at the writer; taking the writer, so the library is safe for any caller and not only for `cli.py` -> if wrong a direct library user writes the bad record · probe: the check calls `add.freeze` directly, never the CLI.
+- A6 [experience] covers: S1 · the request does not say what the actor should see; taking substitution over rejection — a name is a person's, and refusing `O"Brien` teaches nothing -> if wrong an operator is blocked by their own name · probe: the quote becomes an apostrophe and the name stays recognisable.
+- A7 [who] covers: S2 · n/a · `_oneline` is a pure string function taking no actor.
+- A8 [which] covers: S1 · n/a · M2 names the writers exhaustively; A1's probe enumerates them from source.
+- A9 [when] covers: S2 · n/a · a pure function has no temporal boundary.
+- A10 [absent] covers: S1 · n/a · A4 covers the empty-value reading for both surfaces.
+- A11 [order] covers: S1 · n/a · stamps are appended in call order, which this task does not touch.
+- A12 [experience] covers: S2 · n/a · `_oneline` prints nothing; its experience is S1's.
+every `gives:` surface is swept on every dimension; `[<dim>] n/a · <why>` retires one. one line, one silence — split, never bundle. `· probe: <what shipped behavior must show>` declares a reading checkable: cite its A id from CHECKS and the gate holds the PASS to it.
+
+## PLAN
+contract: `_oneline` additionally maps `"` to `'`. The seven `by:` interpolations call it. No reader changes and no existing stamp is rewritten.
+scope: add-method/tooling/add.py, add-method/tests/engine
+
+## EDGES
+- E1 a BALANCED pair (`Tin "TinDang97" Dang`) — already round-trips; it must keep doing so.
+- E2 an empty `by` — the writer's own default still lands.
+- E3 a value that is nothing BUT quotes — normalising must not reduce it to an empty scalar (R:LOSSY).
+- E4 an existing bundle carrying an already-damaged stamp — untouched (A3).
+
+## CHECKS
+- test_oneline_neutralises_the_double_quote · covers: M1 · the returned value carries no `"`.
+- test_a_stamp_survives_an_odd_quote_in_by · covers: M2, M3, R:LIE · every intended key reads back and the seal exists.
+- test_the_actor_stays_recognisable · covers: A6, R:LOSSY · `O"Brien` reads back as `O'Brien`, not as nothing.
+- test_every_stamp_writer_normalises_its_by · covers: M2, A1, A8 · the writers are enumerated from the SOURCE, and each round-trips.
+- test_balanced_quotes_still_round_trip · covers: E1 · the incumbent case is unchanged.
+- test_an_empty_by_keeps_the_writers_default · covers: A4, E2 · `unrecorded` and `process:check` still land.
+- test_a_value_of_only_quotes_is_not_erased · covers: E3, R:LOSSY · normalising substitutes, never deletes.
+- test_the_library_is_safe_without_the_cli · covers: A5 · `add.freeze` called directly is enough.
+- test_a_flow_map_round_trips_every_punctuation · covers: A2 · quotes, braces, colons, commas and newlines.
+- test_no_existing_stamp_is_rewritten · covers: A3, E4 · the fix touches the writer, not history.
+red-first: every check MUST fail first.
+
+## EVIDENCE
+receipt: <runs/<n>.md>
+gate: <PASS | RISK-ACCEPTED | HARD-STOP>
+
+## LESSONS
+- A normaliser is only as good as the set of writers that call it: `_oneline` was correct and applied to one field of seven -> add learn add

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "ADD (AI-Driven Development). The agent is the hands; ADD is the memory, judgment, and conscience — a lean, state-tracked skill that drives every change through one atomic task node: Direction → Build → Verify, red/green TDD built in, trusted on a recorded receipt rather than a plausible diff. State lives on disk, so context rot never survives a new session.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [3.3.0] — 2026-09-01
+
+**The seal has to mean something under every verdict, and the one approval has to be asked for
+out loud.** 3.2 closed the hole where skipping `freeze` did not FAIL the post-freeze guards but
+SWITCHED THEM OFF — for `PASS`. Every one of `gate`'s integrity refusals was written
+`verdict == "PASS"`, so the identical hole stayed open one verdict over: a task created seconds
+earlier, still every template slot, never frozen and never briefed, reached `done` in three calls.
+And `freeze` itself refused an incomplete contract eight ways, every one of them checking the
+DOCUMENT. None checked the CONVERSATION — so ADD's one human approval was a single stamp that said
+nothing about whether the human had seen a single decision they were approving.
+
+### Added
+- **`add interview <slug>`** — puts a node's open decisions to a human before the approval. Every
+  non-`n/a` assumption and every Reject becomes a numbered question carrying the reading the AI
+  took and the cost if it is wrong. Bare it reads; `--answer <id>=confirm|correct|defer --by
+  "<name>"` records, writing a `.d/interviews/<n>.md` sidecar and one `act: interview` stamp.
+  `correct` never completes an interview — it is cleared by EDITING the item, which moves the
+  digest; `defer` does, because a human may accept a risk knowingly. Passes over the same text
+  accumulate in order, so an interview interrupted halfway is finished, not restarted.
+- **A `scaffold` beat** between created and frozen. `add new Task` wrote a file of placeholders and
+  five surfaces then recommended `freeze`, which is structurally guaranteed to refuse it. The beat
+  is derived from the SAME predicates the refusals call, never a copy, and sorts first in
+  `add todo`.
+- **Prose that claims the engine prints something must prove it.** Skill-tree claims naming a
+  backticked verb and a rendering are proven by DRIVING that command against a bundle in the state
+  the claim describes; the anchor is captured stdout. An unregistered claim fails by name.
+
+### Fixed
+- **`RISK-ACCEPTED` no longer walks past the integrity refusals.** They are now two named tuples
+  behind one predicate: INTEGRITY protects the RECORD (unsealed · drift · placeholders ·
+  undeclared-sensitive · phantom-scope) and binds every verdict that approves or closes; EVIDENCE
+  judges the RUN (stale receipt · failed run · unbound `covers:` · open questions · missing lens ·
+  missing brief) and stays PASS-only, because signing for imperfect evidence is what the verdict is
+  FOR. HARD-STOP is refused by neither — it never closes a task, so refusing it would only stop a
+  finding being written down.
+- **`done` checks the seal.** Any (re)freeze must precede the entitling gate.
+- **`freeze` refuses a template Milestone.** `placeholders_in` reads RULES · ASSUMPTIONS · CHECKS
+  and a Milestone body carries none of those three, so it returned `[]` for EVERY milestone and the
+  one human approval was stampable against a node stating no goal and no exit criterion.
+- **`_paths_touch` matches whole path segments.** Read as a string prefix, `scope: src` exempted a
+  changed `srcfoo/secret.yaml` from R:UNDECLARED_SENSITIVE, and `secrets_public/` answered for
+  `secrets/**`.
+- **An unreadable `sensitivity:` floors UP, and `new` refuses it.** `high` and `critical` both read
+  `process` — the LOWEST floor — so a node declaring more caution than the vocabulary knows got
+  less.
+- **A stamp the notary reports written now reads back.** `_oneline` was applied to `--reason` and
+  to nothing else while seven writers interpolated `by:` raw, so an ODD number of `"` in a name
+  terminated the scalar early: `freeze --by 'O"Brien'` PRINTED `freeze recorded` and wrote a record
+  carrying `by` alone, leaving the seal silently absent. It failed closed — the gate then refused
+  with R:UNSEALED — but a notary must never report a record it did not write.
+- **`card_drift` compares the DERIVED beat**, so a freshly frozen node no longer advertises the
+  approval it has just passed.
+
+### Changed
+- The CLI ships **24 verbs**. Skill guidance for the interviewed approval is in all three live
+  skill trees, funded by compressing adjacent prose rather than raising the SKILL.md budget.
+
 ## [3.2.0] — 2026-08-12
 
 **Experience becomes a question the plan must answer.** Every instrument ADD had was about

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "ADD (AI-Driven Development). The agent is the hands; ADD is the memory, judgment, and conscience — a lean, state-tracked skill that drives every change through one atomic task node: Direction → Build → Verify, red/green TDD built in, trusted on a recorded receipt rather than a plausible diff. State lives on disk, so context rot never survives a new session.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "3.2.0"
+version = "3.3.0"
 description = "ADD (AI-Driven Development). The agent is the hands; ADD is the memory, judgment, and conscience — a lean, state-tracked skill that drives every change through one atomic task node: Direction → Build → Verify, red/green TDD built in, trusted on a recorded receipt rather than a plausible diff. State lives on disk, so context rot never survives a new session. Installs the ADD skill and tooling into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "3.2.0"
+__version__ = "3.3.0"

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -836,7 +836,7 @@ RESERVED_FILES = ("index.md", "log.md", "PROJECT.md")
 
 # The engine version — one source of truth. `_stamp`, `init`'s `engine:`/`tooling_engine:` stamps,
 # and the drift-warn all read this, so a version bump is a single edit (M4).
-ENGINE = "add/3.2.0"
+ENGINE = "add/3.3.0"
 # Where `init` vendors from: the engine lives beside this file; the seed corpus sits at the bundle
 # root as its own managed tree (`.add/personas-teacher/` installed; `add-method/personas-teacher/`
 # in the package). `parents[1]` resolves both. Module-level so a test can repoint them to simulate a

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -1303,6 +1303,13 @@ def _oneline(note) -> str:
     An unbalanced `{` in a `--reason` made the parser's list-continuation swallow the FOLLOWING
     stamp: two records written, one read back, from an append-only ledger whose ordering IS the
     trust model (2026-08-28 review). `replan` already normalised its note; `gate` did not.
+
+    EVERY operator-supplied value interpolated into a flow map goes through here, not just
+    `reason`. It was applied to that one field for a year while seven writers interpolated `by`
+    raw, and an ODD number of `"` in a name then terminated the scalar early: `freeze --by
+    'O"Brien'` PRINTED `freeze recorded` and wrote a record that read back carrying `by` alone,
+    so `_is_frozen` was False and the seal silently did not exist (2026-09-01). A balanced pair
+    round-trips, which is why it survived every real use -> "R:LIE".
     """
     return (" ".join(str(note).split())
             .replace('"', "'").replace("{", "(").replace("}", ")"))
@@ -1517,7 +1524,7 @@ def freeze(root, cid: str, by: str, authority: str = None) -> tuple:
     act = "refreeze" if any(s.get("act") in ("freeze", "refreeze") for s in stamps
                             if isinstance(s, dict)) else "freeze"
     node, err = _transition(root, cid, appends=[
-        ("verified", f'{{ by: "{by}", at: {_today()}, act: {act}, authority: {authority}, '
+        ("verified", f'{{ by: "{_oneline(by)}", at: {_today()}, act: {act}, authority: {authority}, '
                      f'direction: "{direction_digest(node_t2)}" }}')])
     if err:
         return None, err + "\nnext: add status"
@@ -1745,7 +1752,7 @@ def check(root, cid: str, indices, off: bool = False, section: str = None,
         return True, (f"unchanged — box{'es' if len(idle) > 1 else ''} "
                       f"{', '.join(str(n) for n in idle)} in {cid} already {verb}\nnext: add status")
 
-    stamp = (f'{{ by: "{by or "process:check"}", at: {_today()}, '
+    stamp = (f'{{ by: "{_oneline(by or "process:check")}", at: {_today()}, '
              f'act: {"check" if want else "uncheck"}, '
              f'authority: {authority_for(scan(root), cid)}, '
              f'via: {via}, boxes: "{_stamp_boxes(moved)}" }}')
@@ -1968,7 +1975,7 @@ def replan(root, cid: str, note: str, by: str = "builder") -> tuple:
     # newline in the note would split it mid-map and take the node's whole trail with it.
     text = " ".join(str(note).split()).replace('"', "'")
     _, err = _transition(root, cid, appends=[
-        ("verified", f'{{ by: "{by}", at: {_today()}, act: replan, authority: process, '
+        ("verified", f'{{ by: "{_oneline(by)}", at: {_today()}, act: replan, authority: process, '
                      f'note: "{text}" }}')])
     if err:
         return None, err + "\nnext: add status"
@@ -2967,7 +2974,7 @@ def interview(root, cid: str, answers: dict = None, by: str = None) -> tuple:
     # decision — that is the human-readable record; this is the machine-readable delta.
     packed = "|".join(f"{d['id']}={answers[d['id']]}" for d in decisions if d["id"] in answers)
     node_w, err = _transition(root, cid, appends=[
-        ("verified", f'{{ by: "{by or "unrecorded"}", at: {_today()}, act: interview, '
+        ("verified", f'{{ by: "{_oneline(by or "unrecorded")}", at: {_today()}, act: interview, '
                      f'authority: human, interview: "{digest}", '
                      f'receipt: /tasks/{slug}.d/interviews/{n}.md, answers: "{_oneline(packed)}" }}')])
     if err:
@@ -3351,7 +3358,7 @@ def brief_stamp(root, cid: str, by: str = "cli") -> tuple:
                       f"\nnext: add freeze {slug}, then add brief {slug}")
     digest = brief(root, cid)["hash"]
     _transition(root, cid, appends=[("verified",
-        f'{{ by: "{by}", at: {_today()}, act: brief, authority: process, '
+        f'{{ by: "{_oneline(by)}", at: {_today()}, act: brief, authority: process, '
         f'brief: "{digest}" }}')])
     return digest, (f"brief {digest} recorded as the build entry"
                     f"\nnext: add run {slug} -- <cmd>")
@@ -3552,7 +3559,7 @@ def gate(root, cid: str, verdict: str, by: str, authority: str = None,
         authority = authority_for(graph, cid)
         extra = (f', kind: sources, closed: "{len(closed)}/{len(musts)}"'
                  if closes else "")
-        stamp = (f'{{ by: "{by}", at: {_today()}, act: gate, authority: {authority}, '
+        stamp = (f'{{ by: "{_oneline(by)}", at: {_today()}, act: gate, authority: {authority}, '
                  f'outcome: {verdict}{extra}'
                  + (f', reason: "{_oneline(reason)}"' if reason else "") + " }")
         _, t_err = _transition(root, cid, appends=[("verified", stamp)])
@@ -3704,7 +3711,7 @@ def gate(root, cid: str, verdict: str, by: str, authority: str = None,
 
     authority = authority_for(graph, cid)          # computed, never the caller's claim (M3)
     digest = brief(root, cid)["hash"]              # A16 — the instructions that drove the work
-    stamp = (f'{{ by: "{by}", at: {_today()}, act: gate, authority: {authority}, '
+    stamp = (f'{{ by: "{_oneline(by)}", at: {_today()}, act: gate, authority: {authority}, '
              f'outcome: {verdict}, receipt: {receipt_cid}, brief: "{digest}"'
              + (f', reason: "{_oneline(reason)}"' if reason else "") + " }")
     _, t_err = _transition(root, cid, appends=[("verified", stamp)])

--- a/add-method/tests/engine/test_stamp_field_integrity.py
+++ b/add-method/tests/engine/test_stamp_field_integrity.py
@@ -1,0 +1,181 @@
+"""A stamp the notary reports written is a stamp that reads back.
+
+`_oneline` exists because an unbalanced `{` in a `--reason` once made the parser's
+list-continuation swallow the FOLLOWING stamp — two records written, one read back, from an
+append-only ledger whose ordering IS the trust model. The fix was correct and was applied to
+exactly one field. Seven writers interpolate `by:` raw.
+
+Measured 2026-09-01, on the incumbent engine:
+
+    $ add freeze t --by 'O"Brien' --authority human
+    freeze recorded at authority `human`        <- reported as success
+    stamp keys read back: ['by']                <- act, authority, direction all swallowed
+    _is_frozen -> False · sealed_direction -> None
+
+The seal silently does not exist while the human is told it does. It fails CLOSED — the gate
+then refuses with R:UNSEALED — so nothing is let through, and that is the whole severity. But a
+notary whose only job is to record faithfully must never report a record it did not write.
+
+The trigger is an ODD number of `"`. A balanced pair round-trips, which is exactly why this
+survived every real use of the engine.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "tooling"))
+import add  # noqa: E402
+
+DIMS = ("who", "which", "when", "absent", "order", "experience")
+ODD = 'O"Brien'
+
+
+def _authored(root, slug="t"):
+    cid, _ = add.new(root, "Task", slug, title=slug)
+    p = root / cid.lstrip("/")
+    t = p.read_text(encoding="utf-8")
+    t = t.replace("- S1 <the surface this publishes — an endpoint, function, or section>", "- S1 x")
+    t = re.sub(r"## RULES\n<must>\n.*?\n</must>",
+               "## RULES\n<must>\n- M1 m\n</must>", t, flags=re.S)
+    t = re.sub(r"<reject>\n.*?\n</reject>", '<reject>\n- R:Z x -> "Z"\n</reject>', t, flags=re.S)
+    t = re.sub(r"## ASSUMPTIONS\n.*?\nevery `gives:`", "## ASSUMPTIONS\n" + "".join(
+        f"- A{i} [{d}] covers: S1 · n; taking r -> c\n" for i, d in enumerate(DIMS, 1)
+    ) + "every `gives:`", t, flags=re.S)
+    t = re.sub(r"## CHECKS\n.*?\nred-first",
+               "## CHECKS\n- test_x · covers: M1, R:Z · p\nred-first", t, flags=re.S)
+    p.write_text(t, encoding="utf-8")
+    return cid, p
+
+
+def _bundle(tmp_path):
+    add.init(tmp_path, "code", "T")
+    return tmp_path
+
+
+def _stamps(p):
+    return [s for s in (add.read(p, "T0")["fm"].get("verified") or []) if isinstance(s, dict)]
+
+
+# ------------------------------------------------------------------ M1 · the normaliser
+
+def test_oneline_neutralises_the_double_quote():
+    """covers: M1 — a scalar the notary builds must not be terminable by its own content."""
+    assert '"' not in add._oneline(ODD)
+    assert '"' not in add._oneline('a"b"c"d')
+
+
+def test_a_value_of_only_quotes_is_not_erased():
+    """covers: E3, R:LOSSY — substitute, never delete. An erased actor is its own falsehood."""
+    out = add._oneline('"""')
+    assert out.strip() != "", "the actor was normalised down to nothing"
+
+
+def test_a_flow_map_round_trips_every_punctuation(tmp_path):
+    """covers: A2 — quotes, braces, colons, commas and newlines, through a real write."""
+    root = _bundle(tmp_path)
+    for i, evil in enumerate(['a"b', 'a{b}', 'a}', 'a: b', 'a, b', 'a\nb', 'a"}{,b']):
+        cid, p = _authored(root, f"punct{i}")
+        node, note = add.freeze(root, cid, by=evil, authority="process")
+        assert node, f"{evil!r}: {note}"
+        st = _stamps(p)
+        assert len(st) == 1, f"{evil!r} wrote {len(st)} readable stamps"
+        assert st[0].get("act") == "freeze", f"{evil!r} lost `act`: {st[0]}"
+        assert st[0].get("authority") == "process", f"{evil!r} lost `authority`: {st[0]}"
+        assert st[0].get("direction", "").startswith("sha256:"), f"{evil!r} lost the seal: {st[0]}"
+
+
+# ------------------------------------------------------------------ M2/M3 · the writers
+
+def test_a_stamp_survives_an_odd_quote_in_by(tmp_path):
+    """covers: M2, M3, R:LIE — the headline: `freeze` said yes and the seal did not exist."""
+    root = _bundle(tmp_path)
+    cid, p = _authored(root, "odd")
+    node, note = add.freeze(root, cid, by=ODD, authority="human")
+    assert node, note
+
+    st = _stamps(p)
+    assert sorted(st[0]) == ["act", "at", "authority", "by", "direction"], st[0]
+    assert add._is_frozen(add.scan(root)[cid]), "the freeze was reported but the seal is absent"
+    assert add.sealed_direction(add.scan(root)[cid]["fm"]), "the direction digest was swallowed"
+
+
+def test_the_actor_stays_recognisable(tmp_path):
+    """covers: A6, R:LOSSY — a name is a person's; refusing or erasing it teaches nothing."""
+    root = _bundle(tmp_path)
+    cid, p = _authored(root, "actor")
+    add.freeze(root, cid, by=ODD, authority="process")
+    assert _stamps(p)[0]["by"] == "O'Brien"
+
+
+def test_every_stamp_writer_normalises_its_by():
+    """covers: M2, A1, A8 — enumerated from the SOURCE, never from a hand list.
+
+    A hand list is how the seventh writer gets missed, which is the defect this task exists for:
+    `_oneline` was correct and applied to one field out of seven.
+    """
+    src = (REPO / "tooling" / "add.py").read_text(encoding="utf-8")
+    raw = re.findall(r'by: "\{(?!_oneline)[^}]*\}', src)
+    assert raw == [], f"{len(raw)} stamp writer(s) still interpolate `by` raw: {raw}"
+
+
+def test_the_library_is_safe_without_the_cli(tmp_path):
+    """covers: A5 — normalising belongs to the writer, so any caller is safe, not only cli.py."""
+    root = _bundle(tmp_path)
+    cid, p = _authored(root, "direct")
+    add.freeze(root, cid, by=ODD, authority="process")     # the library, called directly
+    assert _stamps(p)[0].get("act") == "freeze"
+
+
+def test_a_full_walk_survives_an_odd_quote(tmp_path):
+    """covers: M2, M3 — brief, run and gate write stamps too; the whole walk must read back."""
+    root = _bundle(tmp_path)
+    cid, p = _authored(root, "walk")
+    add.freeze(root, cid, by=ODD, authority="process")
+    add.brief_stamp(root, cid, by=ODD)
+    xml = tmp_path / "r.xml"
+    add.run(root, cid, [sys.executable, "-c",
+                        f"open({str(xml)!r},'w').write('<testsuites><testsuite>"
+                        f"<testcase classname=\"c\" name=\"test_x\"/></testsuite></testsuites>')"],
+            junit=xml)
+    ok, note = add.gate(root, cid, "PASS", by=ODD)
+    assert ok, note
+    acts = [s.get("act") for s in _stamps(p)]
+    assert "freeze" in acts and "brief" in acts and "gate" in acts, acts
+
+
+# ------------------------------------------------------------------ counter-guards
+
+def test_balanced_quotes_still_round_trip(tmp_path):
+    """covers: E1 — the case that always worked must keep working."""
+    root = _bundle(tmp_path)
+    cid, p = _authored(root, "balanced")
+    add.freeze(root, cid, by='Tin "TinDang97" Dang', authority="process")
+    st = _stamps(p)[0]
+    assert st.get("act") == "freeze"
+    assert "TinDang97" in st["by"]
+
+
+def test_an_empty_by_keeps_the_writers_default(tmp_path):
+    """covers: A4, E2 — normalising must not turn a default into an empty scalar."""
+    root = _bundle(tmp_path)
+    cid, p = _authored(root, "empty")
+    add.freeze(root, cid, by="", authority="process")
+    qs, _ = add.interview(root, cid)
+    add.interview(root, cid, answers={q["id"]: "confirm" for q in qs}, by=None)
+    by = [s.get("by") for s in _stamps(p) if s.get("act") == "interview"]
+    assert by == ["unrecorded"], by
+
+
+def test_no_existing_stamp_is_rewritten(tmp_path):
+    """covers: A3, E4 — an append-only ledger whose past can be edited is not a ledger."""
+    root = _bundle(tmp_path)
+    cid, p = _authored(root, "history")
+    add.freeze(root, cid, by="first", authority="process")
+    before = _stamps(p)
+    add.brief_stamp(root, cid, by=ODD)
+    after = _stamps(p)
+    # the STAMP LIST, not the file text: a later write legitimately grows the frontmatter, so
+    # comparing raw text tests the wrong thing (the first cut of this check did exactly that).
+    assert after[:len(before)] == before, "an earlier stamp was rewritten by a later write"
+    assert len(after) == len(before) + 1, "the write was not a pure append"

--- a/add-method/tests/engine/test_stamp_field_integrity.py
+++ b/add-method/tests/engine/test_stamp_field_integrity.py
@@ -72,13 +72,22 @@ def test_a_value_of_only_quotes_is_not_erased():
 
 
 def test_a_flow_map_round_trips_every_punctuation(tmp_path):
-    """covers: A2 — quotes, braces, colons, commas and newlines, through a real write."""
+    """covers: A2, M4 — quotes, braces, colons, commas and newlines, through a real write.
+
+    M4 is the biconditional, not just the happy path: what the verb REPORTS must match what the
+    ledger HOLDS. A success that wrote an unreadable record and a refusal that wrote a good one
+    are both the notary lying; only the two matching outcomes are allowed.
+    """
     root = _bundle(tmp_path)
     for i, evil in enumerate(['a"b', 'a{b}', 'a}', 'a: b', 'a, b', 'a\nb', 'a"}{,b']):
         cid, p = _authored(root, f"punct{i}")
         node, note = add.freeze(root, cid, by=evil, authority="process")
-        assert node, f"{evil!r}: {note}"
         st = _stamps(p)
+        faithful = len(st) == 1 and st[0].get("act") == "freeze"
+        assert bool(node) == faithful, (
+            f"{evil!r}: freeze reported {'success' if node else 'refusal'} but the ledger "
+            f"{'holds' if faithful else 'does NOT hold'} the record — {note}")
+        assert node, f"{evil!r}: {note}"
         assert len(st) == 1, f"{evil!r} wrote {len(st)} readable stamps"
         assert st[0].get("act") == "freeze", f"{evil!r} lost `act`: {st[0]}"
         assert st[0].get("authority") == "process", f"{evil!r} lost `authority`: {st[0]}"

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -836,7 +836,7 @@ RESERVED_FILES = ("index.md", "log.md", "PROJECT.md")
 
 # The engine version — one source of truth. `_stamp`, `init`'s `engine:`/`tooling_engine:` stamps,
 # and the drift-warn all read this, so a version bump is a single edit (M4).
-ENGINE = "add/3.2.0"
+ENGINE = "add/3.3.0"
 # Where `init` vendors from: the engine lives beside this file; the seed corpus sits at the bundle
 # root as its own managed tree (`.add/personas-teacher/` installed; `add-method/personas-teacher/`
 # in the package). `parents[1]` resolves both. Module-level so a test can repoint them to simulate a

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -1303,6 +1303,13 @@ def _oneline(note) -> str:
     An unbalanced `{` in a `--reason` made the parser's list-continuation swallow the FOLLOWING
     stamp: two records written, one read back, from an append-only ledger whose ordering IS the
     trust model (2026-08-28 review). `replan` already normalised its note; `gate` did not.
+
+    EVERY operator-supplied value interpolated into a flow map goes through here, not just
+    `reason`. It was applied to that one field for a year while seven writers interpolated `by`
+    raw, and an ODD number of `"` in a name then terminated the scalar early: `freeze --by
+    'O"Brien'` PRINTED `freeze recorded` and wrote a record that read back carrying `by` alone,
+    so `_is_frozen` was False and the seal silently did not exist (2026-09-01). A balanced pair
+    round-trips, which is why it survived every real use -> "R:LIE".
     """
     return (" ".join(str(note).split())
             .replace('"', "'").replace("{", "(").replace("}", ")"))
@@ -1517,7 +1524,7 @@ def freeze(root, cid: str, by: str, authority: str = None) -> tuple:
     act = "refreeze" if any(s.get("act") in ("freeze", "refreeze") for s in stamps
                             if isinstance(s, dict)) else "freeze"
     node, err = _transition(root, cid, appends=[
-        ("verified", f'{{ by: "{by}", at: {_today()}, act: {act}, authority: {authority}, '
+        ("verified", f'{{ by: "{_oneline(by)}", at: {_today()}, act: {act}, authority: {authority}, '
                      f'direction: "{direction_digest(node_t2)}" }}')])
     if err:
         return None, err + "\nnext: add status"
@@ -1745,7 +1752,7 @@ def check(root, cid: str, indices, off: bool = False, section: str = None,
         return True, (f"unchanged — box{'es' if len(idle) > 1 else ''} "
                       f"{', '.join(str(n) for n in idle)} in {cid} already {verb}\nnext: add status")
 
-    stamp = (f'{{ by: "{by or "process:check"}", at: {_today()}, '
+    stamp = (f'{{ by: "{_oneline(by or "process:check")}", at: {_today()}, '
              f'act: {"check" if want else "uncheck"}, '
              f'authority: {authority_for(scan(root), cid)}, '
              f'via: {via}, boxes: "{_stamp_boxes(moved)}" }}')
@@ -1968,7 +1975,7 @@ def replan(root, cid: str, note: str, by: str = "builder") -> tuple:
     # newline in the note would split it mid-map and take the node's whole trail with it.
     text = " ".join(str(note).split()).replace('"', "'")
     _, err = _transition(root, cid, appends=[
-        ("verified", f'{{ by: "{by}", at: {_today()}, act: replan, authority: process, '
+        ("verified", f'{{ by: "{_oneline(by)}", at: {_today()}, act: replan, authority: process, '
                      f'note: "{text}" }}')])
     if err:
         return None, err + "\nnext: add status"
@@ -2967,7 +2974,7 @@ def interview(root, cid: str, answers: dict = None, by: str = None) -> tuple:
     # decision — that is the human-readable record; this is the machine-readable delta.
     packed = "|".join(f"{d['id']}={answers[d['id']]}" for d in decisions if d["id"] in answers)
     node_w, err = _transition(root, cid, appends=[
-        ("verified", f'{{ by: "{by or "unrecorded"}", at: {_today()}, act: interview, '
+        ("verified", f'{{ by: "{_oneline(by or "unrecorded")}", at: {_today()}, act: interview, '
                      f'authority: human, interview: "{digest}", '
                      f'receipt: /tasks/{slug}.d/interviews/{n}.md, answers: "{_oneline(packed)}" }}')])
     if err:
@@ -3351,7 +3358,7 @@ def brief_stamp(root, cid: str, by: str = "cli") -> tuple:
                       f"\nnext: add freeze {slug}, then add brief {slug}")
     digest = brief(root, cid)["hash"]
     _transition(root, cid, appends=[("verified",
-        f'{{ by: "{by}", at: {_today()}, act: brief, authority: process, '
+        f'{{ by: "{_oneline(by)}", at: {_today()}, act: brief, authority: process, '
         f'brief: "{digest}" }}')])
     return digest, (f"brief {digest} recorded as the build entry"
                     f"\nnext: add run {slug} -- <cmd>")
@@ -3552,7 +3559,7 @@ def gate(root, cid: str, verdict: str, by: str, authority: str = None,
         authority = authority_for(graph, cid)
         extra = (f', kind: sources, closed: "{len(closed)}/{len(musts)}"'
                  if closes else "")
-        stamp = (f'{{ by: "{by}", at: {_today()}, act: gate, authority: {authority}, '
+        stamp = (f'{{ by: "{_oneline(by)}", at: {_today()}, act: gate, authority: {authority}, '
                  f'outcome: {verdict}{extra}'
                  + (f', reason: "{_oneline(reason)}"' if reason else "") + " }")
         _, t_err = _transition(root, cid, appends=[("verified", stamp)])
@@ -3704,7 +3711,7 @@ def gate(root, cid: str, verdict: str, by: str, authority: str = None,
 
     authority = authority_for(graph, cid)          # computed, never the caller's claim (M3)
     digest = brief(root, cid)["hash"]              # A16 — the instructions that drove the work
-    stamp = (f'{{ by: "{by}", at: {_today()}, act: gate, authority: {authority}, '
+    stamp = (f'{{ by: "{_oneline(by)}", at: {_today()}, act: gate, authority: {authority}, '
              f'outcome: {verdict}, receipt: {receipt_cid}, brief: "{digest}"'
              + (f', reason: "{_oneline(reason)}"' if reason else "") + " }")
     _, t_err = _transition(root, cid, appends=[("verified", stamp)])

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,7 +17,7 @@ prose (its PLAN.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "4d7a40ef14f60cbf7d6350c61937a918"  # re-aimed @ stamp-field-integrity: every operator-supplied `by` goes through _oneline, so an odd quote can no longer terminate a stamp scalar early
+ENGINE_MD5 = "504262ae5037d662f2ecfd7a0aebcfbf"  # re-aimed @ stamp-field-integrity: every operator-supplied `by` goes through _oneline, so an odd quote can no longer terminate a stamp scalar early
 # ADD 3.0 (ABF-1): the engine is a flat two-file pair (add.py + cli.py), no add_engine/ package.
 # ENGINE_PKG_MD5 is repurposed to pin the dispatch entry cli.py (the second engine file).
 ENGINE_PKG_MD5 = "a943d7c65bca1d3563ceb55e58761f6d"  # re-aimed @ enforcement-gaps (`check` records the caller context: tty vs process). prior: 5c37c3e0… @ box-check-verb

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,7 +17,7 @@ prose (its PLAN.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "d414ed74e32b07e8c96e11fd835a1a93"  # re-aimed @ freeze-interview: the ONE approval is interviewed first at a human floor (R:UNINTERVIEWED); prior work: risk-accepted-integrity tiers + done seal
+ENGINE_MD5 = "4d7a40ef14f60cbf7d6350c61937a918"  # re-aimed @ stamp-field-integrity: every operator-supplied `by` goes through _oneline, so an odd quote can no longer terminate a stamp scalar early
 # ADD 3.0 (ABF-1): the engine is a flat two-file pair (add.py + cli.py), no add_engine/ package.
 # ENGINE_PKG_MD5 is repurposed to pin the dispatch entry cli.py (the second engine file).
 ENGINE_PKG_MD5 = "a943d7c65bca1d3563ceb55e58761f6d"  # re-aimed @ enforcement-gaps (`check` records the caller context: tty vs process). prior: 5c37c3e0… @ box-check-verb


### PR DESCRIPTION
One defect fix, then the 3.3.0 version bump.

## The fix — a stamp the notary reports written is a stamp that reads back

`_oneline` exists because an unbalanced `{` in a `--reason` once made the parser swallow the following stamp — two records written, one read back, from an append-only ledger whose ordering *is* the trust model. That fix was correct and was applied to exactly one field. **Seven writers interpolated `by:` raw.**

```
$ add freeze t --by 'O"Brien' --authority human
freeze recorded at authority `human`     # reported as SUCCESS

stamp keys read back: ['by']             # act, authority, direction swallowed
_is_frozen       -> False
sealed_direction -> None
```

The seal silently does not exist while the human is told it does. The trigger is an **odd** number of `"` — a balanced pair (`Tin "TinDang97" Dang`) round-trips, which is exactly why this survived every real use of the engine.

**Severity, stated plainly: it fails CLOSED.** The gate then refuses with R:UNSEALED, so nothing is let through. The defect is that a notary whose only job is to record faithfully reported a record it did not write → `R:LIE`.

All seven interpolations (`freeze` · `brief` · `replan` · `check` · `interview` · both `gate` paths) now go through `_oneline`, and the reason is written at the function's own definition, since the fix is one careless edit away from reverting. `test_every_stamp_writer_normalises_its_by` enumerates the writers **from the source**, never from a hand list — a hand list is precisely how the seventh writer got missed, which is the shape of the defect itself.

The gate refused the first PASS: `M4` ("a verb reports a refusal, never a false success") was declared with no check. Rather than staple a `covers:` onto an existing one, the punctuation walk now asserts the **biconditional** — what the verb reports must match what the ledger holds. A success that wrote an unreadable record and a refusal that wrote a good one are both the notary lying.

### Corrections to my own earlier report, disclosed rather than quietly fixed

- I first reported this as a **brace** bug that destroyed the entire `verified:` ledger. **That was wrong.** The probe behind it froze an *unauthored* node, so `freeze` correctly refused on template placeholders and wrote nothing — I read a correct refusal as corruption. Corrected on #208 as well.
- `M1` (`_oneline` neutralises the quote) was **already true** before this task; `_oneline` has always replaced `"`. It stays as a regression pin, but the real rule is `M2` — the writers that never called it.
- `test_no_existing_stamp_is_rewritten` first compared whole-file text, which a later write legitimately grows. It compares the parsed stamp list now.

## The release — 3.3.0

Six version sources in lockstep: `pyproject.toml` · `package.json` · `package-lock.json` (2 places) · `.claude-plugin/plugin.json` · `src/add_method/__init__.py` · `tooling/add.py`'s `ENGINE`.

Bumping `ENGINE` re-aims `add.py`, so the four engine twins are resynced, `ENGINE_MD5` re-aimed, and both dogfood bundles' `engine:`/`tooling_engine:` stamps moved — those ride every version bump and go stale silently otherwise.

The CHANGELOG covers what #207, #208 and this PR shipped: the `scaffold` beat · the claimed-output guard · the INTEGRITY/EVIDENCE split · `done`'s seal check · the template-Milestone refusal · segment-aware `_paths_touch` · sensitivity flooring up · `add interview` · this stamp fix. It says the RISK-ACCEPTED hole failed closed and that the stamp defect made a verb report a record it had not written, because a changelog that only lists wins is the same failure mode as a guard that only checks the happy path.

**873 passed / 0 failed / 7 skipped** across both roots.

## Not in this PR

**Tag and publish remain the human call.** Pushing `v3.3.0` triggers the npm + PyPI publish, and neither registry lets a version be reused. Nothing here pushes a tag.
