### PR TITLE
3.4.0 — a guard asks whether what a stamp attests is TRUE

### DIFF
--- a/.add/index.md
+++ b/.add/index.md
@@ -2,8 +2,8 @@
 abf_version: "1.3"
 name: AIDD-Book
 profile: code
-engine: add/3.3.0
-tooling_engine: add/3.3.0
+engine: add/3.4.0
+tooling_engine: add/3.4.0
 created: 2026-08-08
 sensitive_paths: []
 generated: { by: add/3.0.0, at: 2026-08-08 }

--- a/.claude/skills/add/SKILL.md
+++ b/.claude/skills/add/SKILL.md
@@ -14,7 +14,7 @@ category: workflows
 keywords: [add, aidd, ai-driven-development, spec-first, tdd, contract, receipt, gate, task, resume, explore, research]
 argument-hint: "status | <describe the change or goal>"
 license: MIT
-metadata: { author: add, version: "3.3.0", format: ABF-1 }
+metadata: { author: add, version: "3.4.0", format: ABF-1 }
 ---
 
 # ADD — direction · evidence · a durable bundle (the agent is the hands)
@@ -99,8 +99,8 @@ One task = one atomic node. Three beats, one human decision:
    record it, seal untouched: `add replan <slug> --note "<what changed>"`. Anything that would move
    a frozen surface is a change-request back to Direction, never a silent edit.
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
-   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"`
-   for a fresh, bound receipt — the path twice: `run` READS it, your command WRITES it. Wrap the
+   · architecture — **security HARD-STOP**), then `add run <slug> -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"`
+   for a fresh, bound receipt — `run` reads the report path your command names. Wrap the
    **narrowest command that reports every bound check**; the full suite rides CI. **No runner for your domain? Write one** — `run` parses JUnit XML and does not
    care what produced it, so a script comparing a measured value against a threshold your frozen
    RULES already state earns the same bound receipt (`domains.md`). And **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
@@ -149,7 +149,7 @@ add doctor [--sync]                          # findings, never gates; --sync rec
 add interview <slug> [--answer <id>=confirm|correct|defer]  # the open decisions, put to a human
 add freeze <slug> --by "<name>" --authority human    # the ONE approval → Build
 add replan <slug> --note "<what changed>"    # record a steering turn on a frozen task — seal untouched
-add run <slug> [--timeout <s>] --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"  # receipt · that path twice: run READS it, your cmd WRITES it
+add run <slug> [--timeout <s>] -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"  # receipt · run reads the path your cmd names (an explicit `--junitxml`, before the --, overrides)
 add gate <slug> PASS --by "<name>"           # verdict — a PASS auto-closes · RISK-ACCEPTED (signed) · HARD-STOP
 add done <slug>                              # close after a RISK-ACCEPTED (a PASS gate already closed it)
 add learn <ddd|sdd|udd|tdd|add> "<lesson>" --evidence <ref>   # file a lesson into a living spec

--- a/.claude/skills/add/domains.md
+++ b/.claude/skills/add/domains.md
@@ -42,8 +42,8 @@ sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
 Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
 
 ```bash
-add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
-  python3 checks/recon.py "${TMPDIR:-/tmp}/add-run.xml"
+add run <slug> -- \
+  python3 checks/recon.py --junitxml="${TMPDIR:-/tmp}/add-run.xml"
 ```
 
 **Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —

--- a/.claude/skills/add/phases/verify.md
+++ b/.claude/skills/add/phases/verify.md
@@ -6,15 +6,18 @@ because the diff reads plausible. Verify is where that trust is recorded, once.
 ## 1 · Gather the evidence — a fresh, bound receipt
 
 ```bash
-add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
-    <the test command, carrying its OWN `--junitxml` at that same path>
+add run <slug> -- \
+    <the test command, carrying its own `--junitxml="${TMPDIR:-/tmp}/add-run.xml"`>
 ```
 
 `run` executes your command, parses the JUnit report, and writes a **Run receipt** under
-`.add/tasks/<slug>.d/runs/`. The path appears **twice on purpose**: `--junitxml` before the `--`
-tells `run` where to READ the report, and the wrapped command must WRITE it there. `run` never
-passes the path down. Omit the second and the receipt records only an exit code, nothing binds
-to your rules, and the gate refuses naming the unbound ones. Two properties the gate will demand:
+`.add/tasks/<slug>.d/runs/`. Your command WRITES the report; `run` READS it, sniffing the path out
+of the command you already handed it — either spelling of `--junitxml`, joined by `=` or as the
+following token, and the last one named wins.
+Name no path at all and the receipt records only an exit code, nothing binds to your rules, and the
+gate refuses naming the unbound ones. A runner that reports somewhere its command line never names
+states it with `--junitxml` placed BEFORE the `--`, which overrides the sniff. Two properties the gate will
+demand:
 - **fresh** — the receipt records the git blob hash of every in-`scope:` file at run time; a gate
   recomputes it and refuses on any difference. This kills the stale-green failure (tests that passed
   before the last edit). A directory scope enumerates through git, so **gitignored files (build

--- a/add-method/.claude-plugin/plugin.json
+++ b/add-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "add",
   "displayName": "ADD — AI-Driven Development",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "ADD (AI-Driven Development). The agent is the hands; ADD is the memory, judgment, and conscience — a lean, state-tracked skill that drives every change through one atomic task node: Direction → Build → Verify, red/green TDD built in, trusted on a recorded receipt rather than a plausible diff. State lives on disk, so context rot never survives a new session.",
   "author": {
     "name": "Tin Dang",

--- a/add-method/CHANGELOG.md
+++ b/add-method/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to the ADD method (`@pilotspace/add` on npm,
 `pilotspace-add` on PyPI) are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [3.4.0] — 2026-09-03
+
+**A guard asks whether what a stamp attests is TRUE, not whether the stamp is well-formed — and
+what `new` writes is what the engine reads.** 3.3 hardened the seal; four critics then re-read the
+released tree and found the same shape everywhere underneath it. Every integrity guard asked
+whether a record was *shaped* right. None asked whether the thing it recorded had happened. A
+`gate HARD-STOP` walked on to `done`. A red Task closed on another node's receipt because their
+slugs collided. `brief` resolved no lens at all — not one seeded persona had ever reached a
+worker — and said nothing about the omission. And a scaffold `new` wrote could not survive the
+guards `new` recommended next.
+
+### Added
+- **Every task kind in the taxonomy now routes to a seeded persona.** Five kinds — `docs`, `ui`,
+  `data`, `security`, `explore` — matched no seeded lens, so `brief` fell through to the generic
+  reading with no sign that it had. Five templates added, and a guard fails when the next kind
+  arrives without one.
+- **`new` refuses a `kind:` outside the closed taxonomy** and names the taxonomy in the refusal.
+  The routing guard validated the persona's `task-kinds:` and never the task's `kind:`, so the two
+  sides of the same match were held to different standards.
+- **`doctor` reports an unauthored node.** A file of untouched template slots read as a finding-free
+  bundle.
+- **`join` refuses a path that is not a bundle**, keyed on the `abf_version:` index marker.
+
+### Changed
+- **`add run` reads the report path the command already names.** The build line named one path
+  twice — once to tell the engine where to read, once for the runner to write — and a typo in the
+  restatement cost `ids: unknown`, which the gate reads as every rule unbound. The `--junitxml`
+  flag stays as an override for runners that report somewhere the command line never names, and is
+  consulted first so a sniffed value never beats a stated one.
+- **`new --kind explore` writes the body the explore lane reads**, and `freeze` accepts it
+  unedited. The `budget:` guard now requires a real value: the template's own placeholder had been
+  satisfying it.
+- **`scope:` is seeded in frontmatter, where its readers look** — and seeded EMPTY, because
+  `scope:` is enforced where `gives:` is only descriptive.
+- **A waived sweep dimension must state its reason.** A bare `n/a` retired a `(dimension, surface)`
+  pair silently; the docstring had always promised otherwise. Across 584 assumption lines, only
+  four were real waivers.
+
+### Fixed
+- **`gate HARD-STOP` no longer reaches `done`.** A security stop's authority is COMPUTED, so it is
+  always `human` and no flag could clear it — closing one is now the deliberate act
+  `done --override "<why>"`.
+- **The seal covers the `E<n>` and probed `A<n>` it binds**, not only `RULES` and `CHECKS`.
+- **A slug collision can no longer close a red Task on another node's receipt.**
+- **`brief` says when no lens resolved** instead of silently applying the generic reading. Neither
+  the path-grammar nor the bare-slug form had ever matched a seeded persona.
+- **`freeze --authority process` no longer downgrades a security freeze.**
+
 ## [3.3.0] — 2026-09-01
 
 **The seal has to mean something under every verdict, and the one approval has to be asked for

--- a/add-method/package-lock.json
+++ b/add-method/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pilotspace/add",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pilotspace/add",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1"

--- a/add-method/package.json
+++ b/add-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilotspace/add",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "ADD (AI-Driven Development). The agent is the hands; ADD is the memory, judgment, and conscience — a lean, state-tracked skill that drives every change through one atomic task node: Direction → Build → Verify, red/green TDD built in, trusted on a recorded receipt rather than a plausible diff. State lives on disk, so context rot never survives a new session.",
   "bin": {
     "add": "bin/cli.js"

--- a/add-method/pyproject.toml
+++ b/add-method/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pilotspace-add"
-version = "3.3.0"
+version = "3.4.0"
 description = "ADD (AI-Driven Development). The agent is the hands; ADD is the memory, judgment, and conscience — a lean, state-tracked skill that drives every change through one atomic task node: Direction → Build → Verify, red/green TDD built in, trusted on a recorded receipt rather than a plausible diff. State lives on disk, so context rot never survives a new session. Installs the ADD skill and tooling into any project."
 readme = "README.md"
 license = "MIT"

--- a/add-method/skill/add/SKILL.md
+++ b/add-method/skill/add/SKILL.md
@@ -14,7 +14,7 @@ category: workflows
 keywords: [add, aidd, ai-driven-development, spec-first, tdd, contract, receipt, gate, task, resume, explore, research]
 argument-hint: "status | <describe the change or goal>"
 license: MIT
-metadata: { author: add, version: "3.3.0", format: ABF-1 }
+metadata: { author: add, version: "3.4.0", format: ABF-1 }
 ---
 
 # ADD — direction · evidence · a durable bundle (the agent is the hands)
@@ -99,8 +99,8 @@ One task = one atomic node. Three beats, one human decision:
    record it, seal untouched: `add replan <slug> --note "<what changed>"`. Anything that would move
    a frozen surface is a change-request back to Direction, never a silent edit.
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
-   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"`
-   for a fresh, bound receipt — the path twice: `run` READS it, your command WRITES it. Wrap the
+   · architecture — **security HARD-STOP**), then `add run <slug> -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"`
+   for a fresh, bound receipt — `run` reads the report path your command names. Wrap the
    **narrowest command that reports every bound check**; the full suite rides CI. **No runner for your domain? Write one** — `run` parses JUnit XML and does not
    care what produced it, so a script comparing a measured value against a threshold your frozen
    RULES already state earns the same bound receipt (`domains.md`). And **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
@@ -149,7 +149,7 @@ add doctor [--sync]                          # findings, never gates; --sync rec
 add interview <slug> [--answer <id>=confirm|correct|defer]  # the open decisions, put to a human
 add freeze <slug> --by "<name>" --authority human    # the ONE approval → Build
 add replan <slug> --note "<what changed>"    # record a steering turn on a frozen task — seal untouched
-add run <slug> [--timeout <s>] --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"  # receipt · that path twice: run READS it, your cmd WRITES it
+add run <slug> [--timeout <s>] -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"  # receipt · run reads the path your cmd names (an explicit `--junitxml`, before the --, overrides)
 add gate <slug> PASS --by "<name>"           # verdict — a PASS auto-closes · RISK-ACCEPTED (signed) · HARD-STOP
 add done <slug>                              # close after a RISK-ACCEPTED (a PASS gate already closed it)
 add learn <ddd|sdd|udd|tdd|add> "<lesson>" --evidence <ref>   # file a lesson into a living spec

--- a/add-method/skill/add/domains.md
+++ b/add-method/skill/add/domains.md
@@ -42,8 +42,8 @@ sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
 Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
 
 ```bash
-add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
-  python3 checks/recon.py "${TMPDIR:-/tmp}/add-run.xml"
+add run <slug> -- \
+  python3 checks/recon.py --junitxml="${TMPDIR:-/tmp}/add-run.xml"
 ```
 
 **Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —

--- a/add-method/skill/add/phases/verify.md
+++ b/add-method/skill/add/phases/verify.md
@@ -6,15 +6,18 @@ because the diff reads plausible. Verify is where that trust is recorded, once.
 ## 1 · Gather the evidence — a fresh, bound receipt
 
 ```bash
-add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
-    <the test command, carrying its OWN `--junitxml` at that same path>
+add run <slug> -- \
+    <the test command, carrying its own `--junitxml="${TMPDIR:-/tmp}/add-run.xml"`>
 ```
 
 `run` executes your command, parses the JUnit report, and writes a **Run receipt** under
-`.add/tasks/<slug>.d/runs/`. The path appears **twice on purpose**: `--junitxml` before the `--`
-tells `run` where to READ the report, and the wrapped command must WRITE it there. `run` never
-passes the path down. Omit the second and the receipt records only an exit code, nothing binds
-to your rules, and the gate refuses naming the unbound ones. Two properties the gate will demand:
+`.add/tasks/<slug>.d/runs/`. Your command WRITES the report; `run` READS it, sniffing the path out
+of the command you already handed it — either spelling of `--junitxml`, joined by `=` or as the
+following token, and the last one named wins.
+Name no path at all and the receipt records only an exit code, nothing binds to your rules, and the
+gate refuses naming the unbound ones. A runner that reports somewhere its command line never names
+states it with `--junitxml` placed BEFORE the `--`, which overrides the sniff. Two properties the gate will
+demand:
 - **fresh** — the receipt records the git blob hash of every in-`scope:` file at run time; a gate
   recomputes it and refuses on any difference. This kills the stale-green failure (tests that passed
   before the last edit). A directory scope enumerates through git, so **gitignored files (build

--- a/add-method/src/add_method/__init__.py
+++ b/add-method/src/add_method/__init__.py
@@ -14,4 +14,4 @@ Usage (Python API):
 from add_method._installer import install
 
 __all__ = ["install"]
-__version__ = "3.3.0"
+__version__ = "3.4.0"

--- a/add-method/src/add_method/_bundled/skill/add/SKILL.md
+++ b/add-method/src/add_method/_bundled/skill/add/SKILL.md
@@ -14,7 +14,7 @@ category: workflows
 keywords: [add, aidd, ai-driven-development, spec-first, tdd, contract, receipt, gate, task, resume, explore, research]
 argument-hint: "status | <describe the change or goal>"
 license: MIT
-metadata: { author: add, version: "3.3.0", format: ABF-1 }
+metadata: { author: add, version: "3.4.0", format: ABF-1 }
 ---
 
 # ADD — direction · evidence · a durable bundle (the agent is the hands)
@@ -99,8 +99,8 @@ One task = one atomic node. Three beats, one human decision:
    record it, seal untouched: `add replan <slug> --note "<what changed>"`. Anything that would move
    a frozen surface is a change-request back to Direction, never a silent edit.
 3. **VERIFY** (`phases/verify.md`) — gather evidence, check the 3 residue lenses (security · concurrency
-   · architecture — **security HARD-STOP**), then `add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"`
-   for a fresh, bound receipt — the path twice: `run` READS it, your command WRITES it. Wrap the
+   · architecture — **security HARD-STOP**), then `add run <slug> -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"`
+   for a fresh, bound receipt — `run` reads the report path your command names. Wrap the
    **narrowest command that reports every bound check**; the full suite rides CI. **No runner for your domain? Write one** — `run` parses JUnit XML and does not
    care what produced it, so a script comparing a measured value against a threshold your frozen
    RULES already state earns the same bound receipt (`domains.md`). And **`add gate <slug> PASS --by "<name>"`** — a **PASS auto-closes** the task
@@ -149,7 +149,7 @@ add doctor [--sync]                          # findings, never gates; --sync rec
 add interview <slug> [--answer <id>=confirm|correct|defer]  # the open decisions, put to a human
 add freeze <slug> --by "<name>" --authority human    # the ONE approval → Build
 add replan <slug> --note "<what changed>"    # record a steering turn on a frozen task — seal untouched
-add run <slug> [--timeout <s>] --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"  # receipt · that path twice: run READS it, your cmd WRITES it
+add run <slug> [--timeout <s>] -- <test cmd> --junitxml="${TMPDIR:-/tmp}/add-run.xml"  # receipt · run reads the path your cmd names (an explicit `--junitxml`, before the --, overrides)
 add gate <slug> PASS --by "<name>"           # verdict — a PASS auto-closes · RISK-ACCEPTED (signed) · HARD-STOP
 add done <slug>                              # close after a RISK-ACCEPTED (a PASS gate already closed it)
 add learn <ddd|sdd|udd|tdd|add> "<lesson>" --evidence <ref>   # file a lesson into a living spec

--- a/add-method/src/add_method/_bundled/skill/add/domains.md
+++ b/add-method/src/add_method/_bundled/skill/add/domains.md
@@ -42,8 +42,8 @@ sys.exit(0 if all(ok for _, ok, _ in cases) else 1)
 Cite those IDs from `## CHECKS` exactly as a test runner would, then run it like any other build:
 
 ```bash
-add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
-  python3 checks/recon.py "${TMPDIR:-/tmp}/add-run.xml"
+add run <slug> -- \
+  python3 checks/recon.py --junitxml="${TMPDIR:-/tmp}/add-run.xml"
 ```
 
 **Declare the artifact in `scope:`.** A digested data file makes the receipt `freshness: content` —

--- a/add-method/src/add_method/_bundled/skill/add/phases/verify.md
+++ b/add-method/src/add_method/_bundled/skill/add/phases/verify.md
@@ -6,15 +6,18 @@ because the diff reads plausible. Verify is where that trust is recorded, once.
 ## 1 · Gather the evidence — a fresh, bound receipt
 
 ```bash
-add run <slug> --junitxml "${TMPDIR:-/tmp}/add-run.xml" -- \
-    <the test command, carrying its OWN `--junitxml` at that same path>
+add run <slug> -- \
+    <the test command, carrying its own `--junitxml="${TMPDIR:-/tmp}/add-run.xml"`>
 ```
 
 `run` executes your command, parses the JUnit report, and writes a **Run receipt** under
-`.add/tasks/<slug>.d/runs/`. The path appears **twice on purpose**: `--junitxml` before the `--`
-tells `run` where to READ the report, and the wrapped command must WRITE it there. `run` never
-passes the path down. Omit the second and the receipt records only an exit code, nothing binds
-to your rules, and the gate refuses naming the unbound ones. Two properties the gate will demand:
+`.add/tasks/<slug>.d/runs/`. Your command WRITES the report; `run` READS it, sniffing the path out
+of the command you already handed it — either spelling of `--junitxml`, joined by `=` or as the
+following token, and the last one named wins.
+Name no path at all and the receipt records only an exit code, nothing binds to your rules, and the
+gate refuses naming the unbound ones. A runner that reports somewhere its command line never names
+states it with `--junitxml` placed BEFORE the `--`, which overrides the sniff. Two properties the gate will
+demand:
 - **fresh** — the receipt records the git blob hash of every in-`scope:` file at run time; a gate
   recomputes it and refuses on any difference. This kills the stale-green failure (tests that passed
   before the last edit). A directory scope enumerates through git, so **gitignored files (build

--- a/add-method/src/add_method/_bundled/tooling/add.py
+++ b/add-method/src/add_method/_bundled/tooling/add.py
@@ -850,7 +850,7 @@ RESERVED_FILES = ("index.md", "log.md", "PROJECT.md")
 
 # The engine version — one source of truth. `_stamp`, `init`'s `engine:`/`tooling_engine:` stamps,
 # and the drift-warn all read this, so a version bump is a single edit (M4).
-ENGINE = "add/3.3.0"
+ENGINE = "add/3.4.0"
 # Where `init` vendors from: the engine lives beside this file; the seed corpus sits at the bundle
 # root as its own managed tree (`.add/personas-teacher/` installed; `add-method/personas-teacher/`
 # in the package). `parents[1]` resolves both. Module-level so a test can repoint them to simulate a

--- a/add-method/tests/skill/test_the_taught_run_line_is_the_printed_one.py
+++ b/add-method/tests/skill/test_the_taught_run_line_is_the_printed_one.py
@@ -1,0 +1,88 @@
+"""The `add run` line the skill teaches is the line the engine tells you to run.
+
+`run` now sniffs the report path out of the command it was already handed, so the engine's own
+`next:` hint names that path ONCE. The shipped skill still taught the doubled form — and taught it
+in words, with a comment explaining that the repetition was deliberate. Both spellings still WORK
+(the flag survives as an override), which is exactly why nothing failed: `test_receipt_idiom_truth`
+scopes itself to report-READING examples, decided by whether the engine-side flag is present, so
+dropping that flag makes an example invisible to it rather than wrong.
+
+That is the guard-class hole this release exists to close, one turn later and self-inflicted: a
+capability the prose PROMISES with no noun on the engine to bind it to. The binding here is
+`BEAT_NEXT["build"]` — the string the user is actually shown at the end of a build.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL = REPO / "skill" / "add"
+sys.path.insert(0, str(REPO / "tooling"))
+import add  # noqa: E402
+
+
+def _taught_lines():
+    """Every `add run … -- …` example in the shipped skill, shell continuations joined."""
+    out = []
+    for f in sorted(SKILL.rglob("*.md")):
+        raw = f.read_text(encoding="utf-8").splitlines()
+        i = 0
+        while i < len(raw):
+            start, line = i + 1, raw[i].rstrip()
+            while line.endswith("\\") and i + 1 < len(raw):
+                i += 1
+                line = line[:-1].rstrip() + " " + raw[i].strip()
+            if "add run " in line and " -- " in line:
+                out.append((f.relative_to(SKILL), start, line.strip()))
+            i += 1
+    return out
+
+
+def test_the_engine_hint_names_the_report_path_once():
+    """covers: M1 — the binding subject, stated before it is compared against."""
+    assert add.BEAT_NEXT["build"].count("--junitxml") == 1, add.BEAT_NEXT["build"]
+
+
+def test_no_taught_example_names_the_report_path_twice():
+    """covers: M1, M2 — what the skill teaches agrees with what the engine prints.
+
+    Scoped by the path, not by the flag: an example naming `add-run.xml` on both sides of the
+    `--` is the doubled form however it is spelled, so this cannot go quiet the way the incumbent
+    guard did when the engine-side flag disappeared.
+    """
+    examples = _taught_lines()
+    assert examples, "no `add run` example found — the guard would be vacuous"
+    # The trailing `# …` comment is stripped first: it is prose, not an argument anyone copies,
+    # and the corrected line legitimately NAMES the override flag there while passing it once.
+    doubled = [f"{rel}:{n} — {line}" for rel, n, line in examples
+               if (a := line.split("#", 1)[0]).count("--junitxml") > 1
+               or a.count("add-run.xml") > 1]
+    assert not doubled, (
+        "these teach a report path the engine no longer asks for, while `next:` prints it once:"
+        "\n  " + "\n  ".join(doubled))
+
+
+def test_the_prose_does_not_defend_the_repetition():
+    """covers: M3 — the doubling was explained on purpose, so the explanation must go too.
+
+    A stale example is a typo; a stale SENTENCE saying the repetition is deliberate teaches the
+    reader to distrust the engine's own hint. This is the half a find-and-replace leaves behind.
+    """
+    stale = []
+    for f in sorted(SKILL.rglob("*.md")):
+        text = f.read_text(encoding="utf-8")
+        for m in re.finditer(r"[^\n.]*path twice[^\n.]*", text):
+            stale.append(f"{f.relative_to(SKILL)} — {m.group(0).strip()}")
+    assert not stale, "the prose still defends the doubled path:\n  " + "\n  ".join(stale)
+
+
+def test_the_override_is_still_documented():
+    """covers: M4, E1 — the flag did not disappear, and a reader must still be able to find it.
+
+    Dropping the doubling from the examples must not delete the escape hatch from the docs: a
+    runner that writes its report where the command line never names it has no other route.
+    """
+    text = " ".join((SKILL / "phases" / "verify.md").read_text(encoding="utf-8").split())
+    assert "--junitxml" in text, "verify.md no longer mentions --junitxml at all"
+    assert "override" in text.lower() or "sniff" in text.lower(), \
+        f"verify.md does not explain how the report path is found:\n{text[:400]}"

--- a/add-method/tooling/add.py
+++ b/add-method/tooling/add.py
@@ -850,7 +850,7 @@ RESERVED_FILES = ("index.md", "log.md", "PROJECT.md")
 
 # The engine version — one source of truth. `_stamp`, `init`'s `engine:`/`tooling_engine:` stamps,
 # and the drift-warn all read this, so a version bump is a single edit (M4).
-ENGINE = "add/3.3.0"
+ENGINE = "add/3.4.0"
 # Where `init` vendors from: the engine lives beside this file; the seed corpus sits at the bundle
 # root as its own managed tree (`.add/personas-teacher/` installed; `add-method/personas-teacher/`
 # in the package). `parents[1]` resolves both. Module-level so a test can repoint them to simulate a

--- a/add-method/tooling/engine_pin.py
+++ b/add-method/tooling/engine_pin.py
@@ -17,7 +17,7 @@ prose (its PLAN.md) is the place to record the full rationale for a re-aim —
 this file only ever holds the newest pointer.
 """
 
-ENGINE_MD5 = "9a8000831204f9d080769dc349a48add"  # re-aimed @ scaffold-truth: `run` sniffs the report path the command already names, so the one path is typed once and the flag becomes an override; plus `new` refuses an unroutable kind, seeds `scope:` in frontmatter (empty — `scope:` is enforced where `gives:` is descriptive) and branches its body for the explore lane; `join` refuses a path with no bundle index; `doctor` reports an unauthored node; a waived sweep dimension must state its reason. prior: 72b0bc5c… @ scaffold-truth
+ENGINE_MD5 = "7932ec061ddf19310c138766a691bfdf"  # re-aimed @ 3.4.0 release: the ENGINE version stamp. prior: 9a800083… @ scaffold-truth
 # ADD 3.0 (ABF-1): the engine is a flat two-file pair (add.py + cli.py), no add_engine/ package.
 # ENGINE_PKG_MD5 is repurposed to pin the dispatch entry cli.py (the second engine file).
 ENGINE_PKG_MD5 = "b41bc148795c695b7f04ebd10c1098c1"  # re-aimed @ scaffold-truth (`join` propagates its refusal to a non-zero exit). prior: ad04b73a… @ method-truth-sweep


### PR DESCRIPTION
Cuts 3.4.0. Two merged-but-unreleased PRs ship here: 3.3.0 was tagged before #210 landed, so this carries both #210 and #211.

## What ships

**#210 — the front door teaches a walk that runs.** The documentation described a method the engine did not implement, and nothing could see the gap: every guard checked nouns the engine EXPOSES rather than capabilities the prose PROMISES. `GETTING-STARTED.md` is now executed by the suite, the roster names agents that exist, and `init` seeds selectable personas.

**#211 — a guard asks whether what a stamp attests is TRUE.** Every integrity guard asked whether a record was *shaped* right; none asked whether the thing it recorded had happened. A `gate HARD-STOP` walked to `done`. A red Task closed on another node's receipt through a slug collision. `brief` resolved no lens at all — not one seeded persona had ever reached a worker — and said nothing about the omission. And a scaffold `new` wrote could not survive the guards `new` recommended next.

## Version surface

All eight declarations: five manifests (`package.json`, `package-lock.json` ×2, `pyproject.toml`, `__init__.py`, `plugin.json`), the `ENGINE = "add/3.4.0"` stamp, and the three shipped skill trees. Plus the dogfood bundle's own `engine:`/`tooling_engine:` in `.add/index.md`, which rides every bump.

`ENGINE_MD5` re-aimed `9a800083 → 7932ec06`. `cli.py` untouched, so `ENGINE_PKG_MD5` stands.

## One fix that is not in either PR

`run` learned to sniff the report path last turn, which left the shipped skill teaching the doubled `--junitxml` in four places — one of them a sentence explaining that the repetition was *deliberate*. Both spellings still work, which is why nothing failed.

`test_receipt_idiom_truth` could not catch it. It scopes itself to report-READING examples, decided by whether the engine-side flag is present, so **dropping that flag makes an example invisible to the guard rather than wrong**. That is the same guard-class hole this release exists to close, one turn later and self-inflicted.

The new guard binds the taught line to `BEAT_NEXT["build"]` — the string a user is actually shown at the end of a build — and was mutation-tested: reintroducing the doubling in `verify.md` turns it red, restoring turns it green.

Two smaller notes from that fix:

- My first cut of the guard counted `--junitxml` anywhere on a line and flagged my own corrected line for naming the override flag in a trailing comment. Narrowed to the argument text before `#`; a comment is not something a reader copies.
- The new prose collided with `test_receipt_artifact.py`, which parses `--junitxml <token>` and read my explanatory words (`before`, `<path>`) as documented receipt paths. I reworded the prose rather than touch that guard — it protects a real property.

`SKILL.md` holds at exactly 176/176 lines, funded by compression, no pin bump.

## Verification

`1111 passed, 7 skipped` across both test roots (`add-method/tests/` and `add-method/tooling/`), the full CI shape.

Tag and publish to npm + PyPI follow once this is green and merged.